### PR TITLE
Fix pgAdmin user ID to use standard UID 1000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       PGADMIN_LISTEN_PORT: 5050
     volumes:
       - ./backups:/var/lib/pgadmin/storage
-    user: "5050:5050"
+    user: "1000:1000"
     network_mode: host
     depends_on:
       - postgres


### PR DESCRIPTION
- Changed user specification from 5050:5050 to 1000:1000
- This matches the standard first user UID on most Linux systems
- Improves file ownership compatibility with host system
- Ensures backup files are owned by the host user

# 🚀 Pull Request

## What's Changed?
<!-- Briefly describe what you've changed and why -->

## Related Issues
<!-- Link any related issues (e.g., "Fixes #123") -->

## Checklist
- [x] I've tested these changes
- [x] I've updated documentation (if needed)
- [x] My code follows the project's style

## Screenshots (if applicable)
<!-- Add screenshots if your changes include visual elements -->

Thanks for contributing to AIXCL! 💙
