### PR TITLE
Add docker registry configuration and scripts

### DIFF
--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -7,7 +7,7 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-  
+
   nvidia-gpu-exporter:
     deploy:
       resources:
@@ -16,7 +16,7 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-  
+
   llm-council:
     deploy:
       resources:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,274 @@
+services:
+  ollama:
+    volumes:
+      - ollama:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+    ports:
+      - "11434:11434"
+    container_name: ollama
+    pull_policy: always
+    tty: true
+    restart: unless-stopped
+    image: localhost:5000/ollama_ollama:latest
+    # GPU resources are configured in docker-compose.gpu.yml when available
+    # ARM64 platform is configured in docker-compose.arm.yml when detected
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  open-webui:
+    image: localhost:5000/ghcr.io_open-webui_open-webui:latest
+    container_name: open-webui
+    volumes:
+      - open-webui:/app/backend/data
+      - open-webui-data:/app/data
+      - ./scripts/openwebui.sh:/app/backend/openwebui.sh
+    environment:
+      - DATA_DIR=/app/data
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DATABASE}
+      - WEBUI_NAME=AIXCL
+      - OLLAMA_BASE_URL=http://localhost:11434
+      - OPENWEBUI_EMAIL=${OPENWEBUI_EMAIL}
+      - OPENWEBUI_PASSWORD=${OPENWEBUI_PASSWORD}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - postgres
+      - ollama
+    network_mode: host
+    restart: always
+    command: ["/bin/bash", "-c", "chmod +x openwebui.sh && bash openwebui.sh"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]  # Adjust the health endpoint as necessary
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  postgres:
+    image: localhost:5000/postgres:17.2
+    container_name: postgres
+    environment:
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      POSTGRES_DATABASE: $POSTGRES_DATABASE
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    network_mode: host
+    restart: always
+    command: >
+      postgres
+      -c log_statement=all
+      -c log_destination=stderr
+      -c logging_collector=on
+      -c log_directory=/var/log/postgresql
+      -c log_filename=postgresql-%Y-%m-%d_%H%M%S.log
+      -c log_rotation_age=1d
+      -c log_rotation_size=100MB
+      -c log_min_duration_statement=0
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+  
+  pgadmin:
+    image: localhost:5000/dpage_pgadmin4:9.0
+    container_name: pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: $PGADMIN_EMAIL
+      PGADMIN_DEFAULT_PASSWORD: $PGADMIN_PASSWORD
+      PGADMIN_LISTEN_PORT: 5050
+      PGADMIN_SERVER_JSON_FILE: /pgadmin4/servers.json
+    volumes:
+      - ./backups:/var/lib/pgadmin/storage
+      - ./logs/pgadmin:/var/log/pgadmin
+      - ./pgadmin-data:/var/lib/pgadmin
+      - ./pgadmin-servers.json:/pgadmin4/servers.json
+    user: "0:0"
+    network_mode: host
+    depends_on:
+      - postgres
+    restart: always
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        chown -R 1000:1000 /var/lib/pgadmin/storage /var/lib/pgadmin
+        chmod -R 755 /var/lib/pgadmin/storage /var/lib/pgadmin
+        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \;
+        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \;
+        find /var/lib/pgadmin -type d -exec chmod 755 {} \;
+        find /var/lib/pgadmin -type f -exec chmod 644 {} \;
+        exec /entrypoint.sh
+
+  watchtower:
+    image: localhost:5000/containrrr_watchtower:latest
+    container_name: watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: open-webui
+    restart: always
+
+  llm-council:
+    build: ./llm-council
+    container_name: llm-council
+    environment:
+      - BACKEND_MODE=ollama
+      - OLLAMA_BASE_URL=http://localhost:11434
+      - COUNCIL_MODELS=codellama:7b,qwen3:latest
+      - CHAIRMAN_MODEL=qwen3:latest
+      - DATA_DIR=/app/data
+      - POSTGRES_HOST=localhost
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+      - ENABLE_DB_STORAGE=true
+    volumes:
+      - ./llm-council-data:/app/data
+    network_mode: host
+    depends_on:
+      - ollama
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  prometheus:
+    image: localhost:5000/prom_prometheus:v2.54.0
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  grafana:
+    image: localhost:5000/grafana_grafana:11.3.0
+    container_name: grafana
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_INSTALL_PLUGINS=
+      - GF_SERVER_HTTP_PORT=3000
+    network_mode: host
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  cadvisor:
+    image: localhost:5000/gcr.io_cadvisor_cadvisor:v0.49.1
+    container_name: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    devices:
+      - /dev/kmsg
+    network_mode: host
+    restart: unless-stopped
+    command:
+      - '--port=8081'
+
+  node-exporter:
+    image: localhost:5000/prom_node-exporter:v1.8.2
+    container_name: node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    network_mode: host
+    restart: unless-stopped
+
+  postgres-exporter:
+    image: localhost:5000/prometheuscommunity_postgres-exporter:latest
+    container_name: postgres-exporter
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DATABASE}?sslmode=disable"
+    network_mode: host
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
+  nvidia-gpu-exporter:
+    image: localhost:5000/nvcr.io_nvidia_k8s_dcgm-exporter:3.3.5-3.4.0-ubuntu22.04
+    container_name: nvidia-gpu-exporter
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - DCGM_EXPORTER_LISTEN=:9400
+    # GPU resources are configured in docker-compose.gpu.yml when available
+    # This service will gracefully fail on systems without NVIDIA GPUs
+
+  loki:
+    image: localhost:5000/grafana_loki:3.3.0
+    container_name: loki
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki-config.yml
+    network_mode: host
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  promtail:
+    image: localhost:5000/grafana_promtail:3.3.0
+    container_name: promtail
+    volumes:
+      - ./promtail/promtail-config.yml:/etc/promtail/promtail-config.yml
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/promtail-config.yml
+    network_mode: host
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+volumes:
+  ollama:
+  open-webui:
+  open-webui-data:
+  postgres-data:
+  prometheus-data:
+  grafana-data:
+  loki-data:

