### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/runtime-core/test_council_performance.py
+++ b/tests/runtime-core/test_council_performance.py
@@ -31,7 +31,7 @@ import httpx
 import json
 import sys
 import time
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, Any
 from datetime import datetime
 
 # API endpoints (as users would access them)


### PR DESCRIPTION
To fix the problem, we should remove the unused `List` symbol from the `typing` import, keeping only the types that are actually referenced in the file. This resolves the static analysis warning without affecting runtime behavior, since `typing.List` is only relevant for type hints.

Concretely, in `tests/runtime-core/test_council_performance.py`, update the import on line 34 from:

```py
from typing import Dict, Optional, List, Any
```

to:

```py
from typing import Dict, Optional, Any
```

No additional imports, methods, or definitions are needed. This is a minimal, non-functional change that solely cleans up an unused import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._