### PR TITLE
Simplify LLM Council test messages for shorter responses (#285)

### DIFF
--- a/llm-council/scripts/test/test_continue_integration.py
+++ b/llm-council/scripts/test/test_continue_integration.py
@@ -445,7 +445,7 @@ async def test_continue_integration():
     test_messages = [
         {
             "role": "user",
-            "content": "Hello! This is a test message from the Continue plugin integration test. Can you tell me what 2+2 equals?"
+            "content": "What does `2+2` equal?"
         }
     ]
     
@@ -551,7 +551,7 @@ async def test_continue_integration():
         },
         {
             "role": "user",
-            "content": "What about 3+3?"
+            "content": "What's `len('abc')`?"
         }
     ]
     


### PR DESCRIPTION
Fixes #285

## Changes
- [x] Changed first test message from verbose greeting to simple code question
- [x] Changed follow-up message to code-based question
- [x] Questions now elicit concise, code-focused responses

## Testing
- Verified test workflow executes successfully
- Confirmed responses are shorter and code-focused