### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/runtime-core/test_council_performance.py
+++ b/tests/runtime-core/test_council_performance.py
@@ -29,7 +29,6 @@ import asyncio
 import csv
 import httpx
 import json
-import os
 import sys
 import time
 from typing import Dict, Optional, List, Any


### PR DESCRIPTION
To fix an unused-import problem, remove the import statement if the module is not referenced anywhere in the file. This reduces clutter and avoids misleading readers into thinking `os` plays a role in the script.

Concretely, in `tests/runtime-core/test_council_performance.py`, delete the line `import os` at line 32. No additional code changes, imports, or definitions are required as long as `os` is not actually referenced elsewhere in the file. Since we may only modify shown code, the fix will consist solely of removing that single import line from the visible import block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._