### PR TITLE
Fix: Admin database reappearing in PostgreSQL (#262)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -440,6 +440,18 @@ function ensure_databases() {
     else
         echo "Continue database already exists: $continue_db"
     fi
+    
+    # Remove unwanted "admin" database if it exists and is not the intended database
+    # PostgreSQL may create an "admin" database when POSTGRES_USER=admin but POSTGRES_DATABASE is not set
+    if [ "$webui_db" != "admin" ] && [ "$continue_db" != "admin" ]; then
+        local admin_exists=$(docker exec postgres psql -U "$pg_user" -lqt 2>/dev/null | cut -d \| -f 1 | grep -w "admin" | wc -l)
+        admin_exists=${admin_exists:-0}
+        if [ "$admin_exists" -eq 1 ]; then
+            echo "Removing unwanted admin database..."
+            docker exec postgres psql -U "$pg_user" -d postgres -c "DROP DATABASE IF EXISTS \"admin\";" >/dev/null 2>&1 || true
+            echo "   Admin database removed (only webui and continue databases should exist)"
+        fi
+    fi
 }
 
 function generate_pgadmin_config() {

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -55,9 +55,9 @@ services:
     image: postgres:17.2
     container_name: postgres
     environment:
-      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-      POSTGRES_DATABASE: $POSTGRES_DATABASE
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-webui}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     network_mode: host


### PR DESCRIPTION
Fixes #262

## Changes
- [x] Set default value for POSTGRES_DATABASE in docker-compose.yml to prevent admin database creation
- [x] Added cleanup logic as safety measure in ensure_databases() function
- [x] Updated create_databases.sh script for consistency

## Problem
PostgreSQL creates an admin database when POSTGRES_USER=admin but POSTGRES_DATABASE is not set or is empty. This happens because PostgreSQL defaults to creating a database with the same name as POSTGRES_USER when POSTGRES_DATABASE is unset.

## Solution
Primary Fix: Set default value for POSTGRES_DATABASE in docker-compose.yml using default value syntax. This ensures POSTGRES_DATABASE is always set to webui if not provided, preventing PostgreSQL from creating the unwanted admin database.

Safety Measure: Added cleanup logic that checks if the admin database exists and drops it if it is not the intended database. This provides defense-in-depth for existing installations where the admin database may already exist.

This ensures only the required databases (webui, continue, and postgres) exist.