### PR TITLE
Fix for Commented-out code

### DIFF
--- a/tests/runtime-core/test_council_performance.py
+++ b/tests/runtime-core/test_council_performance.py
@@ -185,16 +185,6 @@ async def get_ollama_model_info(model_name: str) -> Dict[str, Any]:
                         if q_match:
                             quantization = q_match.group(1)
                 
-                # Debug: Print what we found (can be removed later)
-                # Uncomment to debug context_size extraction:
-                # if context_size is None:
-                #     print(f"DEBUG: Model {model_name} - modelfile type: {type(modelfile)}")
-                #     if isinstance(modelfile, str):
-                #         print(f"DEBUG: Modelfile preview: {modelfile[:500]}")
-                #     print(f"DEBUG: Data keys: {list(data.keys())}")
-                #     print(f"DEBUG: Parameters: {data.get('parameters')}")
-                #     print(f"DEBUG: Details: {data.get('details')}")
-                
                 info = {
                     'name': model_name,
                     'quantization': quantization,


### PR DESCRIPTION
In general, the way to fix "commented-out code" issues is to either (a) delete the commented code if it is no longer needed, or (b) turn it into proper code behind a configuration/verbosity flag or into descriptive comments that do not look like executable code. This preserves readability and avoids maintaining dead, non-executed logic.

For this case, the simplest non-functional fix is to remove the block of commented-out debug `if` + `print` statements under the "Debug: Print what we found (can be removed later)" comment. The surrounding logic for computing `info` and caching it is unaffected, and there is no reference to this debug snippet elsewhere, so its removal will not change runtime behavior. Specifically, in `tests/runtime-core/test_council_performance.py`, delete lines 188–196 (the debug block with commented-out `if context_size is None:` and subsequent `print` statements), leaving the rest of the function intact. No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._