### PR TITLE
chore: reorganize file structure to match plan

### DIFF
--- a/docs/manpage.txt
+++ b/docs/manpage.txt
@@ -1,0 +1,126 @@
+AIXCL(1)                          User Commands                          AIXCL(1)
+
+NAME
+       aixcl - AI & Infrastructure Stack Control CLI
+
+SYNOPSIS
+       aixcl <command> <subcommand> [options]
+
+DESCRIPTION
+       AIXCL is a unified command-line tool for managing AI services, monitoring
+       stack, dashboards, and models. It provides a Docker-native workflow for
+       running LLMs locally, managing model configurations, and orchestrating
+       multiple AI services.
+
+COMMANDS
+       stack start
+              Start all services
+
+       stack stop
+              Stop all services
+
+       stack restart
+              Restart the entire stack
+
+       stack status
+              Show service status
+
+       stack logs [svc] [n]
+              Show logs for all or one service, optional line count
+
+       stack clean
+              Remove unused Docker resources
+
+       service <start|stop|restart> <name>
+              Control individual service
+
+              Supported services:
+              ollama, open-webui, postgres, pgadmin, watchtower, prometheus,
+              grafana, cadvisor, node-exporter, postgres-exporter,
+              nvidia-gpu-exporter, loki, promtail
+
+       models <add|remove|list> [name]
+              Manage LLM models
+
+              add     Add a model
+              remove  Remove a model
+              list    List installed models
+
+       council <configure|status|list>
+              Configure LLM Council behavior and members
+
+              configure  Configure council behavior and members
+              status     Show model status
+              list       List council configuration
+
+       dashboard <grafana|openwebui|pgadmin>
+              Launch dashboard in default browser
+
+              grafana    Open Grafana dashboard
+              openwebui  Open Open WebUI interface
+              pgadmin    Open pgAdmin database administration
+
+       utils check-env
+              Validate environment setup
+
+       utils bash-completion
+              Install bash completion support
+
+       help
+              Show help message
+
+EXAMPLES
+       Start the entire stack:
+              aixcl stack start
+
+       Restart a single service:
+              aixcl service restart postgres
+
+       Add a new LLM model:
+              aixcl models add phi3
+
+       Open Grafana:
+              aixcl dashboard grafana
+
+       Check environment requirements:
+              aixcl utils check-env
+
+ENVIRONMENT
+       AIXCL uses environment variables from .env file (auto-created from
+       .env.example on first run). Key variables include:
+
+       POSTGRES_USER
+              PostgreSQL username
+
+       POSTGRES_PASSWORD
+              PostgreSQL password
+
+       POSTGRES_DATABASE
+              PostgreSQL database name
+
+       COUNCIL_MODELS
+              Comma-separated list of council member models
+
+       CHAIRMAN_MODEL
+              Model used as chairman (synthesizes final response)
+
+FILES
+       ~/.env
+              Main configuration file (automatically created)
+
+       ~/.env.example
+              Template configuration file
+
+       ~/.env.local
+              Local overrides (optional, ignored by git)
+
+SEE ALSO
+       docker(1), docker-compose(1), ollama(1)
+
+AUTHOR
+       AIXCL Project
+
+BUGS
+       Report bugs at https://github.com/xencon/aixcl/issues
+
+AIXCL                            2024                             AIXCL(1)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,272 @@
+# AIXCL Usage Guide
+
+## Quick Start
+
+### 1. Check Environment
+
+```bash
+./aixcl.sh utils check-env
+```
+
+This validates:
+- Docker installation and daemon
+- Docker Compose
+- NVIDIA GPU support (if available)
+- System resources (disk space, memory)
+
+### 2. Start Services
+
+```bash
+./aixcl.sh stack start
+```
+
+This will:
+- Create `.env` file from `.env.example` if needed
+- Generate pgAdmin configuration
+- Pull latest Docker images
+- Start all services
+- Wait for services to be ready
+
+### 3. Add Models
+
+```bash
+./aixcl.sh models add phi3:latest qwen2.5:7b
+```
+
+### 4. Configure Council
+
+```bash
+./aixcl.sh council configure
+```
+
+Interactive setup to select:
+- Chairman model (synthesizes final response)
+- Council members (provide initial opinions)
+
+### 5. Check Status
+
+```bash
+./aixcl.sh stack status
+```
+
+Shows:
+- Container status (running/stopped)
+- Service health (API responses)
+- Service logs for failed services
+
+## Common Workflows
+
+### Starting Development Session
+
+```bash
+# Start everything
+./aixcl.sh stack start
+
+# Check everything is running
+./aixcl.sh stack status
+
+# Open dashboards
+./aixcl.sh dashboard openwebui
+./aixcl.sh dashboard grafana
+```
+
+### Adding New Models
+
+```bash
+# List current models
+./aixcl.sh models list
+
+# Add new model
+./aixcl.sh models add codellama:7b
+
+# Update council configuration
+./aixcl.sh council configure
+```
+
+### Troubleshooting
+
+```bash
+# Check service logs
+./aixcl.sh stack logs ollama 50
+./aixcl.sh stack logs llm-council 100
+
+# Restart a specific service
+./aixcl.sh service restart postgres
+
+# Restart entire stack
+./aixcl.sh stack restart
+
+# Clean up and start fresh
+./aixcl.sh stack clean
+./aixcl.sh stack start
+```
+
+### Continue Plugin Setup
+
+1. **Start services:**
+   ```bash
+   ./aixcl.sh stack start
+   ```
+
+2. **Verify LLM Council is running:**
+   ```bash
+   ./aixcl.sh stack status
+   ```
+
+3. **Configure Continue plugin** (in `.continue/config.json`):
+   ```json
+   {
+     "models": [
+       {
+         "model": "council",
+         "title": "LLM-Council (Multi-Model)",
+         "provider": "openai",
+         "apiBase": "http://localhost:8000/v1",
+         "apiKey": "local"
+       }
+     ]
+   }
+   ```
+
+4. **Test integration:**
+   ```bash
+   bash tests/test_continue_integration.sh
+   ```
+
+## Service Management
+
+### Individual Service Control
+
+```bash
+# Start a service
+./aixcl.sh service start grafana
+
+# Stop a service
+./aixcl.sh service stop prometheus
+
+# Restart a service
+./aixcl.sh service restart ollama
+```
+
+### Viewing Logs
+
+```bash
+# All services (follow mode)
+./aixcl.sh stack logs
+
+# Specific service, last 50 lines
+./aixcl.sh stack logs ollama 50
+
+# Specific service, last 100 lines, follow
+./aixcl.sh stack logs postgres 100
+```
+
+## Council Management
+
+### Interactive Configuration
+
+```bash
+./aixcl.sh council configure
+```
+
+This interactive wizard:
+1. Lists available models from Ollama
+2. Prompts for chairman selection
+3. Prompts for council members (1-4 additional models)
+4. Shows configuration summary
+5. Updates `.env` file
+6. Optionally restarts LLM-Council service
+
+### Check Council Status
+
+```bash
+./aixcl.sh council status
+```
+
+Shows:
+- Current configuration (chairman, members)
+- Operational status of each model
+- Service status (LLM-Council, Ollama)
+- Summary statistics
+
+## Monitoring
+
+### View Dashboards
+
+```bash
+# Grafana (metrics and monitoring)
+./aixcl.sh dashboard grafana
+
+# Open WebUI (chat interface)
+./aixcl.sh dashboard openwebui
+
+# pgAdmin (database administration)
+./aixcl.sh dashboard pgadmin
+```
+
+### Check Service Health
+
+```bash
+./aixcl.sh stack status
+```
+
+This comprehensive status check shows:
+- **Container Status:** Which containers are running
+- **Service Health:** HTTP endpoints responding correctly
+- **Logs:** Recent log entries for failed services
+
+## Maintenance
+
+### Clean Up Resources
+
+```bash
+./aixcl.sh stack clean
+```
+
+This removes:
+- Stopped containers
+- Unused images
+- Unused volumes
+- PostgreSQL containers and volumes (careful!)
+
+### Update Services
+
+Services are automatically updated by Watchtower, or manually:
+
+```bash
+# Pull latest images
+cd services
+docker-compose pull
+
+# Restart services
+./aixcl.sh stack restart
+```
+
+## Tips
+
+1. **Always check status first:**
+   ```bash
+   ./aixcl.sh stack status
+   ```
+
+2. **Use logs for debugging:**
+   ```bash
+   ./aixcl.sh stack logs <service> 100
+   ```
+
+3. **Test Continue integration:**
+   ```bash
+   bash tests/test_continue_integration.sh
+   ```
+
+4. **Keep models updated:**
+   ```bash
+   ./aixcl.sh models list
+   # Remove old, add new
+   ```
+
+5. **Backup database before clean:**
+   ```bash
+   # pgAdmin or direct pg_dump
+   docker exec postgres pg_dump -U webui webui > backup.sql
+   ```


### PR DESCRIPTION
## Summary

This PR reorganizes the file structure to match the planned directory layout specified in `scripts/plan.txt` (lines 127-156).

## Changes

- ✅ Renamed `docs/USAGE.md` → `docs/usage.md` (lowercase to match plan)
- ✅ Created `docs/manpage.txt` with manpage-formatted documentation

## Verification

The documentation structure now matches the plan:
- `docs/CLI_SPEC.md` ✓
- `docs/manpage.txt` ✓ (new)
- `docs/usage.md` ✓ (renamed)

All other directory structures (cli/, lib/, services/, completion/) already matched the plan.

## Related

Addresses the directory structure specification in `scripts/plan.txt`.
