### PR TITLE
update cicd

### DIFF
--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 3️⃣ Cache Docker layers
+      # 3️⃣ Cache Docker layers (optional)
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -34,17 +34,32 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq curl
 
-      # 5️⃣ Run ShellCheck only if .sh files exist
-      - name: Run ShellCheck (if .sh files exist)
-        run: |
-          if ls **/*.sh 1> /dev/null 2>&1; then
-            echo "Found shell scripts, running ShellCheck..."
-            docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable **/*.sh
-          else
-            echo "No shell scripts found, skipping ShellCheck."
-          fi
-
-      # 6️⃣ Build Docker image
+      # 5️⃣ Build Docker image
       - name: Build Docker image
         run: |
-          docker build -
+          docker build -t aixcl-test .
+
+      # 6️⃣ Run basic container test
+      - name: Run container sanity check
+        run: |
+          echo "Running basic container test..."
+          docker run --rm aixcl-test echo "✅ Container built and runs successfully!"
+
+      # 7️⃣ Run test scripts inside the container
+      - name: Run tests inside Docker container
+        run: |
+          echo "Checking for test scripts..."
+          if [ -f "./test.sh" ]; then
+            echo "Found test.sh — running inside container..."
+            docker run --rm -v "$PWD:/app" -w /app aixcl-test bash ./test.sh
+          elif [ -d "./tests" ]; then
+            echo "Found tests/ directory — running scripts inside container..."
+            for f in ./tests/*.sh; do
+              if [ -f "$f" ]; then
+                echo "Running $f inside container..."
+                docker run --rm -v "$PWD:/app" -w /app aixcl-test bash "$f"
+              fi
+            done
+          else
+            echo "No test.sh or tests/ folder found — skipping tests."
+          fi

--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -1,23 +1,50 @@
+name: Build & Test Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
     steps:
+      # 1️⃣ Checkout repository
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # 2️⃣ Set up Docker Buildx (for advanced builds)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # 3️⃣ Cache Docker layers (optional but speeds up builds)
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # 4️⃣ Install dependencies
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y jq curl
 
-      - name: Run ShellCheck (linting)
+      # 5️⃣ Run ShellCheck (lint shell scripts)
+      - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@v2
 
-      - name: Test docker build
+      # 6️⃣ Build Docker image (locally)
+      - name: Build Docker image
         run: |
           docker build -t aixcl-test .
 
+      # 7️⃣ Run container tests
+      - name: Run container test
+        run: |
+          echo "Running container test..."
+          docker run --rm aixcl-test echo "✅ Container built and runs successfully!"

--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # 2️⃣ Set up Docker Buildx (for advanced builds)
+      # 2️⃣ Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 3️⃣ Cache Docker layers (optional but speeds up builds)
+      # 3️⃣ Cache Docker layers
       - name: Cache Docker layers
         uses: actions/cache@v4
         with:
@@ -34,17 +34,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq curl
 
-      # 5️⃣ Run ShellCheck (lint shell scripts)
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@v2
+      # 5️⃣ Run ShellCheck only if .sh files exist
+      - name: Run ShellCheck (if .sh files exist)
+        run: |
+          if ls **/*.sh 1> /dev/null 2>&1; then
+            echo "Found shell scripts, running ShellCheck..."
+            docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable **/*.sh
+          else
+            echo "No shell scripts found, skipping ShellCheck."
+          fi
 
-      # 6️⃣ Build Docker image (locally)
+      # 6️⃣ Build Docker image
       - name: Build Docker image
         run: |
-          docker build -t aixcl-test .
-
-      # 7️⃣ Run container tests
-      - name: Run container test
-        run: |
-          echo "Running container test..."
-          docker run --rm aixcl-test echo "✅ Container built and runs successfully!"
+          docker build -


### PR DESCRIPTION
# 🚀 Pull Request

- Workflow now runs on pushes/PRs to `main`, sets up Buildx, caches layers, installs deps, and conditionally runs ShellCheck using the official container if any `.sh` scripts exist.
- Heads-up: the Docker build step currently calls `docker build -`, which feeds build context via stdin; unless that’s intentional, we probably want `docker build .` (optionally with a tag) so it builds the repo as before.
