### PR TITLE
Fix pgAdmin backup file permissions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,14 @@ services:
     depends_on:
       - postgres
     restart: always
+    command: >
+      bash -c "
+        chown -R 1000:1000 /var/lib/pgadmin/storage &&
+        chmod -R 755 /var/lib/pgadmin/storage &&
+        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \; &&
+        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \; &&
+        /entrypoint.sh
+      "
 
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
- Add startup command to set correct ownership (1000:1000) for backup storage
- Set proper permissions: 755 for directories, 644 for files
- Ensures new backups are accessible without manual permission changes
- Resolves issue where pgAdmin creates backups with root ownership

# 🚀 Pull Request

## What's Changed?
<!-- Briefly describe what you've changed and why -->

## Related Issues
<!-- Link any related issues (e.g., "Fixes #123") -->

## Checklist
- [x] I've tested these changes
- [x] I've updated documentation (if needed)
- [x] My code follows the project's style

## Screenshots (if applicable)
<!-- Add screenshots if your changes include visual elements -->

Thanks for contributing to AIXCL! 💙
