### PR TITLE
Clarify Continue plugin omission from RUNTIME_CORE_SERVICES (#398)

### DIFF
--- a/cli/lib/profile.sh
+++ b/cli/lib/profile.sh
@@ -5,7 +5,9 @@
 # Valid profiles array
 VALID_PROFILES=(usr dev ops sys)
 
-# Runtime core services (always present in all profiles)
+# Runtime core services managed by Docker Compose (always present in all profiles).
+# Note: Continue is also part of the architectural runtime core (see 00_invariants.md)
+# but is a VS Code plugin, not a Docker-managed service, so it is not listed here.
 RUNTIME_CORE_SERVICES=(ollama llm-council)
 
 # Profile descriptions
@@ -16,8 +18,10 @@ declare -A PROFILE_DESCRIPTIONS=(
     [sys]="System-oriented (complete stack with automation)"
 )
 
-# Profile service mappings
-# Each profile includes runtime core services plus profile-specific services
+# Profile service mappings (Docker-managed services only)
+# Each profile includes runtime core services plus profile-specific services.
+# Continue (VS Code plugin) is part of the runtime core architecture but is
+# not managed by Docker Compose and therefore not listed in these mappings.
 declare -A PROFILE_SERVICES=(
     [usr]="ollama llm-council postgres"
     [dev]="ollama llm-council open-webui postgres pgadmin"

--- a/docs/architecture/governance/00_invariants.md
+++ b/docs/architecture/governance/00_invariants.md
@@ -33,14 +33,16 @@ Do **not** attempt to generalize or abstract the runtime core.
 
 The following components **always** form the AIXCL runtime core:
 
-- Ollama
-- LLM-Council
-- Continue
+- **Ollama** - LLM inference engine (Docker-managed service)
+- **LLM-Council** - Multi-model orchestration (Docker-managed service)
+- **Continue** - AI-powered code assistance (VS Code plugin, not Docker-managed)
 
 These components are:
 - Always enabled
 - Always present in every profile
 - Never optional
+
+> **Note:** Continue is a client-side VS Code plugin that connects to LLM-Council via the OpenAI-compatible API. It is not managed by Docker Compose and therefore does not appear in the `RUNTIME_CORE_SERVICES` array or profile service mappings. The Docker-managed runtime core services are Ollama and LLM-Council.
 
 Any change that removes, replaces, or conditionally disables these components is considered **architecturally breaking**.
 

--- a/docs/architecture/governance/02_profiles.md
+++ b/docs/architecture/governance/02_profiles.md
@@ -6,9 +6,13 @@ Profiles define **which operational services are enabled** alongside the **alway
 
 ## 1. Runtime Core (Always Enabled)
 
-- Ollama
-- LLM-Council
-- Continue
+The runtime core consists of three components:
+
+- **Ollama** - LLM inference engine (Docker-managed service)
+- **LLM-Council** - Multi-model orchestration (Docker-managed service)
+- **Continue** - AI-powered code assistance (VS Code plugin, not Docker-managed)
+
+Continue is a client-side IDE plugin that connects to LLM-Council via the OpenAI-compatible API. Because it runs inside VS Code rather than as a Docker container, it is not included in the `RUNTIME_CORE_SERVICES` array or `PROFILE_SERVICES` mappings in `cli/lib/profile.sh`.
 
 Note: Runtime persistence is provided by PostgreSQL as an operational service in all current profiles.
 


### PR DESCRIPTION
## Summary

Fixes #398

- [x] Add clarifying comments to `cli/lib/profile.sh` explaining why Continue is absent from `RUNTIME_CORE_SERVICES` and `PROFILE_SERVICES` (it is a VS Code plugin, not a Docker-managed service)
- [x] Update `00_invariants.md` to distinguish Docker-managed runtime core services (Ollama, LLM-Council) from client-side runtime core components (Continue plugin)
- [x] Update `02_profiles.md` with the same distinction and a note about profile service mappings

## Why

The governance docs list Continue as runtime core alongside Ollama and LLM-Council, but the code only lists `(ollama llm-council)` in `RUNTIME_CORE_SERVICES`. This created an apparent discrepancy. The root cause is that Continue is a VS Code extension connecting via API, not a Docker container, so it cannot be managed by Docker Compose. This change documents that distinction explicitly.

## Test plan

- [x] Documentation review for accuracy and consistency across all three files
- [x] `bash -n` syntax check on `cli/lib/profile.sh` passes


Made with [Cursor](https://cursor.com)