### PR TITLE
Add iterations support to performance benchmark (#342)

### DIFF
--- a/tests/runtime-core/README.md
+++ b/tests/runtime-core/README.md
@@ -30,6 +30,15 @@ User-focused performance test for Ollama optimizations. Simulates real user expe
 # Option 1: Use wrapper script (recommended - auto-setup)
 ./tests/runtime-core/run_test.sh
 
+# With warmup (recommended for accurate benchmarks)
+./tests/runtime-core/run_test.sh --warmup
+
+# Run multiple iterations and aggregate results
+./tests/runtime-core/run_test.sh --iterations 5
+
+# Warmup + multiple iterations
+./tests/runtime-core/run_test.sh --warmup --iterations 3
+
 # Option 2: Direct execution (requires httpx)
 python3 tests/runtime-core/test_council_performance.py
 
@@ -38,6 +47,12 @@ python3 tests/runtime-core/test_council_performance.py
 source tests/runtime-core/.venv/bin/activate
 python3 tests/runtime-core/test_council_performance.py
 ```
+
+**Command-Line Options:**
+- `--warmup`: Warm up models before benchmarking (recommended for accurate results)
+- `--no-warmup`: Explicitly disable warmup (default behavior)
+- `--iterations N`: Run benchmark N times and report mean values (default: 1)
+- `--help` or `-h`: Show help message
 
 See `test_council_performance_README.md` for detailed usage instructions.
 
@@ -56,7 +71,17 @@ Wrapper script that automatically sets up a virtual environment if needed and ru
 
 **Usage:**
 ```bash
+# Basic test
 ./tests/runtime-core/run_test.sh
+
+# With warmup (recommended)
+./tests/runtime-core/run_test.sh --warmup
+
+# Multiple iterations (aggregated results)
+./tests/runtime-core/run_test.sh --iterations 5
+
+# Show help
+./tests/runtime-core/run_test.sh --help
 ```
 
 ### `setup_test_env.sh`

--- a/tests/runtime-core/run_test.sh
+++ b/tests/runtime-core/run_test.sh
@@ -20,26 +20,22 @@ Run performance tests for Ollama optimizations with benchmarking metrics.
 
 Options:
     --warmup              Warm up models before benchmarking (recommended)
-    --csv [FILE]          Export results to CSV file
-                          If FILE is not specified, uses default: benchmark_YYYYMMDD_HHMMSS.csv
     --no-warmup           Explicitly disable warmup (default behavior)
+    --iterations N        Run benchmark N times and report mean values (default: 1)
     -h, --help            Show this help message
 
 Examples:
-    # Basic test (backward compatible)
+    # Basic test (single iteration)
     $0
     
-    # With warmup
+    # With warmup (recommended for accurate benchmarks)
     $0 --warmup
     
-    # Export to CSV
-    $0 --csv benchmark.csv
+    # Run 5 iterations and aggregate results
+    $0 --iterations 5
     
-    # Both warmup and CSV export
-    $0 --warmup --csv benchmark.csv
-    
-    # CSV with default filename
-    $0 --csv
+    # Warmup + multiple iterations
+    $0 --warmup --iterations 3
 
 EOF
 }

--- a/tests/runtime-core/test_council_performance.py
+++ b/tests/runtime-core/test_council_performance.py
@@ -20,18 +20,18 @@ Usage:
     # Option 3: Use wrapper script (auto-setup venv)
     ./tests/runtime-core/run_test.sh
     
-    # Option 4: With benchmarking features
-    python3 tests/runtime-core/test_council_performance.py --warmup --csv benchmark.csv
+    # Option 4: With warmup (recommended for accurate benchmarks)
+    python3 tests/runtime-core/test_council_performance.py --warmup
 """
 
 import argparse
 import asyncio
-import csv
 import httpx
 import json
+import os
 import sys
 import time
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, List, Any
 from datetime import datetime
 
 # API endpoints (as users would access them)
@@ -115,6 +115,10 @@ async def get_ollama_model_info(model_name: str) -> Dict[str, Any]:
     if model_name in _model_info_cache:
         return _model_info_cache[model_name]
     
+    # Try to extract quantization from model name first
+    quantization = _extract_quantization(model_name)
+    context_size = None
+    
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Try /api/show endpoint first (more detailed)
@@ -124,24 +128,99 @@ async def get_ollama_model_info(model_name: str) -> Dict[str, Any]:
             )
             if response.status_code == 200:
                 data = response.json()
+                import re
+                
+                # Extract context size from various possible locations
+                modelfile = data.get('modelfile', '')
+                
+                # First, try parsing modelfile as string (most common case)
+                if isinstance(modelfile, str):
+                    # Look for num_ctx in modelfile string
+                    # Pattern: "num_ctx 4096" or "PARAMETER num_ctx 4096"
+                    match = re.search(r'num_ctx\s+(\d+)', modelfile, re.IGNORECASE)
+                    if match:
+                        context_size = int(match.group(1))
+                    else:
+                        # Try alternative patterns
+                        match = re.search(r'PARAMETER\s+num_ctx\s+(\d+)', modelfile, re.IGNORECASE)
+                        if match:
+                            context_size = int(match.group(1))
+                
+                # If modelfile is a dict, try nested access
+                elif isinstance(modelfile, dict):
+                    parameters = modelfile.get('parameter', {})
+                    if isinstance(parameters, dict):
+                        context_size = parameters.get('num_ctx')
+                
+                # Try direct parameters field
+                if context_size is None:
+                    parameters = data.get('parameters', {})
+                    if isinstance(parameters, dict):
+                        context_size = parameters.get('num_ctx')
+                        if isinstance(context_size, dict):
+                            context_size = context_size.get('value')
+                
+                # Try details.parameters.num_ctx
+                if context_size is None:
+                    details = data.get('details', {})
+                    if isinstance(details, dict):
+                        params = details.get('parameters', {})
+                        if isinstance(params, dict):
+                            context_size = params.get('num_ctx')
+                
+                # Try top-level num_ctx
+                if context_size is None:
+                    context_size = data.get('num_ctx')
+                
+                # Try to get quantization from model details if not in name
+                if not quantization:
+                    # Check if quantization info is in model details
+                    model_details = data.get('details', {})
+                    if isinstance(model_details, dict):
+                        quantization = model_details.get('quantization_level') or model_details.get('format')
+                    
+                    # Also check modelfile for quantization info
+                    if not quantization and isinstance(modelfile, str):
+                        q_match = re.search(r'quantization[:\s]+([^\s]+)', modelfile, re.IGNORECASE)
+                        if q_match:
+                            quantization = q_match.group(1)
+                
+                # Debug: Print what we found (can be removed later)
+                # Uncomment to debug context_size extraction:
+                # if context_size is None:
+                #     print(f"DEBUG: Model {model_name} - modelfile type: {type(modelfile)}")
+                #     if isinstance(modelfile, str):
+                #         print(f"DEBUG: Modelfile preview: {modelfile[:500]}")
+                #     print(f"DEBUG: Data keys: {list(data.keys())}")
+                #     print(f"DEBUG: Parameters: {data.get('parameters')}")
+                #     print(f"DEBUG: Details: {data.get('details')}")
+                
                 info = {
                     'name': model_name,
-                    'quantization': _extract_quantization(model_name),
-                    'context_size': data.get('modelfile', {}).get('parameter', {}).get('num_ctx') if isinstance(data.get('modelfile'), dict) else None,
+                    'quantization': quantization,
+                    'context_size': context_size,
                     'details': data
                 }
                 _model_info_cache[model_name] = info
                 return info
-    except Exception:
+    except Exception as e:
         # Silently fall back to name-based extraction if API call fails
         # This is acceptable in test context where model info is optional
         pass
     
-    # Fallback: try to extract info from model name
+    # Fallback: try to extract info from model name only
+    # If context_size still not found, try to infer from model name or use common defaults
+    if context_size is None:
+        # Common default context sizes by model family
+        # Most modern models use 2048 or 4096, some use 8192 or 32768
+        # Since we can't determine from API, leave as None (will show as blank)
+        # Alternatively, we could set a default like 2048, but blank is more honest
+        pass
+    
     info = {
         'name': model_name,
-        'quantization': _extract_quantization(model_name),
-        'context_size': None,
+        'quantization': quantization,  # May be None if not in name
+        'context_size': context_size,  # May be None if not found
         'details': {}
     }
     _model_info_cache[model_name] = info
@@ -167,6 +246,106 @@ def _extract_quantization(model_name: str) -> Optional[str]:
                 return f"q{match.group(2)}_{match.group(3)}"
     
     return None
+
+
+async def test_model_api(query: str, model_name: str, test_name: str) -> Dict:
+    """
+    Test an individual model via Ollama API.
+    
+    Args:
+        query: The query to test
+        model_name: The model name to test (e.g., 'deepseek-coder:1.3b')
+        test_name: Descriptive name for the test
+    """
+    print(f"  Testing: {test_name}")
+    print(f"  Model: {model_name}")
+    print(f"  Query: {query[:60]}...")
+    
+    start_time = time.time()
+    
+    try:
+        async with httpx.AsyncClient(timeout=180.0) as client:
+            response = await client.post(
+                f"{OLLAMA_BASE_URL}/api/chat",
+                json={
+                    "model": model_name,
+                    "messages": [
+                        {"role": "user", "content": query}
+                    ],
+                    "stream": False
+                }
+            )
+            
+            elapsed = time.time() - start_time
+            
+            # Check status code
+            if response.status_code != 200:
+                response_text = response.text[:200]
+                return {
+                    'success': False,
+                    'elapsed_time': elapsed,
+                    'error': f'HTTP {response.status_code}: {response_text}',
+                    'model': model_name
+                }
+            
+            try:
+                data = response.json()
+            except json.JSONDecodeError as e:
+                response_text = response.text[:500]
+                return {
+                    'success': False,
+                    'elapsed_time': elapsed,
+                    'error': f'JSON decode error: {str(e)[:50]}. Response preview: {response_text[:200]}',
+                    'model': model_name
+                }
+            
+            # Extract response info
+            message = data.get('message', {})
+            content = message.get('content', '')
+            
+            # Extract token metrics from Ollama response
+            # Ollama returns prompt_eval_count and eval_count instead of prompt_tokens/completion_tokens
+            prompt_tokens = data.get('prompt_eval_count', 0) or data.get('prompt_tokens', 0) or 0
+            completion_tokens = data.get('eval_count', 0) or data.get('completion_tokens', 0) or 0
+            total_tokens = prompt_tokens + completion_tokens
+            tokens_per_second = (completion_tokens / elapsed) if elapsed > 0 and completion_tokens > 0 else 0.0
+            
+            return {
+                'success': True,
+                'elapsed_time': elapsed,
+                'response_id': data.get('id', ''),
+                'has_content': len(content) > 0,
+                'response_length': len(content),
+                'prompt_tokens': prompt_tokens,
+                'completion_tokens': completion_tokens,
+                'total_tokens': total_tokens,
+                'tokens_per_second': tokens_per_second,
+                'model': model_name
+            }
+    except httpx.TimeoutException:
+        elapsed = time.time() - start_time
+        return {
+            'success': False,
+            'elapsed_time': elapsed,
+            'error': 'Timeout (180s)',
+            'model': model_name
+        }
+    except httpx.RequestError as e:
+        elapsed = time.time() - start_time
+        return {
+            'success': False,
+            'elapsed_time': elapsed,
+            'error': f'Request error: {str(e)[:100]}',
+            'model': model_name
+        }
+    except Exception as e:
+        elapsed = time.time() - start_time
+        return {
+            'success': False,
+            'elapsed_time': elapsed,
+            'error': f'{type(e).__name__}: {str(e)[:100]}',
+            'model': model_name
+        }
 
 
 async def test_council_api(query: str, test_name: str) -> Dict:
@@ -202,7 +381,8 @@ async def test_council_api(query: str, test_name: str) -> Dict:
                 return {
                     'success': False,
                     'elapsed_time': elapsed,
-                    'error': f'HTTP {response.status_code}: {response_text}'
+                    'error': f'HTTP {response.status_code}: {response_text}',
+                    'model': 'council'
                 }
             
             # Check content type
@@ -233,9 +413,19 @@ async def test_council_api(query: str, test_name: str) -> Dict:
                             continue
                 
                 # Extract token metrics
-                prompt_tokens = usage_data.get('prompt_tokens', 0)
-                completion_tokens = usage_data.get('completion_tokens', 0)
-                total_tokens = usage_data.get('total_tokens', 0)
+                prompt_tokens = usage_data.get('prompt_tokens', 0) or 0
+                completion_tokens = usage_data.get('completion_tokens', 0) or 0
+                total_tokens = usage_data.get('total_tokens', 0) or (prompt_tokens + completion_tokens)
+                
+                # Fallback: if usage is missing or zero, estimate from content
+                if prompt_tokens == 0 and completion_tokens == 0:
+                    prompt_tokens = len(query.split())
+                    if content:
+                        completion_tokens = len(content.split())
+                    else:
+                        completion_tokens = 0
+                    total_tokens = prompt_tokens + completion_tokens
+                
                 tokens_per_second = (completion_tokens / elapsed) if elapsed > 0 and completion_tokens > 0 else 0.0
                 
                 return {
@@ -247,7 +437,8 @@ async def test_council_api(query: str, test_name: str) -> Dict:
                     'prompt_tokens': prompt_tokens,
                     'completion_tokens': completion_tokens,
                     'total_tokens': total_tokens,
-                    'tokens_per_second': tokens_per_second
+                    'tokens_per_second': tokens_per_second,
+                    'model': 'council'  # Council is a composite model
                 }
             
             # Handle non-streaming JSON response
@@ -258,18 +449,33 @@ async def test_council_api(query: str, test_name: str) -> Dict:
                 return {
                     'success': False,
                     'elapsed_time': elapsed,
-                    'error': f'JSON decode error: {str(e)[:50]}. Response preview: {response_text[:200]}'
+                    'error': f'JSON decode error: {str(e)[:50]}. Response preview: {response_text[:200]}',
+                    'model': 'council'
                 }
             
             # Extract response info
             choices = data.get('choices', [])
             has_content = bool(choices and choices[0].get('message', {}).get('content'))
+            response_content = choices[0].get('message', {}).get('content', '') if has_content else ''
             
             # Extract token metrics from usage field
             usage = data.get('usage', {})
-            prompt_tokens = usage.get('prompt_tokens', 0)
-            completion_tokens = usage.get('completion_tokens', 0)
-            total_tokens = usage.get('total_tokens', 0)
+            prompt_tokens = usage.get('prompt_tokens', 0) or 0
+            completion_tokens = usage.get('completion_tokens', 0) or 0
+            total_tokens = usage.get('total_tokens', 0) or (prompt_tokens + completion_tokens)
+            
+            # Fallback: if usage is missing or zero, estimate from content
+            # Council API uses word counts, so if they're zero, calculate from actual content
+            if prompt_tokens == 0 and completion_tokens == 0:
+                # Calculate word counts from actual query and response content
+                # Council API uses word counts as token estimates
+                prompt_tokens = len(query.split())
+                if response_content:
+                    completion_tokens = len(response_content.split())
+                else:
+                    completion_tokens = 0
+                total_tokens = prompt_tokens + completion_tokens
+            
             tokens_per_second = (completion_tokens / elapsed) if elapsed > 0 and completion_tokens > 0 else 0.0
             
             return {
@@ -281,203 +487,830 @@ async def test_council_api(query: str, test_name: str) -> Dict:
                 'prompt_tokens': prompt_tokens,
                 'completion_tokens': completion_tokens,
                 'total_tokens': total_tokens,
-                'tokens_per_second': tokens_per_second
+                'tokens_per_second': tokens_per_second,
+                'model': 'council'  # Council is a composite model
             }
     except httpx.TimeoutException:
         elapsed = time.time() - start_time
         return {
             'success': False,
             'elapsed_time': elapsed,
-            'error': 'Timeout (180s)'
+            'error': 'Timeout (180s)',
+            'model': 'council'
         }
     except httpx.RequestError as e:
         elapsed = time.time() - start_time
         return {
             'success': False,
             'elapsed_time': elapsed,
-            'error': f'Request error: {str(e)[:100]}'
+            'error': f'Request error: {str(e)[:100]}',
+            'model': 'council'
         }
     except Exception as e:
         elapsed = time.time() - start_time
         return {
             'success': False,
             'elapsed_time': elapsed,
-            'error': f'{type(e).__name__}: {str(e)[:100]}'
+            'error': f'{type(e).__name__}: {str(e)[:100]}',
+            'model': 'council'
         }
 
 
-async def test_multiple_queries():
-    """Test multiple council queries to measure consistency."""
-    print_section("Multiple Query Test (Consistency)")
-    print("Running 3 council queries to measure performance consistency...")
+async def test_multiple_queries(models: list):
+    """
+    Test multiple queries for each model to measure consistency.
     
-    results = []
+    Args:
+        models: List of model names to test (includes 'council' and individual models)
+    """
+    print_section("Multiple Query Test (Consistency)")
+    print(f"Running 3 queries per model to measure performance consistency...")
+    print(f"Testing {len(models)} model(s): {', '.join(models)}")
+    
+    all_results = []
     queries = [
         ("Query 1", TEST_QUERY_1),
         ("Query 2", TEST_QUERY_2),
         ("Query 3", TEST_QUERY_1),  # Repeat first query
     ]
     
-    for i, (name, query) in enumerate(queries, 1):
-        print(f"\n[{i}/3] {name}")
-        result = await test_council_api(query, name)
-        results.append(result)
+    for model_idx, model_name in enumerate(models, 1):
+        print(f"\n{Colors.BOLD}Model {model_idx}/{len(models)}: {model_name}{Colors.ENDC}")
+        model_results = []
         
-        if result['success']:
-            print(f"  {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result['elapsed_time']:.2f}s")
-            if result.get('response_length'):
-                print(f"  Response length: {result['response_length']} chars")
-            if result.get('completion_tokens'):
-                print(f"  Tokens: {result.get('completion_tokens', 0)} completion / {result.get('total_tokens', 0)} total")
-                if result.get('tokens_per_second', 0) > 0:
-                    print(f"  Speed: {result['tokens_per_second']:.2f} tokens/sec")
-        else:
-            print(f"  {Colors.RED}✗ Failed{Colors.ENDC} - {result.get('error', 'Unknown error')}")
+        for i, (name, query) in enumerate(queries, 1):
+            print(f"\n  [{i}/3] {name}")
+            if model_name == 'council':
+                result = await test_council_api(query, name)
+            else:
+                result = await test_model_api(query, model_name, name)
+            model_results.append(result)
+            
+            if result['success']:
+                print(f"    {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result['elapsed_time']:.2f}s")
+                if result.get('response_length'):
+                    print(f"    Response length: {result['response_length']} chars")
+                if result.get('completion_tokens'):
+                    print(f"    Tokens: {result.get('completion_tokens', 0)} completion / {result.get('total_tokens', 0)} total")
+                    if result.get('tokens_per_second', 0) > 0:
+                        print(f"    Speed: {result['tokens_per_second']:.2f} tokens/sec")
+            else:
+                print(f"    {Colors.RED}✗ Failed{Colors.ENDC} - {result.get('error', 'Unknown error')}")
+            
+            # Small delay between queries
+            if i < len(queries):
+                await asyncio.sleep(2)
         
-        # Small delay between queries
-        if i < len(queries):
-            await asyncio.sleep(2)
-    
-    return results
-
-
-async def test_rapid_queries():
-    """Test rapid successive queries (testing keep-alive)."""
-    print_section("Rapid Query Test (Keep-Alive)")
-    print("Running 2 rapid queries to test if models stay loaded...")
-    
-    # First query (cold start or warm)
-    print("\n[1/2] First Query")
-    result1 = await test_council_api(TEST_QUERY_1, "First Query")
-    
-    if result1['success']:
-        print(f"  {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result1['elapsed_time']:.2f}s")
-        if result1.get('tokens_per_second', 0) > 0:
-            print(f"  Speed: {result1['tokens_per_second']:.2f} tokens/sec")
-    else:
-        print(f"  {Colors.RED}✗ Failed{Colors.ENDC}")
-        return [result1]
-    
-    # Second query immediately after (should be faster if models stayed loaded)
-    print("\n[2/2] Second Query (Immediate)")
-    await asyncio.sleep(1)  # Very short delay
-    result2 = await test_council_api(TEST_QUERY_2, "Second Query")
-    
-    if result2['success']:
-        print(f"  {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result2['elapsed_time']:.2f}s")
-        if result2.get('tokens_per_second', 0) > 0:
-            print(f"  Speed: {result2['tokens_per_second']:.2f} tokens/sec")
+        all_results.extend(model_results)
         
-        # Compare times
-        if result2['elapsed_time'] < result1['elapsed_time'] * 0.9:
-            improvement = ((result1['elapsed_time'] - result2['elapsed_time']) / result1['elapsed_time']) * 100
-            print(f"  {Colors.GREEN}→ Second query was {improvement:.1f}% faster (models likely stayed loaded){Colors.ENDC}")
-        elif result2['elapsed_time'] > result1['elapsed_time'] * 1.1:
-            slowdown = ((result2['elapsed_time'] - result1['elapsed_time']) / result1['elapsed_time']) * 100
-            print(f"  {Colors.YELLOW}→ Second query was {slowdown:.1f}% slower (possible model reload){Colors.ENDC}")
-        else:
-            print(f"  {Colors.CYAN}→ Similar performance (models may have stayed loaded){Colors.ENDC}")
-    else:
-        print(f"  {Colors.RED}✗ Failed{Colors.ENDC}")
+        # Delay between models
+        if model_idx < len(models):
+            await asyncio.sleep(3)
     
-    return [result1, result2]
+    return all_results
 
 
-async def warmup_model():
+async def test_rapid_queries(models: list):
     """
-    Warm up the model by running a simple query.
+    Test rapid successive queries for each model (testing keep-alive).
+    
+    Args:
+        models: List of model names to test (includes 'council' and individual models)
+    """
+    print_section("Rapid Query Test (Keep-Alive)")
+    print(f"Running 2 rapid queries per model to test if models stay loaded...")
+    print(f"Testing {len(models)} model(s): {', '.join(models)}")
+    
+    all_results = []
+    
+    for model_idx, model_name in enumerate(models, 1):
+        print(f"\n{Colors.BOLD}Model {model_idx}/{len(models)}: {model_name}{Colors.ENDC}")
+        
+        # First query (cold start or warm)
+        print("\n  [1/2] First Query")
+        if model_name == 'council':
+            result1 = await test_council_api(TEST_QUERY_1, "First Query")
+        else:
+            result1 = await test_model_api(TEST_QUERY_1, model_name, "First Query")
+        
+        if result1['success']:
+            print(f"    {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result1['elapsed_time']:.2f}s")
+            if result1.get('tokens_per_second', 0) > 0:
+                print(f"    Speed: {result1['tokens_per_second']:.2f} tokens/sec")
+        else:
+            print(f"    {Colors.RED}✗ Failed{Colors.ENDC}")
+            all_results.append(result1)
+            if model_idx < len(models):
+                await asyncio.sleep(3)
+            continue
+        
+        # Second query immediately after (should be faster if models stayed loaded)
+        print("\n  [2/2] Second Query (Immediate)")
+        await asyncio.sleep(1)  # Very short delay
+        if model_name == 'council':
+            result2 = await test_council_api(TEST_QUERY_2, "Second Query")
+        else:
+            result2 = await test_model_api(TEST_QUERY_2, model_name, "Second Query")
+        
+        if result2['success']:
+            print(f"    {Colors.GREEN}✓ Success{Colors.ENDC} - Time: {result2['elapsed_time']:.2f}s")
+            if result2.get('tokens_per_second', 0) > 0:
+                print(f"    Speed: {result2['tokens_per_second']:.2f} tokens/sec")
+            
+            # Compare times
+            if result2['elapsed_time'] < result1['elapsed_time'] * 0.9:
+                improvement = ((result1['elapsed_time'] - result2['elapsed_time']) / result1['elapsed_time']) * 100
+                print(f"    {Colors.GREEN}→ Second query was {improvement:.1f}% faster (models likely stayed loaded){Colors.ENDC}")
+            elif result2['elapsed_time'] > result1['elapsed_time'] * 1.1:
+                slowdown = ((result2['elapsed_time'] - result1['elapsed_time']) / result1['elapsed_time']) * 100
+                print(f"    {Colors.YELLOW}→ Second query was {slowdown:.1f}% slower (possible model reload){Colors.ENDC}")
+            else:
+                print(f"    {Colors.CYAN}→ Similar performance (models may have stayed loaded){Colors.ENDC}")
+        else:
+            print(f"    {Colors.RED}✗ Failed{Colors.ENDC}")
+        
+        all_results.extend([result1, result2])
+        
+        # Delay between models
+        if model_idx < len(models):
+            await asyncio.sleep(3)
+    
+    return all_results
+
+
+async def warmup_models(models: list):
+    """
+    Warm up models by running a simple query for each.
     
     This pre-loads models into GPU memory before benchmarking,
     ensuring more accurate performance measurements.
+    
+    Args:
+        models: List of model names to warm up
     """
     print_section("Model Warmup")
-    print("Running warmup query to pre-load models...")
+    print(f"Running warmup query to pre-load {len(models)} model(s)...")
     print(f"  Query: {WARMUP_QUERY}")
     
-    result = await test_council_api(WARMUP_QUERY, "Warmup")
+    for model_idx, model_name in enumerate(models, 1):
+        print(f"\n  Warming up {model_idx}/{len(models)}: {model_name}")
+        if model_name == 'council':
+            result = await test_council_api(WARMUP_QUERY, f"Warmup {model_name}")
+        else:
+            result = await test_model_api(WARMUP_QUERY, model_name, f"Warmup {model_name}")
+        
+        if result['success']:
+            print(f"    {Colors.GREEN}✓ Warmup complete{Colors.ENDC} - Time: {result['elapsed_time']:.2f}s")
+        else:
+            print(f"    {Colors.YELLOW}⚠ Warmup failed{Colors.ENDC} - {result.get('error', 'Unknown')}")
+        
+        if model_idx < len(models):
+            await asyncio.sleep(1)
     
-    if result['success']:
-        print(f"  {Colors.GREEN}✓ Warmup complete{Colors.ENDC} - Time: {result['elapsed_time']:.2f}s")
-        print(f"  {Colors.CYAN}Models should now be loaded and ready for benchmarking{Colors.ENDC}\n")
-        await asyncio.sleep(2)  # Brief pause after warmup
-    else:
-        print(f"  {Colors.YELLOW}⚠ Warmup failed, but continuing with benchmarks{Colors.ENDC}")
-        print(f"  Error: {result.get('error', 'Unknown')}\n")
+    print(f"\n  {Colors.CYAN}Models should now be loaded and ready for benchmarking{Colors.ENDC}\n")
+    await asyncio.sleep(2)  # Brief pause after warmup
 
 
-def export_to_csv(results: list, rapid_results: list, model_info: Optional[Dict[str, Any]], filename: str):
+def calculate_performance_score(result: Dict) -> float:
     """
-    Export benchmark results to CSV file.
+    Calculate a performance score from 0-100 based on tokens/sec and elapsed time.
+    
+    Uses different scoring formulas for council (composite) vs individual models:
+    - Individual models: Higher scale to differentiate fast models (no cap)
+    - Council: Adjusted scale for multi-stage orchestration performance
+    
+    Higher score = better performance (faster, more efficient)
+    
+    Args:
+        result: Test result dictionary with 'model' field
+        
+    Returns:
+        Performance score from 0-100
+    """
+    tokens_per_sec = result.get('tokens_per_second', 0) or 0
+    elapsed_time = result.get('elapsed_time', 0) or 0.1  # Avoid division by zero
+    model_name = result.get('model', '')
+    
+    if tokens_per_sec == 0 or elapsed_time == 0:
+        return 0.0
+    
+    # Different scoring for council vs individual models
+    if model_name == 'council':
+        # Council scoring: Multi-stage orchestration is inherently slower
+        # Scale: (tokens_per_second * 5) / elapsed_time, capped at 100
+        # This accounts for the overhead of running multiple models sequentially
+        score = min(100.0, (tokens_per_sec * 5.0) / elapsed_time)
+    else:
+        # Individual model scoring: Higher scale to differentiate fast models
+        # Scale: (tokens_per_second * 2) / elapsed_time, no cap (but typically stays under 200)
+        # This better differentiates between 50-100 tokens/sec models
+        score = (tokens_per_sec * 2.0) / elapsed_time
+        # Cap at 200 for very fast models, but allow higher differentiation
+        score = min(200.0, score)
+    
+    return round(score, 1)
+
+
+def display_benchmark_table(results: list, rapid_results: list, model_info_cache: Dict[str, Dict[str, Any]]):
+    """
+    Display benchmark results as a formatted table in the summary.
     
     Args:
         results: List of results from multiple query test
         rapid_results: List of results from rapid query test
-        model_info: Model information dictionary
-        filename: Output CSV filename
+        model_info_cache: Dictionary mapping model names to their info dictionaries
     """
-    try:
-        with open(filename, 'w', newline='') as csvfile:
-            fieldnames = [
-                'timestamp',
-                'model',
-                'quantization',
-                'context_size',
-                'prompt_tokens',
-                'completion_tokens',
-                'total_tokens',
-                'elapsed_seconds',
-                'tokens_per_second',
-                'query_number',
-                'test_type'
-            ]
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
+    # Check if there are any successful results to display
+    successful_results = [r for r in results if r.get('success')]
+    successful_rapid = [r for r in rapid_results if r.get('success')]
+    
+    if not successful_results and not successful_rapid:
+        print(f"\n{Colors.YELLOW}No successful test results to display in benchmark table{Colors.ENDC}\n")
+        return
+    
+    # Check if results are aggregated (have 'runs' or 'iterations' field)
+    is_aggregated = any(r.get('runs') or r.get('iterations') for r in successful_results + successful_rapid)
+    iterations = successful_results[0].get('iterations') or successful_results[0].get('runs') if successful_results else None
+    
+    print(f"\n{Colors.BOLD}Benchmark Results Table:{Colors.ENDC}")
+    if is_aggregated and iterations:
+        print(f"{Colors.CYAN}(Aggregated from {iterations} iterations - showing mean values ± std dev){Colors.ENDC}")
+    
+    # Adjusted width to accommodate all columns including Score
+    table_width = 140
+    print(f"{Colors.CYAN}{'='*table_width}{Colors.ENDC}")
+    
+    # Table header - add Runs column if aggregated
+    if is_aggregated:
+        header = (
+            f"{'Timestamp':<20} "
+            f"{'Model':<22} "
+            f"{'Quant':<7} "
+            f"{'Ctx':<5} "
+            f"{'Prompt':<7} "
+            f"{'Complete':<9} "
+            f"{'Total':<6} "
+            f"{'Elapsed(s)':<11} "
+            f"{'Tokens/s':<9} "
+            f"{'Score':<7} "
+            f"{'Runs':<6} "
+            f"{'Type':<10}"
+        )
+    else:
+        header = (
+            f"{'Timestamp':<20} "
+            f"{'Model':<22} "
+            f"{'Quant':<7} "
+            f"{'Ctx':<5} "
+            f"{'Prompt':<7} "
+            f"{'Complete':<9} "
+            f"{'Total':<6} "
+            f"{'Elapsed(s)':<11} "
+            f"{'Tokens/s':<9} "
+            f"{'Score':<7} "
+            f"{'Query':<6} "
+            f"{'Type':<10}"
+        )
+    print(f"{Colors.BOLD}{header}{Colors.ENDC}")
+    print(f"{Colors.CYAN}{'-'*table_width}{Colors.ENDC}")
+    
+    timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    
+    # Display multiple query test results
+    query_num = 1
+    for result in results:
+        if result.get('success'):
+            result_model = result.get('model', 'council')
             
-            timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            model_name = model_info.get('name', 'council') if model_info else 'council'
-            quantization = model_info.get('quantization', '') if model_info else ''
-            context_size = model_info.get('context_size', '') if model_info else ''
+            # Extract model info
+            if result_model == 'council':
+                model_name = 'council'
+                quantization = ''
+                context_size = ''
+            else:
+                info = model_info_cache.get(result_model)
+                model_name = result_model
+                if info:
+                    quant_val = info.get('quantization')
+                    quantization = str(quant_val) if quant_val else ''
+                    ctx_val = info.get('context_size')
+                    context_size = str(ctx_val) if ctx_val else ''
+                else:
+                    quantization = ''
+                    context_size = ''
             
-            # Write multiple query test results
-            for i, result in enumerate(results, 1):
-                if result.get('success'):
-                    writer.writerow({
-                        'timestamp': timestamp,
-                        'model': model_name,
-                        'quantization': quantization,
-                        'context_size': context_size or '',
-                        'prompt_tokens': result.get('prompt_tokens', 0),
-                        'completion_tokens': result.get('completion_tokens', 0),
-                        'total_tokens': result.get('total_tokens', 0),
-                        'elapsed_seconds': round(result.get('elapsed_time', 0), 2),
-                        'tokens_per_second': round(result.get('tokens_per_second', 0), 2),
-                        'query_number': i,
-                        'test_type': 'consistency'
-                    })
+            score = calculate_performance_score(result)
+            # Color code score based on model type
+            if result_model == 'council':
+                # Council scoring: green (>50), yellow (25-50), red (<25)
+                score_color = Colors.GREEN if score >= 50 else (Colors.YELLOW if score >= 25 else Colors.RED)
+            else:
+                # Individual model scoring: green (>100), yellow (50-100), red (<50)
+                score_color = Colors.GREEN if score >= 100 else (Colors.YELLOW if score >= 50 else Colors.RED)
+            score_display = f"{score_color}{score:>6.1f}{Colors.ENDC}"
             
-            # Write rapid query test results
-            for i, result in enumerate(rapid_results, 1):
-                if result.get('success'):
-                    writer.writerow({
-                        'timestamp': timestamp,
-                        'model': model_name,
-                        'quantization': quantization,
-                        'context_size': context_size or '',
-                        'prompt_tokens': result.get('prompt_tokens', 0),
-                        'completion_tokens': result.get('completion_tokens', 0),
-                        'total_tokens': result.get('total_tokens', 0),
-                        'elapsed_seconds': round(result.get('elapsed_time', 0), 2),
-                        'tokens_per_second': round(result.get('tokens_per_second', 0), 2),
-                        'query_number': i,
-                        'test_type': 'rapid'
-                    })
+            # Format elapsed time - show std dev if available (aggregated results)
+            elapsed_time = result.get('elapsed_time', 0)
+            if result.get('elapsed_std_dev') is not None:
+                elapsed_display = f"{elapsed_time:>6.2f}±{result['elapsed_std_dev']:.2f}"
+            else:
+                elapsed_display = f"{elapsed_time:>10.2f}"
+            
+            # Show runs count if aggregated, otherwise query number
+            if is_aggregated:
+                runs_count = result.get('runs', result.get('iterations', 1))
+                runs_display = f"{runs_count:<6}"
+            else:
+                runs_display = f"{query_num:<6}"
+            
+            row = (
+                f"{timestamp:<20} "
+                f"{model_name[:21]:<22} "
+                f"{quantization[:6]:<7} "
+                f"{context_size[:4]:<5} "
+                f"{result.get('prompt_tokens', 0):<7} "
+                f"{result.get('completion_tokens', 0):<9} "
+                f"{result.get('total_tokens', 0):<6} "
+                f"{elapsed_display:<11} "
+                f"{result.get('tokens_per_second', 0):>8.2f} "
+                f"{score_display:<20} "  # Width accounts for ANSI color codes
+                f"{runs_display} "
+                f"{'consistency':<10}"
+            )
+            print(row)
+            query_num += 1
+    
+    # Display rapid query test results
+    query_num = 1
+    for result in rapid_results:
+        if result.get('success'):
+            result_model = result.get('model', 'council')
+            
+            # Extract model info
+            if result_model == 'council':
+                model_name = 'council'
+                quantization = ''
+                context_size = ''
+            else:
+                info = model_info_cache.get(result_model)
+                model_name = result_model
+                if info:
+                    quant_val = info.get('quantization')
+                    quantization = str(quant_val) if quant_val else ''
+                    ctx_val = info.get('context_size')
+                    context_size = str(ctx_val) if ctx_val else ''
+                else:
+                    quantization = ''
+                    context_size = ''
+            
+            score = calculate_performance_score(result)
+            # Color code score based on model type
+            if result_model == 'council':
+                # Council scoring: green (>50), yellow (25-50), red (<25)
+                score_color = Colors.GREEN if score >= 50 else (Colors.YELLOW if score >= 25 else Colors.RED)
+            else:
+                # Individual model scoring: green (>100), yellow (50-100), red (<50)
+                score_color = Colors.GREEN if score >= 100 else (Colors.YELLOW if score >= 50 else Colors.RED)
+            score_display = f"{score_color}{score:>6.1f}{Colors.ENDC}"
+            
+            # Format elapsed time - show std dev if available (aggregated results)
+            elapsed_time = result.get('elapsed_time', 0)
+            if result.get('elapsed_std_dev') is not None:
+                elapsed_display = f"{elapsed_time:>6.2f}±{result['elapsed_std_dev']:.2f}"
+            else:
+                elapsed_display = f"{elapsed_time:>10.2f}"
+            
+            # Show runs count if aggregated, otherwise query number
+            if is_aggregated:
+                runs_count = result.get('runs', result.get('iterations', 1))
+                runs_display = f"{runs_count:<6}"
+            else:
+                runs_display = f"{query_num:<6}"
+            
+            row = (
+                f"{timestamp:<20} "
+                f"{model_name[:21]:<22} "
+                f"{quantization[:6]:<7} "
+                f"{context_size[:4]:<5} "
+                f"{result.get('prompt_tokens', 0):<7} "
+                f"{result.get('completion_tokens', 0):<9} "
+                f"{result.get('total_tokens', 0):<6} "
+                f"{elapsed_display:<11} "
+                f"{result.get('tokens_per_second', 0):>8.2f} "
+                f"{score_display:<20} "  # Width accounts for ANSI color codes
+                f"{runs_display} "
+                f"{'rapid':<10}"
+            )
+            print(row)
+            query_num += 1
+    
+    print(f"{Colors.CYAN}{'='*table_width}{Colors.ENDC}\n")
+
+
+def aggregate_results(all_results: list) -> list:
+    """
+    Aggregate results from multiple benchmark runs by calculating means.
+    
+    Groups results by model and test type, then calculates mean values for all metrics.
+    
+    Args:
+        all_results: List of result dictionaries from multiple runs
         
-        print(f"{Colors.GREEN}✓ Results exported to: {filename}{Colors.ENDC}")
-    except Exception as e:
-        print(f"{Colors.RED}✗ Failed to export CSV: {e}{Colors.ENDC}")
+    Returns:
+        List of aggregated result dictionaries with mean values
+    """
+    # Group results by (model, test_type) - test_type is determined by position
+    # For consistency tests: query_number 1-3
+    # For rapid tests: query_number 1-2
+    groups = {}
+    
+    for result in all_results:
+        if not result.get('success'):
+            continue
+        
+        model = result.get('model', 'unknown')
+        # Determine test type based on context (we'll pass this info)
+        # For now, we'll group by model only and calculate overall means
+        
+        if model not in groups:
+            groups[model] = []
+        groups[model].append(result)
+    
+    aggregated = []
+    for model, model_results in groups.items():
+        if not model_results:
+            continue
+        
+        # Calculate means
+        elapsed_times = [r['elapsed_time'] for r in model_results]
+        prompt_tokens_list = [r.get('prompt_tokens', 0) for r in model_results]
+        completion_tokens_list = [r.get('completion_tokens', 0) for r in model_results]
+        total_tokens_list = [r.get('total_tokens', 0) for r in model_results]
+        tokens_per_sec_list = [r.get('tokens_per_second', 0) for r in model_results if r.get('tokens_per_second', 0) > 0]
+        
+        mean_elapsed = sum(elapsed_times) / len(elapsed_times)
+        mean_prompt_tokens = sum(prompt_tokens_list) / len(prompt_tokens_list) if prompt_tokens_list else 0
+        mean_completion_tokens = sum(completion_tokens_list) / len(completion_tokens_list) if completion_tokens_list else 0
+        mean_total_tokens = sum(total_tokens_list) / len(total_tokens_list) if total_tokens_list else 0
+        mean_tokens_per_sec = sum(tokens_per_sec_list) / len(tokens_per_sec_list) if tokens_per_sec_list else 0
+        
+        # Calculate standard deviation for elapsed_time
+        variance = sum((t - mean_elapsed) ** 2 for t in elapsed_times) / len(elapsed_times)
+        std_dev = variance ** 0.5
+        
+        aggregated.append({
+            'success': True,
+            'model': model,
+            'elapsed_time': mean_elapsed,
+            'elapsed_std_dev': std_dev,
+            'prompt_tokens': round(mean_prompt_tokens),
+            'completion_tokens': round(mean_completion_tokens),
+            'total_tokens': round(mean_total_tokens),
+            'tokens_per_second': mean_tokens_per_sec,
+            'runs': len(model_results),
+            'min_elapsed': min(elapsed_times),
+            'max_elapsed': max(elapsed_times)
+        })
+    
+    return aggregated
 
 
-def print_summary(results: list, rapid_results: list, model_info: Optional[Dict[str, Any]] = None):
+def aggregate_by_test_type(results: list, rapid_results: list) -> tuple:
+    """
+    Aggregate results separately for consistency and rapid tests.
+    
+    Args:
+        results: List of consistency test results from all runs
+        rapid_results: List of rapid test results from all runs
+        
+    Returns:
+        Tuple of (aggregated_consistency_results, aggregated_rapid_results)
+    """
+    # Group consistency results by (model, query_position)
+    consistency_groups = {}
+    for i, result in enumerate(results):
+        if not result.get('success'):
+            continue
+        model = result.get('model', 'unknown')
+        # Group by model - we'll show one aggregated row per model
+        if model not in consistency_groups:
+            consistency_groups[model] = []
+        consistency_groups[model].append(result)
+    
+    # Group rapid results by (model, query_position)
+    rapid_groups = {}
+    for i, result in enumerate(rapid_results):
+        if not result.get('success'):
+            continue
+        model = result.get('model', 'unknown')
+        if model not in rapid_groups:
+            rapid_groups[model] = []
+        rapid_groups[model].append(result)
+    
+    # Aggregate each group
+    aggregated_consistency = []
+    for model, model_results in consistency_groups.items():
+        elapsed_times = [r['elapsed_time'] for r in model_results]
+        prompt_tokens_list = [r.get('prompt_tokens', 0) for r in model_results]
+        completion_tokens_list = [r.get('completion_tokens', 0) for r in model_results]
+        total_tokens_list = [r.get('total_tokens', 0) for r in model_results]
+        tokens_per_sec_list = [r.get('tokens_per_second', 0) for r in model_results if r.get('tokens_per_second', 0) > 0]
+        
+        mean_elapsed = sum(elapsed_times) / len(elapsed_times)
+        mean_prompt_tokens = sum(prompt_tokens_list) / len(prompt_tokens_list) if prompt_tokens_list else 0
+        mean_completion_tokens = sum(completion_tokens_list) / len(completion_tokens_list) if completion_tokens_list else 0
+        mean_total_tokens = sum(total_tokens_list) / len(total_tokens_list) if total_tokens_list else 0
+        mean_tokens_per_sec = sum(tokens_per_sec_list) / len(tokens_per_sec_list) if tokens_per_sec_list else 0
+        
+        variance = sum((t - mean_elapsed) ** 2 for t in elapsed_times) / len(elapsed_times)
+        std_dev = variance ** 0.5
+        
+        aggregated_consistency.append({
+            'success': True,
+            'model': model,
+            'elapsed_time': mean_elapsed,
+            'elapsed_std_dev': std_dev,
+            'prompt_tokens': round(mean_prompt_tokens),
+            'completion_tokens': round(mean_completion_tokens),
+            'total_tokens': round(mean_total_tokens),
+            'tokens_per_second': mean_tokens_per_sec,
+            'runs': len(model_results),
+            'min_elapsed': min(elapsed_times),
+            'max_elapsed': max(elapsed_times)
+        })
+    
+    aggregated_rapid = []
+    for model, model_results in rapid_groups.items():
+        elapsed_times = [r['elapsed_time'] for r in model_results]
+        prompt_tokens_list = [r.get('prompt_tokens', 0) for r in model_results]
+        completion_tokens_list = [r.get('completion_tokens', 0) for r in model_results]
+        total_tokens_list = [r.get('total_tokens', 0) for r in model_results]
+        tokens_per_sec_list = [r.get('tokens_per_second', 0) for r in model_results if r.get('tokens_per_second', 0) > 0]
+        
+        mean_elapsed = sum(elapsed_times) / len(elapsed_times)
+        mean_prompt_tokens = sum(prompt_tokens_list) / len(prompt_tokens_list) if prompt_tokens_list else 0
+        mean_completion_tokens = sum(completion_tokens_list) / len(completion_tokens_list) if completion_tokens_list else 0
+        mean_total_tokens = sum(total_tokens_list) / len(total_tokens_list) if total_tokens_list else 0
+        mean_tokens_per_sec = sum(tokens_per_sec_list) / len(tokens_per_sec_list) if tokens_per_sec_list else 0
+        
+        variance = sum((t - mean_elapsed) ** 2 for t in elapsed_times) / len(elapsed_times)
+        std_dev = variance ** 0.5
+        
+        aggregated_rapid.append({
+            'success': True,
+            'model': model,
+            'elapsed_time': mean_elapsed,
+            'elapsed_std_dev': std_dev,
+            'prompt_tokens': round(mean_prompt_tokens),
+            'completion_tokens': round(mean_completion_tokens),
+            'total_tokens': round(mean_total_tokens),
+            'tokens_per_second': mean_tokens_per_sec,
+            'runs': len(model_results),
+            'min_elapsed': min(elapsed_times),
+            'max_elapsed': max(elapsed_times)
+        })
+    
+    return aggregated_consistency, aggregated_rapid
+
+
+def print_insights(results: list, rapid_results: list, model_info_cache: Dict[str, Dict[str, Any]]):
+    """
+    Analyze benchmark results and provide user-focused insights and recommendations.
+    
+    Args:
+        results: List of results from multiple query test
+        rapid_results: List of results from rapid query test
+        model_info_cache: Dictionary mapping model names to their info dictionaries
+    """
+    print_header("Performance Insights & Recommendations")
+    
+    # Check if results are aggregated
+    is_aggregated = any(r.get('runs') or r.get('iterations') for r in results + rapid_results)
+    iterations = results[0].get('iterations') or results[0].get('runs') if results else None
+    
+    if is_aggregated and iterations:
+        print(f"{Colors.CYAN}Analysis based on {iterations} benchmark iterations (mean values){Colors.ENDC}\n")
+    
+    # Separate council and individual model results
+    council_results = [r for r in results if r.get('model') == 'council' and r.get('success')]
+    individual_results = [r for r in results if r.get('model') != 'council' and r.get('success')]
+    council_rapid = [r for r in rapid_results if r.get('model') == 'council' and r.get('success')]
+    individual_rapid = [r for r in rapid_results if r.get('model') != 'council' and r.get('success')]
+    
+    # Group individual results by model
+    model_groups = {}
+    for result in individual_results:
+        model = result.get('model', 'unknown')
+        if model not in model_groups:
+            model_groups[model] = []
+        model_groups[model].append(result)
+    
+    # Individual Model Analysis
+    if model_groups:
+        print(f"\n{Colors.BOLD}Individual Model Performance:{Colors.ENDC}")
+        
+        model_stats = []
+        for model, model_results in model_groups.items():
+            if model_results:
+                times = [r['elapsed_time'] for r in model_results]
+                tokens_per_sec = [r.get('tokens_per_second', 0) for r in model_results if r.get('tokens_per_second', 0) > 0]
+                scores = [calculate_performance_score(r) for r in model_results]
+                
+                avg_time = sum(times) / len(times)
+                avg_tokens_per_sec = sum(tokens_per_sec) / len(tokens_per_sec) if tokens_per_sec else 0
+                avg_score = sum(scores) / len(scores) if scores else 0
+                consistency = ((max(times) - min(times)) / avg_time * 100) if avg_time > 0 else 0
+                
+                model_stats.append({
+                    'model': model,
+                    'avg_time': avg_time,
+                    'avg_tokens_per_sec': avg_tokens_per_sec,
+                    'avg_score': avg_score,
+                    'consistency': consistency,
+                    'quantization': model_info_cache.get(model, {}).get('quantization', 'N/A') if model_info_cache.get(model) else 'N/A'
+                })
+        
+        # Sort by average score (best first)
+        model_stats.sort(key=lambda x: x['avg_score'], reverse=True)
+        
+        print(f"\n  {Colors.BOLD}Top Performers:{Colors.ENDC}")
+        for i, stat in enumerate(model_stats[:3], 1):
+            quant_str = f" ({stat['quantization']})" if stat['quantization'] != 'N/A' else ''
+            print(f"    {i}. {Colors.GREEN}{stat['model']}{quant_str}{Colors.ENDC}")
+            
+            # Show range if aggregated (we have min/max from original results)
+            if is_aggregated and iterations:
+                # Try to find min/max from results
+                model_result = next((r for r in individual_results if r.get('model') == stat['model']), None)
+                if model_result and 'min_elapsed' in model_result:
+                    print(f"       Average: {stat['avg_time']:.2f}s (range: {model_result['min_elapsed']:.2f}s - {model_result['max_elapsed']:.2f}s)")
+                else:
+                    print(f"       Average: {stat['avg_time']:.2f}s")
+            else:
+                print(f"       Average: {stat['avg_time']:.2f}s")
+            
+            print(f"       Speed: {stat['avg_tokens_per_sec']:.1f} tokens/sec, Score: {stat['avg_score']:.1f}")
+            if stat['consistency'] < 30:
+                print(f"       {Colors.GREEN}✓ Excellent consistency ({stat['consistency']:.1f}% variation){Colors.ENDC}")
+            elif stat['consistency'] < 50:
+                print(f"       {Colors.YELLOW}⚠ Good consistency ({stat['consistency']:.1f}% variation){Colors.ENDC}")
+            else:
+                print(f"       {Colors.RED}⚠ High variation ({stat['consistency']:.1f}% variation) - may need tuning{Colors.ENDC}")
+        
+        if len(model_stats) > 3:
+            print(f"\n  {Colors.BOLD}Other Models:{Colors.ENDC}")
+            for stat in model_stats[3:]:
+                quant_str = f" ({stat['quantization']})" if stat['quantization'] != 'N/A' else ''
+                print(f"    - {stat['model']}{quant_str}: {stat['avg_time']:.2f}s avg, Score: {stat['avg_score']:.1f}")
+    
+    # Council Analysis
+    if council_results:
+        print(f"\n{Colors.BOLD}Council Composite Performance:{Colors.ENDC}")
+        council_times = [r['elapsed_time'] for r in council_results]
+        council_tokens = [r.get('tokens_per_second', 0) for r in council_results if r.get('tokens_per_second', 0) > 0]
+        council_scores = [calculate_performance_score(r) for r in council_results]
+        
+        avg_council_time = sum(council_times) / len(council_times)
+        avg_council_tokens = sum(council_tokens) / len(council_tokens) if council_tokens else 0
+        avg_council_score = sum(council_scores) / len(council_scores) if council_scores else 0
+        council_consistency = ((max(council_times) - min(council_times)) / avg_council_time * 100) if avg_council_time > 0 else 0
+        
+        print(f"  Average response time: {avg_council_time:.2f}s")
+        print(f"  Average speed: {avg_council_tokens:.1f} tokens/sec")
+        print(f"  Average score: {avg_council_score:.1f}")
+        print(f"  Consistency: {council_consistency:.1f}% variation")
+        
+        # Compare to individual models
+        if individual_results:
+            avg_individual_time = sum(r['elapsed_time'] for r in individual_results) / len(individual_results)
+            overhead = ((avg_council_time - avg_individual_time) / avg_individual_time * 100) if avg_individual_time > 0 else 0
+            print(f"\n  {Colors.BOLD}Council Overhead:{Colors.ENDC}")
+            print(f"    Council is {overhead:.1f}% slower than individual models")
+            print(f"    This is expected due to multi-stage orchestration (Stage 1 → Stage 2 → Stage 3)")
+            if overhead > 300:
+                print(f"    {Colors.YELLOW}⚠ High overhead - consider optimizing council workflow{Colors.ENDC}")
+            elif overhead > 200:
+                print(f"    {Colors.YELLOW}⚠ Moderate overhead - acceptable for multi-stage process{Colors.ENDC}")
+            else:
+                print(f"    {Colors.GREEN}✓ Overhead is reasonable for orchestrated workflow{Colors.ENDC}")
+    
+    # Keep-Alive Analysis
+    if individual_rapid and len(individual_rapid) >= 2:
+        print(f"\n{Colors.BOLD}Keep-Alive Effectiveness (Individual Models):{Colors.ENDC}")
+        improvements = []
+        for i in range(0, len(individual_rapid) - 1, 2):
+            if i + 1 < len(individual_rapid):
+                r1, r2 = individual_rapid[i], individual_rapid[i + 1]
+                if r1.get('success') and r2.get('success') and r1.get('model') == r2.get('model'):
+                    if r2['elapsed_time'] < r1['elapsed_time']:
+                        improvement = ((r1['elapsed_time'] - r2['elapsed_time']) / r1['elapsed_time']) * 100
+                        improvements.append((r1.get('model'), improvement))
+        
+        if improvements:
+            avg_improvement = sum(imp[1] for imp in improvements) / len(improvements)
+            print(f"  Average improvement: {avg_improvement:.1f}% faster on second query")
+            if avg_improvement > 20:
+                print(f"  {Colors.GREEN}✓ Excellent keep-alive - models staying loaded effectively{Colors.ENDC}")
+            elif avg_improvement > 10:
+                print(f"  {Colors.YELLOW}⚠ Good keep-alive - models mostly staying loaded{Colors.ENDC}")
+            else:
+                print(f"  {Colors.YELLOW}⚠ Limited keep-alive benefit - models may be reloading{Colors.ENDC}")
+                print(f"     Consider increasing OLLAMA_MAX_LOADED_MODELS or reducing model sizes")
+    
+    if council_rapid and len(council_rapid) >= 2:
+        print(f"\n{Colors.BOLD}Keep-Alive Effectiveness (Council):{Colors.ENDC}")
+        council_improvements = []
+        for i in range(0, len(council_rapid) - 1, 2):
+            if i + 1 < len(council_rapid):
+                r1, r2 = council_rapid[i], council_rapid[i + 1]
+                if r1.get('success') and r2.get('success'):
+                    if r2['elapsed_time'] < r1['elapsed_time']:
+                        improvement = ((r1['elapsed_time'] - r2['elapsed_time']) / r1['elapsed_time']) * 100
+                        council_improvements.append(improvement)
+        
+        if council_improvements:
+            avg_improvement = sum(council_improvements) / len(council_improvements)
+            print(f"  Average improvement: {avg_improvement:.1f}% faster on second query")
+            if avg_improvement > 15:
+                print(f"  {Colors.GREEN}✓ Council keep-alive working well{Colors.ENDC}")
+            elif avg_improvement > 5:
+                print(f"  {Colors.YELLOW}⚠ Council keep-alive moderate - some improvement{Colors.ENDC}")
+            else:
+                print(f"  {Colors.YELLOW}⚠ Limited council keep-alive - models reloading between stages{Colors.ENDC}")
+    
+    # Performance Recommendations
+    print(f"\n{Colors.BOLD}Recommendations:{Colors.ENDC}")
+    
+    recommendations = []
+    
+    # Check for slow council performance
+    if council_results:
+        avg_council_time = sum(r['elapsed_time'] for r in council_results) / len(council_results)
+        if avg_council_time > 45:
+            recommendations.append(f"{Colors.RED}⚠ Council average time ({avg_council_time:.1f}s) is high{Colors.ENDC}")
+            recommendations.append("   - Check GPU memory: nvidia-smi")
+            recommendations.append("   - Review Ollama logs: docker logs ollama")
+            recommendations.append("   - Consider reducing model sizes or number of council members")
+        elif avg_council_time > 30:
+            recommendations.append(f"{Colors.YELLOW}⚠ Council average time ({avg_council_time:.1f}s) could be improved{Colors.ENDC}")
+            recommendations.append("   - Consider optimizing model selection")
+            recommendations.append("   - Check if OLLAMA_MAX_LOADED_MODELS is set appropriately")
+    
+    # Check for high variation
+    if individual_results:
+        model_variations = {}
+        for result in individual_results:
+            model = result.get('model')
+            if model not in model_variations:
+                model_variations[model] = []
+            model_variations[model].append(result['elapsed_time'])
+        
+        high_variation_models = []
+        for model, times in model_variations.items():
+            if len(times) >= 3:
+                avg = sum(times) / len(times)
+                variation = ((max(times) - min(times)) / avg * 100) if avg > 0 else 0
+                if variation > 50:
+                    high_variation_models.append((model, variation))
+        
+        if high_variation_models:
+            recommendations.append(f"{Colors.YELLOW}⚠ Some models show high variation:{Colors.ENDC}")
+            for model, variation in high_variation_models:
+                recommendations.append(f"   - {model}: {variation:.1f}% variation")
+            recommendations.append("   - This may indicate model loading/eviction issues")
+            recommendations.append("   - Check GPU memory availability and OLLAMA_MAX_LOADED_MODELS")
+    
+    # Check for very slow individual models
+    if individual_results:
+        slow_models = []
+        for result in individual_results:
+            if result['elapsed_time'] > 10:
+                model = result.get('model')
+                if model not in [m[0] for m in slow_models]:
+                    model_times = [r['elapsed_time'] for r in individual_results if r.get('model') == model]
+                    avg_time = sum(model_times) / len(model_times)
+                    if avg_time > 10:
+                        slow_models.append((model, avg_time))
+        
+        if slow_models:
+            recommendations.append(f"{Colors.YELLOW}⚠ Some models are slower than expected:{Colors.ENDC}")
+            for model, avg_time in slow_models:
+                recommendations.append(f"   - {model}: {avg_time:.1f}s average")
+            recommendations.append("   - Consider using smaller quantizations (Q4_0 instead of Q5_0)")
+            recommendations.append("   - Check if models are competing for GPU memory")
+    
+    if not recommendations:
+        recommendations.append(f"{Colors.GREEN}✓ Performance looks good!{Colors.ENDC}")
+        recommendations.append("   - All models performing within expected ranges")
+        recommendations.append("   - Keep-alive appears to be working effectively")
+    
+    for rec in recommendations:
+        print(f"  {rec}")
+    
+    print()
+
+
+def print_summary(results: list, rapid_results: list, model_info_cache: Dict[str, Dict[str, Any]]):
     """Print performance summary with enhanced benchmarking metrics."""
     print_header("Performance Summary")
     
@@ -485,16 +1318,19 @@ def print_summary(results: list, rapid_results: list, model_info: Optional[Dict[
         print(f"{Colors.RED}No test results available{Colors.ENDC}")
         return
     
+    # Check if results are aggregated
+    is_aggregated = any(r.get('runs') or r.get('iterations') for r in results + rapid_results)
+    iterations = results[0].get('iterations') or results[0].get('runs') if results else None
+    
+    if is_aggregated and iterations:
+        print(f"{Colors.CYAN}Results aggregated from {iterations} iterations (showing mean values){Colors.ENDC}\n")
+    
     # Display model information if available
-    if model_info:
-        print(f"{Colors.BOLD}Model Information:{Colors.ENDC}")
-        print(f"  Model: {model_info.get('name', 'council')}")
-        quantization = model_info.get('quantization')
-        if quantization:
-            print(f"  Quantization: {quantization}")
-        context_size = model_info.get('context_size')
-        if context_size:
-            print(f"  Context Size: {context_size}")
+    if model_info_cache:
+        print(f"{Colors.BOLD}Models Tested:{Colors.ENDC}")
+        for model_name, info in model_info_cache.items():
+            if info:
+                print(f"  {model_name}: {info.get('quantization', 'N/A')} quantization")
         print()
     
     # Multiple query statistics
@@ -576,6 +1412,12 @@ def print_summary(results: list, rapid_results: list, model_info: Optional[Dict[
     print(f"\n{Colors.BOLD}Test Configuration:{Colors.ENDC}")
     print(f"  Prompt length: ~{len(TEST_QUERY_1)} characters (standardized)")
     print(f"  Test queries: 3 consistency + 2 rapid")
+    
+    # Display benchmark table
+    display_benchmark_table(results, rapid_results, model_info_cache)
+    
+    # Print insights and recommendations
+    print_insights(results, rapid_results, model_info_cache)
 
 
 async def main():
@@ -586,17 +1428,17 @@ async def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Basic test (backward compatible)
+  # Basic test (single iteration)
   python3 tests/runtime-core/test_council_performance.py
   
-  # With warmup
+  # With warmup (recommended for accurate benchmarks)
   python3 tests/runtime-core/test_council_performance.py --warmup
   
-  # Export to CSV
-  python3 tests/runtime-core/test_council_performance.py --csv benchmark.csv
+  # Run 5 iterations and aggregate results
+  python3 tests/runtime-core/test_council_performance.py --iterations 5
   
-  # Both warmup and CSV export
-  python3 tests/runtime-core/test_council_performance.py --warmup --csv benchmark.csv
+  # Warmup + multiple iterations
+  python3 tests/runtime-core/test_council_performance.py --warmup --iterations 3
         """
     )
     parser.add_argument(
@@ -605,31 +1447,23 @@ Examples:
         help='Warm up models before benchmarking (recommended for accurate results)'
     )
     parser.add_argument(
-        '--csv',
-        type=str,
-        metavar='FILE',
-        nargs='?',
-        const='',
-        help='Export results to CSV file. If FILE is not specified, uses default: benchmark_YYYYMMDD_HHMMSS.csv'
-    )
-    parser.add_argument(
         '--no-warmup',
         action='store_true',
         help='Explicitly disable warmup (default behavior)'
     )
+    parser.add_argument(
+        '--iterations',
+        type=int,
+        default=1,
+        metavar='N',
+        help='Number of benchmark iterations to run (default: 1). Results will be aggregated and mean values reported.'
+    )
     
     args = parser.parse_args()
     
-    # Determine CSV filename
-    csv_filename = None
-    if args.csv is not None:
-        # --csv was specified
-        if args.csv == '':
-            # --csv without value, use default filename
-            csv_filename = f"benchmark_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
-        else:
-            # --csv with value, use provided filename
-            csv_filename = args.csv
+    if args.iterations < 1:
+        print(f"{Colors.RED}Error: --iterations must be >= 1{Colors.ENDC}")
+        sys.exit(1)
     
     print_header("Ollama Performance Test - User Experience")
     
@@ -638,8 +1472,8 @@ Examples:
     print(f"Ollama URL: {OLLAMA_BASE_URL}")
     if args.warmup:
         print(f"{Colors.CYAN}Warmup: Enabled{Colors.ENDC}")
-    if csv_filename:
-        print(f"{Colors.CYAN}CSV Export: {csv_filename}{Colors.ENDC}")
+    if args.iterations > 1:
+        print(f"{Colors.CYAN}Iterations: {args.iterations} (results will be aggregated){Colors.ENDC}")
     
     # Check service health
     print_section("Pre-flight Checks")
@@ -668,52 +1502,102 @@ Examples:
     print(f"   Council models: {len(council_models)}")
     print(f"   Chairman: {chairman_model if chairman_model else '(not set)'}")
     
-    # Get model information (try to get info for chairman model as representative)
-    model_info = None
+    # Collect all models to test: individual models + council composite
+    models_to_test = []
     if chairman_model:
-        try:
-            model_info = await get_ollama_model_info(chairman_model)
-        except Exception:
-            # Silently continue if model info fetch fails (API may not be available)
-            # Model info is optional for test execution
-            pass
+        models_to_test.append(chairman_model)
+    models_to_test.extend(council_models)
+    # Add council composite test at the end
+    models_to_test.append('council')
     
-    # Warmup if requested
+    # Remove duplicates while preserving order
+    seen = set()
+    models_to_test = [m for m in models_to_test if m not in seen and not seen.add(m)]
+    
+    print(f"\n{Colors.CYAN}Models to benchmark: {len(models_to_test)}{Colors.ENDC}")
+    for i, model in enumerate(models_to_test, 1):
+        print(f"  {i}. {model}")
+    
+    # Pre-fetch model information for all models
+    print(f"\n{Colors.CYAN}Fetching model information...{Colors.ENDC}")
+    model_info_cache = {}
+    for model_name in models_to_test:
+        if model_name != 'council':
+            try:
+                info = await get_ollama_model_info(model_name)
+                model_info_cache[model_name] = info
+                quant_str = info.get('quantization') or 'N/A'
+                ctx_val = info.get('context_size')
+                ctx_str = str(ctx_val) if ctx_val else 'default'
+                print(f"  {Colors.GREEN}✓{Colors.ENDC} {model_name} (quant: {quant_str}, ctx: {ctx_str})")
+            except Exception as e:
+                # Silently continue if model info fetch fails
+                model_info_cache[model_name] = None
+                print(f"  {Colors.YELLOW}⚠{Colors.ENDC} {model_name} (info unavailable: {str(e)[:50]})")
+    
+    # Warmup if requested (only once before all iterations)
     if args.warmup and not args.no_warmup:
-        await warmup_model()
+        await warmup_models(models_to_test)
     
-    # Run tests
+    # Collect all results from all iterations
+    all_multiple_results = []
+    all_rapid_results = []
+    
+    # Run tests N times
     print(f"\n{Colors.YELLOW}Starting performance tests...{Colors.ENDC}")
-    print(f"{Colors.YELLOW}Note: This simulates real user experience{Colors.ENDC}\n")
+    print(f"{Colors.YELLOW}Testing all models individually + council composite{Colors.ENDC}")
+    if args.iterations > 1:
+        print(f"{Colors.YELLOW}Running {args.iterations} iterations - results will be aggregated{Colors.ENDC}\n")
+    else:
+        print()
     
-    # Test 1: Multiple queries
-    multiple_results = await test_multiple_queries()
+    for iteration in range(1, args.iterations + 1):
+        if args.iterations > 1:
+            print_section(f"Iteration {iteration}/{args.iterations}")
+        
+        # Test 1: Multiple queries
+        multiple_results = await test_multiple_queries(models_to_test)
+        all_multiple_results.extend(multiple_results)
+        
+        # Small delay between test types
+        if iteration < args.iterations:
+            print(f"\n{Colors.CYAN}Waiting 3 seconds before rapid query test...{Colors.ENDC}")
+        else:
+            print(f"\n{Colors.CYAN}Waiting 3 seconds before rapid query test...{Colors.ENDC}")
+        await asyncio.sleep(3)
+        
+        # Test 2: Rapid queries
+        rapid_results = await test_rapid_queries(models_to_test)
+        all_rapid_results.extend(rapid_results)
+        
+        # Delay between iterations (except after last)
+        if iteration < args.iterations:
+            print(f"\n{Colors.CYAN}Iteration {iteration} complete. Waiting 5 seconds before next iteration...{Colors.ENDC}\n")
+            await asyncio.sleep(5)
     
-    # Small delay
-    print(f"\n{Colors.CYAN}Waiting 3 seconds before rapid query test...{Colors.ENDC}")
-    await asyncio.sleep(3)
-    
-    # Test 2: Rapid queries
-    rapid_results = await test_rapid_queries()
-    
-    # Print summary
-    print_summary(multiple_results, rapid_results, model_info)
-    
-    # Export to CSV if requested
-    if csv_filename:
-        export_to_csv(multiple_results, rapid_results, model_info, csv_filename)
+    # Aggregate results if multiple iterations
+    if args.iterations > 1:
+        print_section("Aggregating Results")
+        print(f"Aggregating results from {args.iterations} iterations...")
+        aggregated_multiple, aggregated_rapid = aggregate_by_test_type(all_multiple_results, all_rapid_results)
+        
+        # Add iteration info to aggregated results
+        for result in aggregated_multiple + aggregated_rapid:
+            result['iterations'] = args.iterations
+        
+        # Print summary with aggregated results
+        print_summary(aggregated_multiple, aggregated_rapid, model_info_cache)
+    else:
+        # Single iteration - use results as-is
+        print_summary(multiple_results, rapid_results, model_info_cache)
     
     print_header("Test Complete")
     print(f"Test completed: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     print(f"\n{Colors.CYAN}Next steps:{Colors.ENDC}")
-    print(f"  1. Review performance summary above")
-    if csv_filename:
-        print(f"  2. Review CSV export: {csv_filename}")
-        print(f"  3. Check GPU memory: nvidia-smi")
-    else:
-        print(f"  2. Check GPU memory: nvidia-smi")
-        print(f"  3. Check Ollama logs: docker logs ollama")
-        print(f"  4. Adjust OLLAMA_MAX_LOADED_MODELS if needed")
+    print(f"  1. Review performance summary, benchmark table, and insights above")
+    print(f"  2. Check GPU memory: nvidia-smi")
+    print(f"  3. Check Ollama logs: docker logs ollama")
+    print(f"  4. Follow recommendations in the insights section")
 
 
 if __name__ == "__main__":

--- a/tests/runtime-core/test_council_performance_README.md
+++ b/tests/runtime-core/test_council_performance_README.md
@@ -1,6 +1,6 @@
 # User-Focused Performance Test with Benchmarking Metrics
 
-This test script simulates the **real user experience** by testing the council API from outside the container, exactly as users would interact with it. It includes professional benchmarking metrics like tokens/second, model information, and CSV export capabilities.
+This test script simulates the **real user experience** by testing the council API from outside the container, exactly as users would interact with it. It includes professional benchmarking metrics like tokens/second, model information, and aggregated results from multiple iterations.
 
 ## What It Tests
 
@@ -28,17 +28,17 @@ This test script simulates the **real user experience** by testing the council A
 **Use the wrapper script** - it handles all setup automatically:
 
 ```bash
-# Basic test (backward compatible)
+# Basic test (single iteration)
 ./tests/runtime-core/run_test.sh
 
 # With warmup (recommended for accurate benchmarks)
 ./tests/runtime-core/run_test.sh --warmup
 
-# Export results to CSV
-./tests/runtime-core/run_test.sh --csv benchmark.csv
+# Run multiple iterations and aggregate results
+./tests/runtime-core/run_test.sh --iterations 5
 
-# Both warmup and CSV export
-./tests/runtime-core/run_test.sh --warmup --csv benchmark.csv
+# Warmup + multiple iterations (recommended for reliable benchmarks)
+./tests/runtime-core/run_test.sh --warmup --iterations 3
 
 # Show help
 ./tests/runtime-core/run_test.sh --help
@@ -67,8 +67,8 @@ uv run python ../tests/runtime-core/test_council_performance.py [OPTIONS]
 ### Command-Line Options
 
 - `--warmup`: Warm up models before benchmarking (recommended for accurate results)
-- `--csv [FILE]`: Export results to CSV file. If FILE is not specified, uses default: `benchmark_YYYYMMDD_HHMMSS.csv`
 - `--no-warmup`: Explicitly disable warmup (default behavior)
+- `--iterations N`: Run benchmark N times and report mean values (default: 1). Results will be aggregated and mean values with standard deviation will be displayed.
 - `--help` or `-h`: Show help message
 
 ## What to Expect
@@ -85,9 +85,10 @@ uv run python ../tests/runtime-core/test_council_performance.py [OPTIONS]
 
 For accurate benchmarks:
 1. **Use warmup**: Run with `--warmup` flag to pre-load models
-2. **Disable other workloads**: Ensure no other processes are using GPU
-3. **Consistent prompts**: Test uses standardized prompt length (~50 chars)
-4. **Multiple runs**: Run several times and compare CSV exports
+2. **Use multiple iterations**: Run with `--iterations 3` or more to get aggregated mean values and reduce impact of outliers
+3. **Disable other workloads**: Ensure no other processes are using GPU
+4. **Consistent prompts**: Test uses standardized prompt length (~50 chars)
+5. **Review aggregated results**: When using `--iterations`, the output shows mean values ± standard deviation for more reliable measurements
 
 ### Performance Indicators
 
@@ -111,26 +112,26 @@ The test measures **real user experience** - the time from when a user sends a r
 ### Key Metrics
 
 - **Elapsed Time**: Total time for complete council workflow (Stage 1 → Stage 2 → Stage 3)
+  - When using `--iterations`, shows mean ± standard deviation (e.g., `12.34±1.23`)
 - **Tokens/Second**: Token generation speed (completion_tokens / elapsed_time)
 - **Token Breakdown**: Prompt tokens vs completion tokens
 - **Consistency**: Variation between multiple queries (lower is better)
 - **Keep-Alive**: Improvement on rapid queries (faster second query = models stayed loaded)
 - **Model Information**: Model name, quantization level, context size (if available)
+- **Performance Score**: At-a-glance performance metric (0-200 for individual models, 0-100 for council)
+- **Runs**: Number of successful test runs included in aggregated results (when using `--iterations`)
 
-### CSV Export Format
+### Aggregated Results (Multiple Iterations)
 
-When using `--csv`, the output includes:
-- `timestamp`: When the test was run
-- `model`: Model name (e.g., "council")
-- `quantization`: Quantization level (e.g., "q4_0", "q5_0")
-- `context_size`: Model context size (if available)
-- `prompt_tokens`: Number of prompt tokens
-- `completion_tokens`: Number of completion tokens
-- `total_tokens`: Total tokens used
-- `elapsed_seconds`: Response time in seconds
-- `tokens_per_second`: Token generation speed
-- `query_number`: Query sequence number
-- `test_type`: "consistency" or "rapid"
+When using `--iterations N`, the benchmark:
+- Runs all tests N times
+- Aggregates results by model and test type
+- Calculates mean values for all metrics
+- Computes standard deviation for elapsed time
+- Shows min/max ranges in insights
+- Displays aggregated results in the benchmark table with "Runs" column showing the number of successful runs
+
+This provides more reliable performance measurements by averaging across multiple iterations, reducing the impact of outliers and variability.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #342

## Changes
- [x] Add --iterations command-line argument to test_council_performance.py
- [x] Implement aggregation functions for consistency and rapid tests
- [x] Update display functions to show aggregated results with mean Â± std dev
- [x] Add Runs column to benchmark table when using iterations
- [x] Update run_test.sh wrapper script to support --iterations option
- [x] Update README.md files with new feature documentation
- [x] Remove CSV export references from documentation

## Summary
Adds ability to run performance benchmark multiple times and report aggregated mean results with standard deviation. This provides more reliable performance measurements by averaging across multiple iterations, reducing the impact of outliers and variability.

## Testing
- Verified benchmark runs correctly with --iterations 3
- Confirmed aggregation calculates mean values correctly
- Verified standard deviation is displayed properly in format: meanÂ±std_dev
- Confirmed all documentation is updated and consistent