### PR TITLE
Update Open WebUI to v0.6.43 (#264)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       start_period: 30s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.6.41
+    image: ghcr.io/open-webui/open-webui:v0.6.43
     container_name: open-webui
     pull_policy: always
     volumes:


### PR DESCRIPTION
Fixes #264

## Changes
- [x] Updated Open WebUI image from v0.6.41 to v0.6.43

## Release Notes
Version v0.6.43 includes the following fixes:
- Python dependency installation issues resolved
- Speech-to-Text default content type handling fixed
- Temporary chat image handling fixed
- Image action button restored

Reference: https://github.com/open-webui/open-webui/releases/tag/v0.6.43