### PR TITLE
Ensure check-env requires bash shell

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -149,6 +149,16 @@ function check_env() {
         echo "✅ Docker Compose is installed"
     fi
 
+    # Check Bash shell
+    echo -e "\nChecking shell environment..."
+    if ! command -v bash &> /dev/null; then
+        echo "❌ Bash shell is not installed"
+        echo "   Install bash to continue: https://www.gnu.org/software/bash/"
+        missing_deps=1
+    else
+        echo "✅ Bash shell is available"
+    fi
+
     # Check NVIDIA drivers and toolkit (optional)
     echo -e "\nChecking NVIDIA support..."
     if ! command -v nvidia-smi &> /dev/null; then


### PR DESCRIPTION
# 🚀 Pull Request

## PR Comment Draft

- Added a bash shell dependency check to `check_env`, causing the command to fail fast when `bash` is missing and guiding users to install it.
- This keeps the environment validator aligned with the CLI’s interpreter requirements.

**Testing**
- Run `./aixcl check-env` on a machine with bash present to confirm no regressions.
- (Optional) Temporarily adjust `PATH` to hide `bash` and ensure the new failure path triggers.
