### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/api/test_continue_integration.py
+++ b/tests/api/test_continue_integration.py
@@ -26,7 +26,6 @@ import asyncio
 import sys
 import os
 import json
-import uuid
 from typing import Dict, Any, Optional
 from datetime import datetime
 


### PR DESCRIPTION
In general, to fix an "import is not used" issue, you either remove the unused import or start using it meaningfully in the code if it was intended to be used. Since we must avoid changing existing functionality and there is no visible use of `uuid`, the safest and cleanest solution is to remove the `import uuid` line.

Concretely, in `tests/api/test_continue_integration.py`, delete line 29 containing `import uuid`, leaving the rest of the imports unchanged. No additional imports, methods, or definitions are required. This will eliminate the unused import and have no impact on runtime behavior, assuming `uuid` is not referenced elsewhere in the file (as suggested by CodeQL).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._