### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/runtime-core/check_models.py
+++ b/tests/runtime-core/check_models.py
@@ -6,7 +6,6 @@ Quick diagnostic script to check if council models are available in Ollama.
 import os
 import sys
 import subprocess
-import json
 
 # Get models from environment
 # Read from CHAIRMAN_MODEL and COUNCIL_MODELS environment variables


### PR DESCRIPTION
To fix the problem, we should remove the unused `json` import from the top of `tests/runtime-core/check_models.py`. In general, unused imports should be deleted to keep the code clean and avoid linter/CodeQL warnings. The best minimal fix here is to delete the single line `import json` while leaving all other imports and logic intact.

Concretely, in `tests/runtime-core/check_models.py`, at the import section near the top, remove line 9 that reads `import json`. No additional methods, imports, or definitions are needed, since nothing in the shown code relies on the `json` module. This will resolve the CodeQL finding without altering existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._