### PR TITLE
Add benchmarking metrics to performance tests (#313)

### DIFF
--- a/tests/runtime-core/run_test.sh
+++ b/tests/runtime-core/run_test.sh
@@ -1,14 +1,59 @@
 #!/bin/bash
-# Wrapper script to run performance test with automatic venv setup
+# Main entry point for running performance tests with benchmarking metrics
+# This script handles venv setup and passes all arguments to the Python test script
+
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$SCRIPT_DIR/.venv"
 TEST_SCRIPT="$SCRIPT_DIR/test_council_performance.py"
 
+# Store all arguments to pass to Python script
+ARGS=("$@")
+
+# Function to show usage
+show_usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Run performance tests for Ollama optimizations with benchmarking metrics.
+
+Options:
+    --warmup              Warm up models before benchmarking (recommended)
+    --csv [FILE]          Export results to CSV file
+                          If FILE is not specified, uses default: benchmark_YYYYMMDD_HHMMSS.csv
+    --no-warmup           Explicitly disable warmup (default behavior)
+    -h, --help            Show this help message
+
+Examples:
+    # Basic test (backward compatible)
+    $0
+    
+    # With warmup
+    $0 --warmup
+    
+    # Export to CSV
+    $0 --csv benchmark.csv
+    
+    # Both warmup and CSV export
+    $0 --warmup --csv benchmark.csv
+    
+    # CSV with default filename
+    $0 --csv
+
+EOF
+}
+
+# Check for help flag
+if [[ " ${ARGS[@]} " =~ " --help " ]] || [[ " ${ARGS[@]} " =~ " -h " ]]; then
+    show_usage
+    exit 0
+fi
+
 # Check if httpx is available
 if python3 -c "import httpx" 2>/dev/null; then
     echo "httpx is available - running test directly"
-    python3 "$TEST_SCRIPT"
+    python3 "$TEST_SCRIPT" "${ARGS[@]}"
     exit $?
 fi
 
@@ -28,12 +73,12 @@ source "$VENV_DIR/bin/activate"
 # Install httpx if not installed
 if ! python -c "import httpx" 2>/dev/null; then
     echo "Installing httpx..."
-    pip install httpx
+    pip install httpx --quiet
 fi
 
-# Run test
+# Run test with all arguments
 echo "Running performance test..."
-python "$TEST_SCRIPT"
+python "$TEST_SCRIPT" "${ARGS[@]}"
 
 # Exit code from test
 exit $?


### PR DESCRIPTION
Fixes #313

## Changes
- [x] Extract token metrics (prompt_tokens, completion_tokens, total_tokens, tokens_per_second) from API responses
- [x] Add model information retrieval (quantization, context size) from Ollama API
- [x] Add warmup functionality to pre-load models before benchmarking
- [x] Enhance output display with token performance metrics and model information
- [x] Add CSV export functionality with all benchmark metrics
- [x] Add command-line arguments (--warmup, --csv) using argparse
- [x] Update run_test.sh to be main entry point with argument passthrough
- [x] Update documentation with benchmarking features and usage examples

## Testing
- Verified warmup functionality works correctly
- Confirmed CSV export includes all metrics
- Tested backward compatibility (works without arguments)
- Verified token metrics are extracted from both streaming and non-streaming responses