### PR TITLE
refactor: rename install-completion to bash-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd aixcl
 ./aixcl check-env
 
 # Install CLI completion for bash shell
-./aixcl install-completion
+./aixcl bash-completion
 
 # Start the services (automatically creates .env from .env.example if needed)
 ./aixcl start
@@ -58,7 +58,7 @@ cd aixcl
 ## CLI Commands
 
 ```
-Usage: ./aixcl {start|stop|restart|logs|clean|status|models|dashboard|council|help|install-completion|check-env}
+Usage: ./aixcl {start|stop|restart|logs|clean|status|models|dashboard|council|help|bash-completion|check-env}
 Commands:
   start                Start the Docker Compose deployment
   stop                 Stop the Docker Compose deployment
@@ -70,7 +70,7 @@ Commands:
   dashboard [...]      Open a web dashboard (grafana, openwebui, pgadmin)
   council [...]        Configure or list LLM Council models
   help                 Show this help menu
-  install-completion   Install bash completion for aixcl
+  bash-completion      Install bash completion for aixcl
   check-env            Check environment dependencies
 ```
 
@@ -345,7 +345,7 @@ AIXCL includes bash completion support to make using the CLI faster and easier:
 
 ```bash
 # Install bash completion
-./aixcl install-completion
+./aixcl bash-completion
 
 # Now you can use tab completion
 ./aixcl [TAB]          # Shows all commands

--- a/aixcl
+++ b/aixcl
@@ -1091,7 +1091,7 @@ function dashboard() {
 }
 
 function help_menu() {
-    echo "Usage: $0 {start|stop|restart|logs|clean|status|models|dashboard|council|help|install-completion|check-env}"
+    echo "Usage: $0 {start|stop|restart|logs|clean|status|models|dashboard|council|help|bash-completion|check-env}"
     echo "Commands:"
     echo "  start                Start the AIXCL stack"
     echo "  stop                 Stop the AIXCL stack"
@@ -1106,7 +1106,7 @@ function help_menu() {
     echo "  council {configure|list} Configure or list LLM Council models"
     echo "  check-env            Check environment dependencies"
     echo "  help                 Show this help menu"
-    echo "  install-completion   Install bash completion"
+    echo "  bash-completion      Install bash completion"
     exit 1
 }
 
@@ -1730,7 +1730,7 @@ function main() {
         help)
             help_menu
             ;;
-        install-completion)
+        bash-completion)
             install_completion
             ;;
         check-env)

--- a/aixcl_completion.sh
+++ b/aixcl_completion.sh
@@ -8,7 +8,7 @@
 # To use this script:
 # 1. Source it directly: source /path/to/aixcl_completion.sh
 # 2. Or install it system-wide: sudo cp aixcl_completion.sh /etc/bash_completion.d/aixcl
-# 3. Or run: ./aixcl install-completion
+# 3. Or run: ./aixcl bash-completion
 #
 
 # Function to get available models from Ollama
@@ -26,7 +26,7 @@ _aixcl_complete() {
     _init_completion || return
 
     # List of all possible commands
-    local commands="start stop restart logs clean status models dashboard council help install-completion check-env"
+    local commands="start stop restart logs clean status models dashboard council help bash-completion check-env"
 
     # List of services for logs command
     local services="ollama open-webui postgres pgadmin watchtower prometheus grafana cadvisor node-exporter postgres-exporter nvidia-gpu-exporter"


### PR DESCRIPTION
## Changes
Renamed the install-completion command to ash-completion to make it more obvious what the command does.

## Updated Files
- ixcl - Updated command name in switch case, help text, and usage
- README.md - Updated all documentation references
- ixcl_completion.sh - Updated completion script references

## Rationale
The new name ash-completion is more descriptive and immediately conveys that this command installs bash completion functionality, rather than the more generic install-completion which could refer to any type of completion.