### PR TITLE
Clarify model examples comment in usage documentation (#349)

### DIFF
--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -115,7 +115,7 @@ Shows:
 # List current models
 ./aixcl models list
 
-# Add new model (examples)
+# Add example starter models
 ./aixcl models add deepseek-coder:1.3b    # Small, fast chairman
 ./aixcl models add codegemma:2b            # Small council member
 ./aixcl models add qwen2.5-coder:3b        # Small council member


### PR DESCRIPTION
Fixes #349

## Changes
- [x] Updated comment in docs/user/usage.md to clarify that listed models are recommended starter models
- [x] Changed from examples to example starter models for better clarity

## Testing
- Verified documentation change displays correctly