--- a/registry_mapping.txt
+++ b/registry_mapping.txt
@@ -1,0 +1,16 @@
+aixcl_llm-council:latest=localhost:5000/aixcl_llm-council:latest
+python:3.11.14-slim=localhost:5000/python:3.11.14-slim
+ollama/ollama:latest=localhost:5000/ollama_ollama:latest
+ghcr.io/open-webui/open-webui:latest=localhost:5000/ghcr.io_open-webui_open-webui:latest
+prometheuscommunity/postgres-exporter:latest=localhost:5000/prometheuscommunity_postgres-exporter:latest
+dpage/pgadmin4:9.0=localhost:5000/dpage_pgadmin4:9.0
+postgres:17.2=localhost:5000/postgres:17.2
+grafana/promtail:3.3.0=localhost:5000/grafana_promtail:3.3.0
+grafana/loki:3.3.0=localhost:5000/grafana_loki:3.3.0
+grafana/grafana:11.3.0=localhost:5000/grafana_grafana:11.3.0
+prom/prometheus:v2.54.0=localhost:5000/prom_prometheus:v2.54.0
+prom/node-exporter:v1.8.2=localhost:5000/prom_node-exporter:v1.8.2
+gcr.io/cadvisor/cadvisor:v0.49.1=localhost:5000/gcr.io_cadvisor_cadvisor:v0.49.1
+nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.0-ubuntu22.04=localhost:5000/nvcr.io_nvidia_k8s_dcgm-exporter:3.3.5-3.4.0-ubuntu22.04
+containrrr/watchtower:latest=localhost:5000/containrrr_watchtower:latest
+registry:2=localhost:5000/registry:2

