### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/llm-council/backend/main.py
+++ b/llm-council/backend/main.py
@@ -741,7 +741,9 @@ Please provide a helpful response based on the context provided above."""
                     yield f"data: {json.dumps(final_chunk)}\n\n"
                     yield "data: [DONE]\n\n"
                 except Exception as stream_error:
-                    # Send error in OpenAI streaming format
+                    # Log full error details server-side, including stack trace
+                    logging.error("Error in streaming response", exc_info=True)
+                    # Send sanitized error in OpenAI streaming format (no internal details)
                     error_chunk = {
                         "id": response_id,
                         "object": "chat.completion.chunk",
@@ -753,14 +755,14 @@ Please provide a helpful response based on the context provided above."""
                             "finish_reason": None
                         }],
                         "error": {
-                            "message": str(stream_error),
+                            "message": "An internal streaming error occurred.",
                             "type": "internal_error",
                             "code": "stream_error"
                         }
                     }
                     yield f"data: {json.dumps(error_chunk)}\n\n"
                     yield "data: [DONE]\n\n"
-                    print(f"DEBUG: Error in stream: {stream_error}", flush=True)
+                    print("DEBUG: Error in stream (details logged server-side)", flush=True)
             
             return StreamingResponse(
                 generate_stream(),


### PR DESCRIPTION
Potential fix for [https://github.com/xencon/aixcl/security/code-scanning/6](https://github.com/xencon/aixcl/security/code-scanning/6)

In general, the fix is to avoid sending raw exception details back to the client. Instead, log the detailed error (including stack trace) on the server side and send a generic, non-sensitive error message in the streamed response. This preserves observability for developers while preventing attackers from learning about internal structure or error conditions.

For this specific code, we should modify the `except Exception as stream_error:` block in `generate_stream()` (around lines 743–763). Currently it builds `error_chunk` using `str(stream_error)` for `"message"`. We will:

1. Replace the client-facing `"message"` with a generic string like `"An internal streaming error occurred."` that does not reflect internal details.
2. Log the detailed error server-side, including a stack trace, using the existing `traceback` and `logging` imports, e.g. `logging.error("...", exc_info=True)` or `traceback.format_exc()`.
3. Optionally, include a minimal, non-sensitive `code` such as `"stream_error"` (as already present) so clients can programmatically react, without leaking internals.

We will only adjust the contents of `error_chunk` and add server-side logging inside this `except` block, keeping the streaming protocol, IDs, and structure unchanged, to avoid breaking existing client behavior apart from the now-generic message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
