### PR TITLE
Fix double-save of assistant response in chat_completions (#388)

### DIFF
--- a/llm-council/backend/main.py
+++ b/llm-council/backend/main.py
@@ -829,23 +829,9 @@ Please provide a helpful response based on the context provided above."""
             )
         
         # Non-streaming response
+        # Note: Database save already handled above (before streaming decision)
         response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
         created_time = int(time.time())
-        
-        # Save assistant response to database if enabled
-        if ENABLE_DB_STORAGE and conversation_id:
-            stage_data = {
-                "stage1": stage1_results,
-                "stage2": stage2_results,
-                "stage3": stage3_result,
-            }
-            await db_storage.add_message_to_conversation(
-                conversation_id,
-                "assistant",
-                final_content,
-                stage_data
-            )
-            print(f"DEBUG: Saved assistant message to conversation {conversation_id}", flush=True)
         
         # Create OpenAI-compatible response
         response = ChatCompletionResponse(


### PR DESCRIPTION
Fixes #388

## Changes
- [x] Removed duplicate database save in the non-streaming path of `chat_completions` endpoint
- [x] Added clarifying comment noting the save is handled before the streaming decision

## Problem
The assistant response was saved to the database twice for non-streaming requests:
1. Unconditionally at line ~708 (before streaming decision) - handles both paths
2. Again at line ~836 (non-streaming path only) - duplicate

This caused duplicate records in the `continue` database for every non-streaming chat completion.

## Fix
Removed the redundant save block in the non-streaming path (lines ~836-848), since the earlier unconditional save at lines ~706-732 already correctly handles both streaming and non-streaming cases.

## Testing
- Verify non-streaming requests save exactly one assistant message to the database
- Verify streaming requests continue to save exactly one assistant message
- Verify the `/v1/chat/completions` endpoint returns correct responses for both modes

Made with [Cursor](https://cursor.com)