### PR TITLE
wip-Tue Feb 25 07:10:30 PM CET 2025

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -87,8 +87,26 @@ function restart() {
 }
 
 function logs() {
-    echo "Fetching logs..."
-    $COMPOSE_CMD logs --tail=0 --follow
+    if [ $# -eq 0 ]; then
+        echo "Fetching logs for all services..."
+        $COMPOSE_CMD logs --tail=0 --follow
+    else
+        local container="$1"
+        local tail_count="${2:-50}"  # Default to 50 lines if not specified
+        
+        # Validate container name
+        case "$container" in
+            ollama|open-webui|postgres|pgadmin|watchtower)
+                echo "Fetching logs for $container..."
+                docker logs "$container" --tail="$tail_count" --follow
+                ;;
+            *)
+                echo "Error: Unknown container '$container'"
+                echo "Available containers: ollama, open-webui, postgres, pgadmin, watchtower"
+                return 1
+                ;;
+        esac
+    fi
 }
 
 function clean() {
@@ -267,7 +285,7 @@ function help_menu() {
     echo "  start                Start the AIXCL stack"
     echo "  stop                 Stop the AIXCL stack"
     echo "  restart              Restart all services"
-    echo "  logs                 Show logs for all containers"
+    echo "  logs [container] [n] Show logs for all containers or a specific container (with optional number of lines)"
     echo "  clean                Remove unused Docker containers, images, and volumes"
     echo "  stats                Show resource usage statistics"
     echo "  status               Check services status"
@@ -350,7 +368,8 @@ function main() {
             restart
             ;;
         logs)
-            logs
+            shift  # Remove the 'logs' command from the arguments
+            logs "$@"  # Pass all remaining arguments to the logs function
             ;;
         clean)
             clean

--- a/aixcl_completion.sh
+++ b/aixcl_completion.sh
@@ -53,6 +53,12 @@ _aixcl_completion() {
             fi
             return 0
             ;;
+        logs)
+            # For logs, suggest container names
+            local containers="ollama open-webui postgres pgadmin watchtower"
+            COMPREPLY=($(compgen -W "${containers}" -- "${cur}"))
+            return 0
+            ;;
         *)
             # Check if we're in a multi-model add or remove command
             if [[ ${COMP_CWORD} -gt 2 ]]; then


### PR DESCRIPTION
# 🚀 Pull Request

1. **How It Works**:
 - When you type `./aixcl logs ` and press Tab, the bash completion will suggest the available container names:
 - ollama
 - open-webui
 - postgres
 - pgadmin
 - watchtower

2. **Testing the Autocomplete**:
 - Type `./aixcl logs ` (with a space after "logs") and press Tab
 - You should see the container names as suggestions
 - If you start typing a container name (e.g., `./aixcl logs o`), pressing Tab will complete to matching containers (like "ollama" or "open-webui")

3. **Installation**:
 - The completion script has been installed to `/home/sbadakhc/.local/share/bash-completion/completions/aixcl`
 - It's also referenced in your `~/.bashrc` file, so it will be automatically loaded in new shell sessions

The autocomplete functionality is now fully implemented and installed. You can use tab completion to easily specify container names when using the `logs` command.

Thanks for contributing to AIXCL! 💙
