### PR TITLE
Remove Healthy/Unhealthy text labels from service status output (#289)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1503,10 +1503,10 @@ function status() {
             esac
             
             if [ "$health_result" = "200" ] || [ "$health_result" = "302" ] || [ "$health_result" = "307" ] || [ "$health_result" = "healthy" ]; then
-                health_status=" (Healthy)"
+                health_status=""
                 is_healthy=true
             else
-                health_status=" (Unhealthy)"
+                health_status=""
                 if [ "$is_critical" = "true" ]; then
                     echo "    Checking ${service_name} logs (last 3 lines):"
                     timeout 2 docker logs "${container_name}" --tail 3 2>/dev/null || echo "    (Logs unavailable or timeout)"
@@ -1602,14 +1602,14 @@ function status() {
     if docker ps --format "{{.Names}}" | grep -q "^loki$"; then
         LOKI_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3100/ready 2>/dev/null || echo "000")
         if [ "$LOKI_STATUS" = "200" ]; then
-            echo "  ✅ Loki (Healthy)"
+            echo "  ✅ Loki"
             ((operational_total++)) || true
             ((operational_healthy++)) || true
         elif [ "$LOKI_STATUS" = "503" ]; then
             echo "  ⚠️  Loki (starting up)"
             ((operational_total++)) || true
         else
-            echo "  ❌ Loki (Unhealthy)"
+            echo "  ❌ Loki"
             echo "    Checking Loki logs (last 3 lines):"
             timeout 2 docker logs loki --tail 3 2>/dev/null || echo "    (Logs unavailable or timeout)"
             ((operational_total++)) || true
@@ -1621,11 +1621,11 @@ function status() {
 
     if docker ps --format "{{.Names}}" | grep -q "^promtail$"; then
         if docker exec promtail wget --no-verbose --tries=1 --spider http://localhost:9080/ready 2>/dev/null; then
-            echo "  ✅ Promtail (Healthy)"
+            echo "  ✅ Promtail"
             ((operational_total++)) || true
             ((operational_healthy++)) || true
         else
-            echo "  ❌ Promtail (Unhealthy)"
+            echo "  ❌ Promtail"
             ((operational_total++)) || true
         fi
     else

--- a/aixcl_governance/03_stack_status.md
+++ b/aixcl_governance/03_stack_status.md
@@ -22,15 +22,15 @@ Status: Running
 
 Runtime Core (Strict - Always Enabled)
 ---------------------------------------
-✅ ollama          Running    Healthy (API responding)
-✅ llm-council     Running    Healthy (API responding)
+✅ ollama          Running
+✅ llm-council     Running
 ✅ continue        Active     Connected (VS Code plugin)
 
 Operational Services (Guided - Profile-Dependent)
 --------------------------------------------------
-✅ postgres        Running    Healthy (database ready)
-✅ open-webui      Running    Healthy (web UI accessible)
-✅ pgadmin         Running    Healthy (admin UI accessible)
+✅ postgres        Running
+✅ open-webui      Running
+✅ pgadmin         Running
 ⏸  prometheus      Stopped    (not in 'dev' profile)
 ⏸  grafana         Stopped    (not in 'dev' profile)
 ⏸  watchtower      Stopped    (not in 'dev' profile)
@@ -46,19 +46,19 @@ Overall:      ✅ All critical services healthy
 
 ### Runtime Core Health
 - **Critical**: All runtime core services must be healthy for AIXCL to function
+- **Status indicators**: ✅ (running and healthy), ❌ (stopped or unhealthy)
 - **Status meanings**:
-  - `Healthy`: Service is running and API/interface is responding
-  - `Degraded`: Service is running but experiencing issues
-  - `Unhealthy`: Service is not responding or has failed
-  - `Stopped`: Service is not running (should never happen for runtime core)
+  - ✅: Service is running and API/interface is responding
+  - ❌: Service is not running or not responding
+  - ⚠️: Service is starting up or experiencing issues
 
 ### Operational Services Health
 - **Informational**: Operational services support but do not define the product
+- **Status indicators**: ✅ (running and healthy), ❌ (stopped or unhealthy)
 - **Status meanings**:
-  - `Healthy`: Service is running and functioning normally
-  - `Degraded`: Service is running but experiencing issues
-  - `Unhealthy`: Service is not responding or has failed
-  - `Stopped`: Service is not running (may be expected if not in active profile)
+  - ✅: Service is running and functioning normally
+  - ❌: Service is not running or not responding
+  - ⚠️: Service is starting up or experiencing issues
 
 ## Profile-Specific Status
 


### PR DESCRIPTION
Fixes #289

## Changes
- [x] Removed (Healthy) and (Unhealthy) text labels from service status output
- [x] Updated status output to show only visual indicators (checkmarks and crosses)
- [x] Updated documentation to reflect status indicator changes

## Testing
- Verified status output displays correctly with only visual indicators
- Confirmed health checks still function internally
- Updated documentation examples