### PR TITLE
Update Ollama to latest version for gemma3 model support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     pull_policy: always
     tty: true
     restart: unless-stopped
-    image: ollama/ollama:0.3.4
+    image: ollama/ollama:latest
     # GPU resources are configured in docker-compose.gpu.yml when available
     # ARM64 platform is configured in docker-compose.arm.yml when detected
     healthcheck:


### PR DESCRIPTION
Updates Ollama from version 0.3.4 to latest to support newer models like gemma3:latest.

This change addresses the error when trying to add gemma3:latest model: \Error: pull model manifest: 412: The model you are attempting to pull requires a newer version of Ollama. \ By using the latest tag, we ensure compatibility with the newest models available.
