### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/api/test_continue_integration.py
+++ b/tests/api/test_continue_integration.py
@@ -27,7 +27,6 @@ import sys
 import os
 import json
 from typing import Dict, Any, Optional
-from datetime import datetime
 
 # Add backend to path
 # Script is now in tests/api/, need to find llm-council directory


### PR DESCRIPTION
To fix an unused-import issue, the general approach is to remove the import statement if the symbol is not referenced anywhere in the file. This keeps the code cleaner, avoids misleading readers into thinking `datetime` is used, and can slightly reduce startup time.

In this specific case, the best fix is to delete the line `from datetime import datetime` at line 30 in `tests/api/test_continue_integration.py`. No other code changes are required, because we are not altering any functionality—just removing an unused symbol. We do not need any new imports or definitions to replace it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._