### PR TITLE
Fix: Grafana container logs dashboard not displaying logs (#241)

### DIFF
--- a/grafana/provisioning/dashboards/logs-dashboard.json
+++ b/grafana/provisioning/dashboards/logs-dashboard.json
@@ -51,7 +51,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "{compose_project=\"aixcl\", compose_service=~\"$service\"} |~ \"(?i)$search\"",
+          "expr": "{compose_project=\"services\", compose_service=~\"$service\"} |~ \"(?i)$search\"",
           "queryType": "range",
           "refId": "A"
         }
@@ -140,7 +140,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum by (compose_service) (count_over_time({compose_project=\"aixcl\"}[$__interval]))",
+          "expr": "sum by (compose_service) (count_over_time({compose_project=\"services\"}[$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -208,7 +208,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({compose_project=\"aixcl\"}[$__range]))",
+          "expr": "sum(count_over_time({compose_project=\"services\"}[$__range]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -268,7 +268,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "count(count by (compose_service) (count_over_time({compose_project=\"aixcl\"}[1m])))",
+          "expr": "count(count by (compose_service) (count_over_time({compose_project=\"services\"}[1m])))",
           "queryType": "range",
           "refId": "A"
         }
@@ -337,7 +337,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum by (compose_service) (count_over_time({compose_project=\"aixcl\"}[$__range]))",
+          "expr": "sum by (compose_service) (count_over_time({compose_project=\"services\"}[$__range]))",
           "queryType": "range",
           "refId": "A"
         }

--- a/promtail/promtail-config.yml
+++ b/promtail/promtail-config.yml
@@ -19,7 +19,7 @@ scrape_configs:
         refresh_interval: 5s
         filters:
           - name: label
-            values: ["com.docker.compose.project=aixcl"]
+            values: ["com.docker.compose.project=services"]
     
     relabel_configs:
       # Container name


### PR DESCRIPTION
Fixes #241

## Changes
- [x] Updated Promtail configuration to filter for com.docker.compose.project=services
- [x] Updated all dashboard queries to use compose_project=services instead of aixcl

## Testing
- Verified Promtail now discovers Docker containers
- Confirmed Loki API shows compose_project and compose_service labels are available
- Dashboard should now display container logs correctly