### PR TITLE
fix: Add missing profile.sh library (#220)

### DIFF
--- a/cli/lib/profile.sh
+++ b/cli/lib/profile.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Profile management library for AIXCL
+# Defines profiles and provides functions to query profile information
+
+# Valid profiles array
+VALID_PROFILES=(core dev ops full)
+
+# Runtime core services (always present in all profiles)
+RUNTIME_CORE_SERVICES=(ollama llm-council)
+
+# Profile descriptions
+declare -A PROFILE_DESCRIPTIONS=(
+    [core]="Minimal runtime (CI, constrained systems)"
+    [dev]="Developer workstation (UI + DB)"
+    [ops]="Observability-focused (monitoring/logging)"
+    [full]="Complete stack (default)"
+)
+
+# Profile service mappings
+# Each profile includes runtime core services plus profile-specific services
+declare -A PROFILE_SERVICES=(
+    [core]="ollama llm-council"
+    [dev]="ollama llm-council open-webui postgres pgadmin"
+    [ops]="ollama llm-council postgres prometheus grafana loki promtail cadvisor node-exporter postgres-exporter nvidia-gpu-exporter"
+    [full]="ollama llm-council open-webui postgres pgadmin prometheus grafana loki promtail cadvisor node-exporter postgres-exporter nvidia-gpu-exporter watchtower"
+)
+
+# Profile database storage settings
+# Core profile uses file-based persistence (no PostgreSQL dependency)
+# Other profiles use database storage
+declare -A PROFILE_DB_STORAGE=(
+    [core]="false"
+    [dev]="true"
+    [ops]="true"
+    [full]="true"
+)
+
+# Check if a profile name is valid
+is_valid_profile() {
+    local profile="$1"
+    if [ -z "$profile" ]; then
+        return 1
+    fi
+    for valid_profile in "${VALID_PROFILES[@]}"; do
+        if [ "$profile" = "$valid_profile" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Get description for a profile
+get_profile_description() {
+    local profile="$1"
+    if [ -z "${PROFILE_DESCRIPTIONS[$profile]}" ]; then
+        echo "Unknown profile"
+        return 1
+    fi
+    echo "${PROFILE_DESCRIPTIONS[$profile]}"
+}
+
+# Get services for a profile
+get_profile_services() {
+    local profile="$1"
+    if [ -z "${PROFILE_SERVICES[$profile]}" ]; then
+        echo ""
+        return 1
+    fi
+    echo "${PROFILE_SERVICES[$profile]}"
+}
+
+# Get database storage enabled setting for a profile
+get_profile_db_storage_enabled() {
+    local profile="$1"
+    if [ -z "${PROFILE_DB_STORAGE[$profile]}" ]; then
+        echo "true"  # Default to true if profile not found
+        return 1
+    fi
+    echo "${PROFILE_DB_STORAGE[$profile]}"
+}
+
+# List all available profiles with descriptions
+list_profiles() {
+    echo ""
+    echo "Available profiles:"
+    echo "==================="
+    echo ""
+    for profile in "${VALID_PROFILES[@]}"; do
+        echo "  - $profile: $(get_profile_description "$profile")"
+    done
+    echo ""
+    echo "For detailed profile information, see: aixcl_governance/02_profiles.md"
+}
+
+# Print detailed information about a profile
+print_profile_info() {
+    local profile="$1"
+    
+    if ! is_valid_profile "$profile"; then
+        echo "Error: Invalid profile: $profile" >&2
+        return 1
+    fi
+    
+    echo ""
+    echo "Profile: $profile"
+    echo "=================="
+    echo "Description: $(get_profile_description "$profile")"
+    echo ""
+    echo "Services included:"
+    local services
+    services=($(get_profile_services "$profile"))
+    for service in "${services[@]}"; do
+        # Check if it's a runtime core service
+        local is_core=false
+        for core_service in "${RUNTIME_CORE_SERVICES[@]}"; do
+            if [ "$service" = "$core_service" ]; then
+                is_core=true
+                break
+            fi
+        done
+        
+        if [ "$is_core" = true ]; then
+            echo "  - $service (runtime core)"
+        else
+            echo "  - $service"
+        fi
+    done
+    echo ""
+    echo "Database storage: $(get_profile_db_storage_enabled "$profile")"
+    echo ""
+}
+


### PR DESCRIPTION
Fixes #220

## Problem
Running ./aixcl stack start -p core failed with error:


The code expected cli/lib/profile.sh to exist but the file was missing.

## Solution
Created cli/lib/profile.sh with complete profile management functionality:

- [x] Created cli/lib/ directory structure
- [x] Implemented is_valid_profile() function
- [x] Implemented list_profiles() function
- [x] Implemented get_profile_description() function
- [x] Implemented get_profile_services() function
- [x] Implemented get_profile_db_storage_enabled() function
- [x] Implemented print_profile_info() function
- [x] Defined VALID_PROFILES array (core, dev, ops, full)
- [x] Defined RUNTIME_CORE_SERVICES array (ollama, llm-council)
- [x] Mapped profile service lists based on aixcl_governance/02_profiles.md
- [x] Configured database storage settings per profile

## Testing
- Verified profile validation works correctly
- Verified get_profile_services() returns correct service lists
- Functions tested and working as expected
