### PR TITLE
Fix: stack restart command does not accept profile arguments (#252)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -747,7 +747,7 @@ function restart() {
     echo "Restarting services..."
     stop
     sleep 5
-    start
+    start "$@"
 }
 
 function start_service() {
@@ -2676,7 +2676,7 @@ function stack_cmd() {
             stop
             ;;
         restart)
-            restart
+            restart "$@"
             ;;
         status)
             status


### PR DESCRIPTION
Fixes #252

## Changes
- [x] Updated restart function to accept arguments via "$@"
- [x] Updated restart function to pass arguments to start function
- [x] Updated stack_cmd to pass arguments to restart function

## Problem
The `stack restart` command did not accept profile arguments like `-p sys` or `--profile sys`. When users ran `./aixcl stack restart -p sys`, the command would stop services but then show the profile selection menu instead of restarting with the specified profile.

## Solution
Modified the `restart` function to accept and forward all arguments to the `start` function, and updated the call site in `stack_cmd` to pass arguments through. Now the restart command works identically to the start command in terms of profile argument handling.

## Testing
- [x] Verified restart function signature accepts arguments
- [x] Verified arguments are passed to start function
- [x] Verified stack_cmd passes arguments to restart
