### PR TITLE
Fix for Unused import

### DIFF
--- a/llm-council/backend/main.py
+++ b/llm-council/backend/main.py
@@ -18,7 +18,7 @@ import logging
 from . import storage
 from . import db
 from . import db_storage
-from .conversation_tracker import generate_conversation_id, extract_conversation_context
+from .conversation_tracker import generate_conversation_id
 from .council import run_full_council, generate_conversation_title, stage1_collect_responses, stage2_collect_rankings, stage3_synthesize_final, calculate_aggregate_rankings
 from .config import BACKEND_MODE, OLLAMA_BASE_URL, FORCE_STREAMING, ENABLE_MARKDOWN_FORMATTING, ENABLE_DB_STORAGE
 from .config_manager import get_config, update_config, reload_config, validate_ollama_models


### PR DESCRIPTION
In general, the way to fix “import is not required as it is not used” issues is to remove the unused symbol from the import statement (or remove the entire import if none of its symbols are used). This keeps the code clean and slightly reduces import time and namespace clutter, without affecting behavior.

For this specific case in `llm-council/backend/main.py`, the best minimal change is to modify the import on line 21 so that it only imports `generate_conversation_id` from `.conversation_tracker` and no longer imports `extract_conversation_context`. No other code changes are necessary if `extract_conversation_context` is indeed unused in this file. We do not change other imports or any logic to preserve existing functionality.

Concretely:
- Edit `llm-council/backend/main.py`.
- Locate the line:
 - `from .conversation_tracker import generate_conversation_id, extract_conversation_context`
- Replace it with:
 - `from .conversation_tracker import generate_conversation_id`

No new methods, imports, or definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
