### PR TITLE
Fix Docker image manifest errors by updating to available image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       start_period: 30s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:1.30.0
+    image: ghcr.io/open-webui/open-webui:latest
     container_name: open-webui
     volumes:
       - open-webui:/app/backend/data
@@ -76,7 +76,7 @@ services:
       retries: 3
   
   pgadmin:
-    image: dpage/pgadmin4:9.0.1
+    image: dpage/pgadmin4:9.0
     container_name: pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: $PGADMIN_EMAIL
@@ -106,7 +106,7 @@ services:
         exec /entrypoint.sh
 
   watchtower:
-    image: containrrr/watchtower:1.7.0
+    image: containrrr/watchtower:latest
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -216,7 +216,7 @@ services:
     restart: unless-stopped
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:v0.16.2
+    image: prometheuscommunity/postgres-exporter:latest
     container_name: postgres-exporter
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DATABASE}?sslmode=disable"


### PR DESCRIPTION
## Summary
This PR fixes Docker image manifest errors that were preventing services from starting.

## Changes
- Update `pgadmin4` from `9.0.1` to `9.0` (tag 9.0.1 doesn't exist)
- Update `watchtower` from `1.7.0` to `latest` (tag 1.7.0 doesn't exist)
- Update `postgres-exporter` from `v0.16.2` to `latest` (tag v0.16.2 doesn't exist)
- Update `open-webui` from `1.30.0` to `latest` (tag 1.30.0 doesn't exist)

## Testing
- Verified docker-compose.yml syntax is valid
- Tested pulling the updated image tags successfully
- All images now pull without 'manifest unknown' errors

## Impact
Resolves the deployment issue where `./aixcl start` was failing due to missing Docker image tags.