### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/database/test_db_connection.py
+++ b/tests/database/test_db_connection.py
@@ -45,7 +45,7 @@ if backend_dir not in sys.path:
 
 from backend import db
 from backend import db_storage
-from backend.conversation_tracker import generate_conversation_id, create_message_entry
+from backend.conversation_tracker import generate_conversation_id
 
 
 async def test_database_connection():


### PR DESCRIPTION
In general, the correct fix for an "import is not required as it is not used" warning is to either (1) remove the unused imported name, or (2) start using it if it was intended to be used. Since the test code uses only `generate_conversation_id` and never refers to `create_message_entry`, the best fix is to adjust the import statement to only import the actually used symbol.

Concretely, in `tests/database/test_db_connection.py`, modify the import at line 48 so that it imports only `generate_conversation_id` from `backend.conversation_tracker` and drops `create_message_entry`. No other changes are needed in this file because `create_message_entry` is not referenced elsewhere, and the rest of the imports are used. This preserves existing behavior while eliminating the unused import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._