### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/runtime-core/test_council_performance.py
+++ b/tests/runtime-core/test_council_performance.py
@@ -28,7 +28,6 @@ import argparse
 import asyncio
 import httpx
 import json
-import os
 import sys
 import time
 from typing import Dict, Optional, List, Any


### PR DESCRIPTION
To fix an unused-import issue, the general remedy is to remove the import statement if the module really is not used, or to add actual uses of the module if it was intended to be used but the code is incomplete. Here, the simplest and safest way to fix the problem without changing existing functionality is to delete the `import os` line, because nothing in the shown code depends on it, and unused imports have no side effects for the `os` module.

Concretely, in `tests/runtime-core/test_council_performance.py`, remove line 31: `import os`. No other changes are necessary. There is no need to add any new imports, methods, or definitions, and removing this line will not impact runtime behavior since the module was never referenced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._