### PR TITLE
fix: Update ContainerHighMemory alert to handle containers without memory limits (#243)

### DIFF
--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -145,7 +145,15 @@ groups:
           description: "Container {{ $labels.name }} CPU usage is above 80% for more than 5 minutes. Current usage: {{ $value }}%"
 
       - alert: ContainerHighMemory
-        expr: (container_memory_usage_bytes{name=~"ollama|open-webui|postgres|pgadmin"} / container_spec_memory_limit_bytes{name=~"ollama|open-webui|postgres|pgadmin"}) * 100 > 80
+        expr: |
+          (
+            container_memory_usage_bytes{name=~"ollama|open-webui|postgres|pgadmin"}
+            /
+            container_spec_memory_limit_bytes{name=~"ollama|open-webui|postgres|pgadmin"}
+            * 100 > 80
+          )
+          and
+          (container_spec_memory_limit_bytes{name=~"ollama|open-webui|postgres|pgadmin"} > 0)
         for: 5m
         labels:
           severity: warning

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -154,6 +154,7 @@ services:
     container_name: prometheus
     volumes:
       - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'


### PR DESCRIPTION
Fixes #243

## Changes

- [x] Update ContainerHighMemory alert query to only evaluate containers with memory limits set
- [x] Add condition to prevent false positives from containers with unlimited memory
- [x] Update docker-compose.yml to mount alerts.yml file in Prometheus container
- [x] Fix +Inf% memory usage calculations

## Problem

The ContainerHighMemory alert was firing false positives for containers without memory limits configured. When containers have unlimited memory, the calculation memory_usage / memory_limit * 100 results in division by zero, producing +Inf% values.

## Solution

Updated the alert query to include a condition that only evaluates containers where container_spec_memory_limit_bytes > 0. This ensures:
- Only containers with memory limits are monitored
- No false positives from unlimited memory containers
- Accurate memory usage percentage calculations

## Testing

- Verified alert rules load correctly in Prometheus
- Confirmed ContainerHighMemory alerts are resolved
- All 17 alert rules are evaluating correctly
- Prometheus configuration reloaded successfully