### PR TITLE
docs: Fix misclassification of GitHub issue types vs labels (#274)

### DIFF
--- a/DEVELOPMENT_WORKFLOW.md
+++ b/DEVELOPMENT_WORKFLOW.md
@@ -23,7 +23,9 @@ We follow an **Issue-First Development** workflow:
 
 **Using GitHub CLI:**
 ```bash
-gh issue create --title "Brief description" --body "Detailed description of the problem or feature" --label "type:bug,component:cli"
+# Note: GitHub CLI doesn't support setting issue type directly
+# Set the type in GitHub UI, then add labels:
+gh issue create --title "Brief description" --body "Detailed description of the problem or feature" --label "component:cli"
 ```
 
 **Best Practices:**
@@ -108,24 +110,23 @@ Fixes #217
 
 ## Label Guidelines
 
-**Labels are required for all issues.** Labels help organize issues, track work, and make it easier to find related issues.
+**GitHub Issue Types and Labels are required for all issues.** GitHub has native issue types that are separate from labels. Both help organize issues, track work, and make it easier to find related issues.
+
+### GitHub Issue Types (Required - Select One)
+
+GitHub provides native issue types that must be set for each issue. These are separate from labels:
+
+- **Bug** - An unexpected problem or behavior
+- **Feature** - A request, idea, or new functionality
+- **Task** - A specific piece of work
+
+**Note:** You cannot create custom issue types in GitHub. Use labels for additional categorization (see below).
 
 ### Label Categories
 
 Labels are organized into categories using prefixes:
 
-#### Type Labels (Required - Select One)
-
-These labels should be created in GitHub's label sections if they don't exist. These correspond to GitHub's issue types:
-
-- `Bug` - An unexpected problem or behavior (GitHub issue type)
-- `Feature` - A request, idea, or new functionality (GitHub issue type)
-- `Task` - A specific piece of work (GitHub issue type)
-- `Fix` - A fix for a bug or issue (custom issue type)
-- `Enhancement` - Improvement to existing functionality
-- `Refactor` - Code refactoring without changing functionality
-- `Maintenance` - Maintenance tasks and housekeeping
-- `documentation` - Improvements or additions to documentation (GitHub default)
+#### Component Labels (Select All That Apply)
 
 #### Component Labels (Select All That Apply)
 - `component:runtime-core` - Runtime core services (Ollama, LLM-Council, Continue)
@@ -149,6 +150,13 @@ These labels should be created in GitHub's label sections if they don't exist. T
 - `profile:ops` - Affects ops profile (observability-focused)
 - `profile:sys` - Affects sys profile (full deployment)
 
+#### Category Labels (Select All That Apply)
+- `Fix` - A fix for a bug or issue (use with Bug or Task type)
+- `Enhancement` - Improvement to existing functionality (use with Feature or Task type)
+- `Refactor` - Code refactoring without changing functionality (use with Task type)
+- `Maintenance` - Maintenance tasks and housekeeping (use with Task type)
+- `documentation` - Improvements or additions to documentation (GitHub default)
+
 #### Other Labels
 - `dependencies` - Dependency updates and management
 - `good first issue` - Good for newcomers
@@ -159,28 +167,31 @@ These labels should be created in GitHub's label sections if they don't exist. T
 
 **When creating an issue:**
 ```bash
-# Add labels during creation
-gh issue create --title "Title" --body "Description" --label "Bug,component:cli,priority:high"
+# Add labels during creation (set issue type in GitHub UI)
+gh issue create --title "Title" --body "Description" --label "component:cli,priority:high"
 
 # Or add labels after creation
-gh issue edit <number> --add-label "Bug,component:cli"
+gh issue edit <number> --add-label "component:cli"
 ```
 
-**Label Selection Guidelines:**
-1. **Always select one type label** - This categorizes the issue
+**Note:** GitHub CLI doesn't support setting the issue type (Bug/Feature/Task) directly. Set the type in the GitHub web interface, then use CLI for labels.
+
+**Issue Type and Label Selection Guidelines:**
+1. **Always select one GitHub issue type** - Bug, Feature, or Task (set via GitHub's Type field)
 2. **Select relevant component labels** - Helps identify which part of the system is affected
-3. **Select priority if applicable** - Helps prioritize work
-4. **Select profile labels if issue is profile-specific** - Helps identify deployment impact
-5. **Use other labels as appropriate** - `good first issue`, `help wanted`, etc.
+3. **Select category labels if applicable** - Fix, Enhancement, Refactor, Maintenance for additional context
+4. **Select priority if applicable** - Helps prioritize work
+5. **Select profile labels if issue is profile-specific** - Helps identify deployment impact
+6. **Use other labels as appropriate** - `good first issue`, `help wanted`, etc.
 
 **Examples:**
-- Bug in CLI: `Bug,component:cli`
-- New feature for observability: `Feature,component:observability`
-- Fix for database issue: `Fix,component:persistence`
-- Task for infrastructure: `Task,component:infrastructure`
-- Enhancement affecting all profiles: `Enhancement,profile:usr,profile:dev,profile:ops,profile:sys`
-- High priority bug: `Bug,component:runtime-core,priority:high`
-- Dependency update: `dependencies,Maintenance`
+- Bug in CLI: Type: **Bug**, Labels: `component:cli`
+- New feature for observability: Type: **Feature**, Labels: `component:observability`
+- Fix for database issue: Type: **Bug**, Labels: `Fix,component:persistence`
+- Task for infrastructure: Type: **Task**, Labels: `component:infrastructure`
+- Enhancement affecting all profiles: Type: **Feature**, Labels: `Enhancement,profile:usr,profile:dev,profile:ops,profile:sys`
+- High priority bug: Type: **Bug**, Labels: `component:runtime-core,priority:high`
+- Dependency update: Type: **Task**, Labels: `dependencies,Maintenance`
 
 ### Checking Available Labels
 
@@ -225,11 +236,11 @@ Follow the development workflow documented in DEVELOPMENT_WORKFLOW.md:
 ## Quick Reference Commands
 
 ```bash
-# Create issue with labels
-gh issue create --title "Title" --body "Description" --label "Bug,component:cli,priority:high"
+# Create issue with labels (set issue type in GitHub UI)
+gh issue create --title "Title" --body "Description" --label "component:cli,priority:high"
 
 # Or add labels after creation
-gh issue edit <number> --add-label "Bug,component:cli"
+gh issue edit <number> --add-label "component:cli"
 
 # Create branch
 git checkout -b issue-<number>/<description>


### PR DESCRIPTION
Fixes #274

## Changes
- [x] Clarified distinction between GitHub native issue types (Bug, Feature, Task) and labels
- [x] Moved Fix, Enhancement, Refactor, Maintenance to Category Labels section
- [x] Updated examples to show proper usage: set type in GitHub UI, use labels for categorization
- [x] Updated Quick Reference to note that GitHub CLI cannot set issue types directly

## Summary
GitHub has native issue types (Bug, Feature, Task) that are separate from labels. Issues should have one GitHub issue type set via the Type field in GitHub UI, and then use labels for additional categorization (component:, priority:, profile:, Fix, Enhancement, etc.).