--- a/scripts/registry.sh
+++ b/scripts/registry.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+# ======================================================
+# Local Docker Registry Caching Tool
+# - Mirrors Docker + Ollama images into local registry
+# - Rewrites docker-compose.yml accordingly
+# - Handles manual add/remove/list
+# - Supports dry-run mode
+# ======================================================
+
+### PATHS ###############################################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+REGISTRY="localhost:5000"
+
+# Mapping format: SOURCE=TARGET
+MAPPING_FILE="$PROJECT_ROOT/registry_mapping.txt"
+
+# Logs
+LOG_FILE="$PROJECT_ROOT/registry_master.log"
+
+# Compose
+COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yml"
+OUTPUT_FILE="$PROJECT_ROOT/docker-compose.local.yml"
+
+DRY_RUN=0
+
+### LOGGING ##############################################
+
+log() {
+    local MSG="$1"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $MSG" | tee -a "$LOG_FILE"
+}
+
+run() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "[DRY-RUN] $*"
+    else
+        log "$*"
+        eval "$*"
+    fi
+}
+
+### REGISTRY SETUP ########################################
+
+ensure_registry() {
+    if ! docker ps --format '{{.Names}}' | grep -q '^local-registry$'; then
+        log "Starting local Docker registry..."
+        run "docker run -d -p 5000:5000 --restart=always --name local-registry registry:2"
+        sleep 3
+    fi
+    log "Registry ready at $REGISTRY"
+}
+
+### MAPPING FUNCTIONS ######################################
+
+save_mapping() {
+    local SOURCE="$1"
+    local TARGET="$2"
+    grep -v "^$SOURCE=" "$MAPPING_FILE" 2>/dev/null > "$MAPPING_FILE.tmp" || true
+    mv "$MAPPING_FILE.tmp" "$MAPPING_FILE"
+    echo "$SOURCE=$TARGET" >> "$MAPPING_FILE"
+}
+
+### AUTO DISCOVERY #########################################
+
+auto_cache() {
+    log "Scanning Docker images..."
+    DOCKER_IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>' || true)
+
+    log "Scanning Ollama models..."
+    if command -v ollama >/dev/null 2>&1; then
+        LLM_IMAGES=$(ollama list | awk 'NR>1 {print $1":"$3}' || true)
+    else
+        LLM_IMAGES=""
+    fi
+
+    > "$MAPPING_FILE"
+
+    for IMAGE in $DOCKER_IMAGES $LLM_IMAGES; do
+        LOCAL_TAG="${IMAGE//\//_}"   # replace / with _
+        TARGET="$REGISTRY/$LOCAL_TAG"
+
+        log "Caching: $IMAGE  →  $TARGET"
+
+        run "docker tag $IMAGE $TARGET"
+        run "docker push $TARGET"
+
+        save_mapping "$IMAGE" "$TARGET"
+    done
+}
+
+### MANUAL ADD ############################################
+
+add_image() {
+    local SRC="$1"
+    local TAG="$2"
+
+    if [ -z "$SRC" ] || [ -z "$TAG" ]; then
+        echo "Usage: $0 add <source_image> <local_tag>"
+        exit 1
+    fi
+
+    TARGET="$REGISTRY/$TAG"
+
+    run "docker tag $SRC $TARGET"
+    run "docker push $TARGET"
+
+    save_mapping "$SRC" "$TARGET"
+}
+
+### MANUAL REMOVE ##########################################
+
+remove_image() {
+    local TAG="$1"
+
+    if [ -z "$TAG" ]; then
+        echo "Usage: $0 remove <local_tag>"
+        exit 1
+    fi
+
+    local TARGET="$REGISTRY/$TAG"
+
+    run "docker rmi $TARGET || true"
+
+    grep -v "=$TARGET$" "$MAPPING_FILE" > "$MAPPING_FILE.tmp"
+    mv "$MAPPING_FILE.tmp" "$MAPPING_FILE"
+}
+
+### LIST MAPPINGS ##########################################
+
+list_images() {
+    log "=== Cached Images ==="
+    cat "$MAPPING_FILE"
+}
+
+### COMPOSE REWRITE ########################################
+
+rewrite_compose() {
+    if [ ! -f "$COMPOSE_FILE" ]; then
+        log "Compose file not found: $COMPOSE_FILE"
+        return
+    fi
+
+    cp "$COMPOSE_FILE" "$OUTPUT_FILE"
+
+    while IFS='=' read -r SRC DST; do
+        [ -z "$SRC" ] && continue
+
+        SRC_ESC=$(printf '%s\n' "$SRC" | sed 's/[\/&]/\\&/g')
+        DST_ESC=$(printf '%s\n' "$DST" | sed 's/[\/&]/\\&/g')
+
+        run "sed -i \"s/$SRC_ESC/$DST_ESC/g\" \"$OUTPUT_FILE\""
+    done < "$MAPPING_FILE"
+
+    log "Compose rewritten → $OUTPUT_FILE"
+}
+
+### PRUNE (LOCAL ONLY) #####################################
+
+prune_local() {
+    log "Pruning unused cached local images…"
+
+    while IFS='=' read -r SRC DST; do
+        [ -z "$SRC" ] && continue
+        USED_TARGETS+="$DST "
+    done < "$MAPPING_FILE"
+
+    ALL_LOCAL=$(docker images "$REGISTRY"/* --format '{{.Repository}}:{{.Tag}}' || true)
+
+    for IMG in $ALL_LOCAL; do
+        if [[ " $USED_TARGETS " != *" $IMG "* ]]; then
+            log "Pruning unused: $IMG"
+            run "docker rmi $IMG || true"
+        fi
+    done
+}
+
+### COMMAND PARSER #########################################
+
+if [ "$1" == "--dry-run" ]; then
+    DRY_RUN=1
+    shift
+fi
+
+CMD="$1"
+shift || true
+
+case "$CMD" in
+    auto)
+        ensure_registry
+        auto_cache
+        rewrite_compose
+        prune_local
+        ;;
+    add)
+        ensure_registry
+        add_image "$@"
+        rewrite_compose
+        ;;
+    remove)
+        remove_image "$@"
+        rewrite_compose
+        prune_local
+        ;;
+    list)
+        list_images
+        ;;
+    prune)
+        prune_local
+        ;;
+    *)
+        echo "Usage: $0 [--dry-run] {auto|add|remove|list|prune}"
+        exit 1
+        ;;
+esac
+

--- a/scripts/registry_mapping.txt
+++ b/scripts/registry_mapping.txt
@@ -1,0 +1,16 @@
+aixcl_llm-council:latest -> localhost:5000/aixcl_llm-council:latest
+python:3.11.14-slim -> localhost:5000/python:3.11.14-slim
+ollama/ollama:latest -> localhost:5000/ollama_ollama:latest
+ghcr.io/open-webui/open-webui:latest -> localhost:5000/ghcr.io_open-webui/open-webui:latest
+prometheuscommunity/postgres-exporter:latest -> localhost:5000/prometheuscommunity_postgres-exporter:latest
+dpage/pgadmin4:9.0 -> localhost:5000/dpage_pgadmin4:9.0
+postgres:17.2 -> localhost:5000/postgres:17.2
+grafana/promtail:3.3.0 -> localhost:5000/grafana_promtail:3.3.0
+grafana/loki:3.3.0 -> localhost:5000/grafana_loki:3.3.0
+grafana/grafana:11.3.0 -> localhost:5000/grafana_grafana:11.3.0
+prom/prometheus:v2.54.0 -> localhost:5000/prom_prometheus:v2.54.0
+prom/node-exporter:v1.8.2 -> localhost:5000/prom_node-exporter:v1.8.2
+gcr.io/cadvisor/cadvisor:v0.49.1 -> localhost:5000/gcr.io_cadvisor/cadvisor:v0.49.1
+nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.0-ubuntu22.04 -> localhost:5000/nvcr.io_nvidia/k8s/dcgm-exporter:3.3.5-3.4.0-ubuntu22.04
+containrrr/watchtower:latest -> localhost:5000/containrrr_watchtower:latest
+registry:2 -> localhost:5000/registry:2


### PR DESCRIPTION
This PR adds docker registry configuration files and scripts for managing registry mappings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a local Docker registry caching script, mapping files, and a host-networked docker-compose for running the stack with locally mirrored images.
> 
> - **Tooling**:
>   - Add `scripts/registry.sh` to mirror images into `localhost:5000`, maintain `registry_mapping.txt`, rewrite `docker-compose.yml` to `docker-compose.local.yml`, and support `auto|add|remove|list|prune` with dry-run.
> - **Compose**:
>   - Introduce `docker-compose.local.yml` running `ollama`, `open-webui`, `llm-council`, `postgres`, `pgadmin`, `prometheus`, `grafana`, `cadvisor`, `node-exporter`, `postgres-exporter`, `loki`, `promtail`, and `watchtower` via locally cached images and host networking.
> - **Mappings**:
>   - Add image mapping files `registry_mapping.txt` and `scripts/registry_mapping.txt` for source→`localhost:5000/...` tags.
> - **GPU**:
>   - Keep `docker-compose.gpu.yml` with NVIDIA GPU reservations for `ollama`, `nvidia-gpu-exporter`, and `llm-council`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dad7a5bb93028d0cda1590daf0a2d50051ac3f2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->