### PR TITLE
Fix basedpyright import resolution for python-dotenv (#338)

### DIFF
--- a/llm-council/pyproject.toml
+++ b/llm-council/pyproject.toml
@@ -12,3 +12,8 @@ dependencies = [
     "pydantic==2.12.4",
     "asyncpg==0.29.0",
 ]
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.10"


### PR DESCRIPTION
Fixes #338

## Changes

- [x] Add `[tool.pyright]` section to `llm-council/pyproject.toml` with venv configuration
- [x] Configure `venvPath` and `venv` to point to `llm-council/.venv`
- [x] Set `pythonVersion` to 3.10 to match `.python-version`

## Summary

This PR fixes the basedpyright import resolution warning for `python-dotenv` by configuring pyright to use the virtual environment where packages are installed.

## Testing

- Verified `python-dotenv` is installed: `uv pip list | grep dotenv` shows `python-dotenv 1.2.1`
- Configuration added to `pyproject.toml` following standard Python tool configuration practices
- After IDE reload, basedpyright should be able to resolve the import
