### PR TITLE
Fix pgAdmin permissions via Docker Compose entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,16 @@ services:
     depends_on:
       - postgres
     restart: always
+    entrypoint: >
+      bash -c "
+        chown -R 1000:1000 /var/lib/pgadmin/storage /var/lib/pgadmin &&
+        chmod -R 755 /var/lib/pgadmin/storage /var/lib/pgadmin &&
+        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \; &&
+        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \; &&
+        find /var/lib/pgadmin -type d -exec chmod 755 {} \; &&
+        find /var/lib/pgadmin -type f -exec chmod 644 {} \; &&
+        exec /entrypoint.sh
+      "
 
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
- Add custom entrypoint to automatically fix permissions on startup
- Set ownership to 1000:1000 (user) for all pgAdmin directories
- Set proper permissions: 755 for directories, 644 for files
- Ensures permissions are fixed automatically on every restart
- Resolves persistent permission issues with backup directories

# 🚀 Pull Request

## What's Changed?
<!-- Briefly describe what you've changed and why -->

## Related Issues
<!-- Link any related issues (e.g., "Fixes #123") -->

## Checklist
- [x] I've tested these changes
- [x] I've updated documentation (if needed)
- [x] My code follows the project's style

## Screenshots (if applicable)
<!-- Add screenshots if your changes include visual elements -->

Thanks for contributing to AIXCL! 💙
