### PR TITLE
Fix for Unused local variable

### DIFF
--- a/llm-council/backend/main.py
+++ b/llm-council/backend/main.py
@@ -512,7 +512,6 @@ async def chat_completions(request: ChatCompletionRequest):
         
         # Handle conversation tracking and database storage
         conversation_id = None
-        is_new_conversation = False
         
         if ENABLE_DB_STORAGE:
             # Generate or find conversation ID
@@ -534,7 +533,6 @@ async def chat_completions(request: ChatCompletionRequest):
                     title = first_user_msg[:50] + "..." if len(first_user_msg) > 50 else first_user_msg
                     created_conv = await db_storage.create_continue_conversation(conversation_id, first_user_msg, title)
                     if created_conv:
-                        is_new_conversation = True
                         print(f"DEBUG: Created new conversation {conversation_id}", flush=True)
                     else:
                         logging.warning(f"Failed to create conversation {conversation_id} in database")


### PR DESCRIPTION
In general, to fix a “local variable defined but not used” issue, you either (a) remove the variable and any writes to it if they are not needed, or (b) add meaningful uses of the variable if its value is actually important. Here, there is no later use of `is_new_conversation`, and introducing a new usage solely to silence the warning would add unnecessary complexity and behavior. The cleanest fix is to remove the unused variable entirely.

Concretely, in `llm-council/backend/main.py` in the shown handler, remove the initialization `is_new_conversation = False` at line 515, and remove the assignment `is_new_conversation = True` at line 537. No other code relies on this variable, and these deletions do not change functionality: conversation creation, logging, and error handling all operate independently of `is_new_conversation`. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._