### PR TITLE
Fix LLM-Council permission errors preventing service startup (#281)

### DIFF
--- a/llm-council/Dockerfile
+++ b/llm-council/Dockerfile
@@ -25,12 +25,18 @@ WORKDIR /app
 # Copy project files
 COPY . /app
 
-# Install Python dependencies using uv
-RUN uv sync
-
 # Create a non-root user for runtime security
-RUN groupadd -r appuser && useradd -r -g appuser appuser && \
-    chown -R appuser:appuser /app
+# Create home directory and cache directory for uv
+# Do this before installing dependencies so venv is owned by appuser
+RUN groupadd -r appuser && \
+    useradd -r -g appuser -m -d /home/appuser appuser && \
+    mkdir -p /home/appuser/.cache/uv && \
+    chown -R appuser:appuser /app /home/appuser
+
+# Install Python dependencies using uv as appuser
+# This ensures .venv is created with correct ownership
+USER appuser
+RUN uv sync
 
 # Expose API port
 EXPOSE 8000


### PR DESCRIPTION
Fixes #281

## Changes
- [x] Create home directory for appuser with -m flag
- [x] Create cache directory /home/appuser/.cache/uv with proper permissions
- [x] Install Python dependencies as appuser to ensure .venv has correct ownership
- [x] Fix permission denied errors when uv tries to create cache directory
- [x] Fix permission denied errors when accessing .venv/bin/python3

## Problem
LLM-Council container was failing to start due to permission errors:
- `error: failed to create directory '/home/appuser/.cache/uv': Permission denied`
- `error: Failed to query Python interpreter: Permission denied` for `/app/.venv/bin/python3`

## Solution
1. Create user with home directory using `useradd -m -d /home/appuser`
2. Pre-create cache directory `/home/appuser/.cache/uv` with proper ownership
3. Install dependencies as appuser so `.venv` is owned by appuser
4. Ensure all directories have correct ownership before switching to appuser

## Testing
- Verified LLM-Council starts successfully
- Verified health endpoint responds: `{"status":"healthy","service":"LLM Council API"}`
- Verified stack status shows: `✅ LLM-Council (Healthy)`
- No more permission errors in container logs
