### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -1,4 +1,6 @@
 name: Check Environment
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xencon/aixcl/security/code-scanning/1](https://github.com/xencon/aixcl/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with minimal required privileges to the workflow. As the workflow only checks out the code and runs shell commands and does not need to write to repo contents, or interact with pull requests or issues, the best practice is to set `permissions: contents: read` at the top level—either at the root of the workflow (applies to all jobs) or within each job (if different jobs need different permissions). Since there is only one job and all workflow steps do not require write permissions, adding a top-level `permissions` block is appropriate. This requires editing `.github/workflows/bash-ci.yml` and inserting a block right below the `name: ...` line or above `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
