### PR TITLE
database backups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       PGADMIN_DEFAULT_EMAIL: $PGADMIN_EMAIL
       PGADMIN_DEFAULT_PASSWORD: $PGADMIN_PASSWORD
       PGADMIN_LISTEN_PORT: 5050
+    volumes:
+      - ./backups:/var/lib/pgadmin/storage
+    user: "5050:5050"
     network_mode: host
     depends_on:
       - postgres


### PR DESCRIPTION
# 🚀 Pull Request

## What's Changed?
Added volume mount for pgAdmin to enable easy access to database backups from the host system. The changes include:

- Added volume mount `./backups:/var/lib/pgadmin/storage` to pgAdmin service
- Added `user: "5050:5050"` to ensure proper permissions for the mounted volume
- This allows users to easily save and retrieve database backups created through pgAdmin

Previously, backups created in pgAdmin were stored inside the container and not easily accessible from the host system.

## Related Issues
<!-- Link any related issues (e.g., "Fixes #123") -->

## Checklist
- [x] I've tested these changes
- [x] I've updated documentation (if needed)
- [x] My code follows the project's style

## Screenshots (if applicable)
<!-- Add screenshots if your changes include visual elements -->

Thanks for contributing to AIXCL! 💙
