### PR TITLE
Enhance gpu check env

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -123,6 +123,13 @@ function check_env() {
     echo "Checking environment dependencies..."
     local missing_deps=0
 
+    local is_wsl=0
+    if grep -qi "microsoft" /proc/sys/kernel/osrelease 2>/dev/null || \
+       grep -qi "microsoft" /proc/version 2>/dev/null; then
+        is_wsl=1
+        echo "ℹ️  Windows Subsystem for Linux detected. GPU checks rely on nvidia-smi/docker instead of lspci."
+    fi
+
     # Check Docker
     if ! command -v docker &> /dev/null; then
         echo "❌ Docker is not installed"
@@ -185,8 +192,26 @@ function check_env() {
             echo "⚠️ NVIDIA GPU hardware not detected"
         fi
     else
-        echo "⚠️ Unable to detect GPU hardware (missing lspci command)"
-        echo "   Install pciutils to enable hardware detection (e.g., sudo apt install pciutils)"
+        if [ "$is_wsl" -eq 1 ]; then
+            echo "⚠️ lspci is unavailable in WSL; falling back to runtime detection."
+            if command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null; then
+                echo "✅ NVIDIA GPU support detected via nvidia-smi"
+                has_gpu_hardware=1
+            elif [ -e /dev/dxg ]; then
+                echo "✅ NVIDIA GPU hardware exposed via /dev/dxg"
+                has_gpu_hardware=1
+            elif has_nvidia; then
+                echo "✅ NVIDIA GPU support detected via Docker runtime checks"
+                has_gpu_hardware=1
+            else
+                echo "ℹ️  Unable to confirm NVIDIA GPU support in WSL."
+                echo "   If you expect GPU access, ensure you've installed the Windows CUDA drivers"
+                echo "   and enabled GPU sharing in WSL: https://learn.microsoft.com/windows/wsl/tutorials/gpu-compute"
+            fi
+        else
+            echo "⚠️ Unable to detect GPU hardware (missing lspci command)"
+            echo "   Install pciutils to enable hardware detection (e.g., sudo apt install pciutils)"
+        fi
     fi
 
     if command -v nvidia-smi &> /dev/null; then

--- a/aixcl
+++ b/aixcl
@@ -161,22 +161,76 @@ function check_env() {
 
     # Check NVIDIA drivers and toolkit (optional)
     echo -e "\nChecking NVIDIA support..."
-    if ! command -v nvidia-smi &> /dev/null; then
-        echo "⚠️ NVIDIA drivers not found (optional)"
-        echo "   For GPU support, install NVIDIA drivers"
+    local os_id=""
+    local os_pretty=""
+    if [ -f /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        os_id="${ID:-}"
+        os_pretty="${PRETTY_NAME:-$os_id}"
+    fi
+
+    if [ -n "$os_pretty" ]; then
+        echo "Detected operating system: $os_pretty"
     else
-        echo "✅ NVIDIA drivers installed"
-        # Check NVIDIA Container Toolkit
-        if command -v nvidia-container-cli &> /dev/null; then
-            echo "✅ NVIDIA Container Toolkit installed"
-        elif command -v dpkg &> /dev/null && dpkg -l | grep -q nvidia-container-toolkit; then
-            echo "✅ NVIDIA Container Toolkit installed"
-        elif command -v rpm &> /dev/null && rpm -qa | grep -q nvidia-container-toolkit; then
-            echo "✅ NVIDIA Container Toolkit installed"
+        echo "⚠️ Could not determine operating system (using generic GPU checks)"
+    fi
+
+    local has_gpu_hardware=0
+    if command -v lspci &> /dev/null; then
+        if lspci | grep -qi "nvidia"; then
+            echo "✅ NVIDIA GPU hardware detected"
+            has_gpu_hardware=1
         else
-            echo "⚠️ NVIDIA Container Toolkit not found (optional)"
-            echo "   For GPU support, install: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html"
+            echo "⚠️ NVIDIA GPU hardware not detected"
         fi
+    else
+        echo "⚠️ Unable to detect GPU hardware (missing lspci command)"
+        echo "   Install pciutils to enable hardware detection (e.g., sudo apt install pciutils)"
+    fi
+
+    if command -v nvidia-smi &> /dev/null; then
+        echo "✅ NVIDIA drivers installed"
+    elif [ "$has_gpu_hardware" -eq 1 ]; then
+        echo "❌ NVIDIA drivers not found"
+        case "$os_id" in
+            ubuntu|debian)
+                echo "   Install drivers with: sudo ubuntu-drivers autoinstall"
+                ;;
+            fedora)
+                echo "   Install drivers with RPM Fusion: sudo dnf install akmod-nvidia xorg-x11-drv-nvidia-cuda"
+                ;;
+            *)
+                echo "   Refer to NVIDIA docs for driver installation: https://www.nvidia.com/Download/index.aspx"
+                ;;
+        esac
+    else
+        echo "⚠️ NVIDIA drivers not found (no GPU detected)"
+    fi
+
+    # Check NVIDIA Container Toolkit
+    if command -v nvidia-container-cli &> /dev/null; then
+        echo "✅ NVIDIA Container Toolkit installed"
+    elif command -v dpkg &> /dev/null && dpkg -l | grep -q nvidia-container-toolkit; then
+        echo "✅ NVIDIA Container Toolkit installed"
+    elif command -v rpm &> /dev/null && rpm -qa | grep -q nvidia-container-toolkit; then
+        echo "✅ NVIDIA Container Toolkit installed"
+    else
+        echo "⚠️ NVIDIA Container Toolkit not found (optional)"
+        case "$os_id" in
+            ubuntu|debian)
+                echo "   Install toolkit with:"
+                echo "   sudo apt update && sudo apt install -y nvidia-container-toolkit"
+                ;;
+            fedora)
+                echo "   Install toolkit with:"
+                echo "   sudo dnf config-manager --add-repo https://nvidia.github.io/libnvidia-container/stable/fedora/libnvidia-container.repo"
+                echo "   sudo dnf install -y nvidia-container-toolkit"
+                ;;
+            *)
+                echo "   Install instructions: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html"
+                ;;
+        esac
     fi
 
     # Check available disk space


### PR DESCRIPTION
# 🚀 Pull Request

- `check_env` now announces WSL runs (`ℹ️ Windows Subsystem for Linux detected…`) so users understand why GPU probing behaves differently.
- GPU detection under WSL falls back to `nvidia-smi`, `/dev/dxg`, and Docker runtime checks, eliminating false “hardware missing” warnings when passthrough is enabled.
- Keeps the generic lspci-based path for native Linux systems and still treats missing GPU software as optional when no hardware is present.

**Testing**
- `./aixcl check-env` inside WSL with GPU passthrough → confirms informational WSL message and successful driver/toolkit detection.
- `./aixcl check-env` on a non-GPU Linux host → still warns appropriately without failing the environment check.
