### PR TITLE
Fix missing sys import in council members test (#358)

### DIFF
--- a/tests/runtime-core/test_council_members.py
+++ b/tests/runtime-core/test_council_members.py
@@ -5,6 +5,7 @@ Tests each council model and the chairman model with a simple query.
 """
 
 import asyncio
+import sys
 import httpx
 from typing import Dict, List, Optional
 


### PR DESCRIPTION
Fixes #358

## Changes
- [x] Added missing import sys statement to test_council_members.py
- [x] Fixes NameError that occurred when test completed successfully

## Testing
- Verified import is now present
- Test should now exit cleanly with proper exit code