### PR TITLE
Update Open WebUI to v0.7.2 (#372)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       start_period: 30s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.6.43
+    image: ghcr.io/open-webui/open-webui:v0.7.2
     container_name: open-webui
     pull_policy: always
     volumes:


### PR DESCRIPTION
Fixes #372

## Changes
- [x] Updated Open WebUI image version in services/docker-compose.yml
- [x] Changed from ghcr.io/open-webui/open-webui:v0.6.43 to ghcr.io/open-webui/open-webui:v0.7.2

## Testing
- [x] Verified Open WebUI starts correctly with new version (stack status shows healthy)
- [x] Tested basic functionality - stack deployment successful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Upgrade Open WebUI container image**
> 
> - Bumps `open-webui` service image in `services/docker-compose.yml` from `v0.6.43` to `v0.7.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2ae2107df27c96e0a1629b447e3b78eae80bfa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->