### PR TITLE
fix: Handle missing CLI argument values gracefully (#230)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -440,12 +440,12 @@ function start() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --profile|-p)
-                if [[ -z "$2" ]]; then
+                # Check if argument exists before accessing it
+                if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
                     echo "❌ Error: Profile name is required after --profile" >&2
-                    echo "Usage: aixcl stack start [--profile <profile>]"
-                    echo ""
-                    echo "Available profiles:"
-                    list_profiles
+                    echo "Usage: aixcl stack start [--profile <profile>]" >&2
+                    echo "" >&2
+                    list_profiles >&2
                     exit 1
                 fi
                 profile="$2"

--- a/tests/platform-tests.sh
+++ b/tests/platform-tests.sh
@@ -1353,7 +1353,8 @@ main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --profile|-p)
-                if [[ -z "$2" ]]; then
+                # Check if argument exists before accessing it
+                if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
                     echo "Error: Profile name is required after --profile" >&2
                     echo "Usage: $0 --profile <core|dev|ops|full>" >&2
                     exit 1
@@ -1362,7 +1363,8 @@ main() {
                 shift 2
                 ;;
             --component|-c)
-                if [[ -z "$2" ]]; then
+                # Check if argument exists before accessing it
+                if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
                     echo "Error: Component name is required after --component" >&2
                     echo "Usage: $0 --component <runtime-core|database|monitoring|logging|ui|automation|api>" >&2
                     exit 1


### PR DESCRIPTION
Fixes #230

## Problem
When running CLI commands with incomplete arguments, the script exposed shell errors about unbound variables.

## Solution
Fixed argument parsing to check if enough arguments exist before accessing them, providing user-friendly error messages instead of shell errors.

## Changes
- [x] Fixed aixcl stack start --profile/-p argument parsing
- [x] Fixed tests/platform-tests.sh --profile argument parsing
- [x] Fixed tests/platform-tests.sh --component argument parsing
- [x] Removed duplicate header in error output
