### PR TITLE
Improve token usage reporting with actual Ollama counts (#400)

### DIFF
--- a/llm-council/backend/ollama_adapter.py
+++ b/llm-council/backend/ollama_adapter.py
@@ -56,11 +56,16 @@ async def query_model(
             data = response.json()
             
             content = data.get('message', {}).get('content', '')
-            logger.debug("extracted content length = %d", len(content))
+            prompt_eval_count = data.get('prompt_eval_count', 0)
+            eval_count = data.get('eval_count', 0)
+            logger.debug("extracted content length = %d, prompt_tokens = %d, completion_tokens = %d",
+                         len(content), prompt_eval_count, eval_count)
             
             return {
                 'content': content,
-                'reasoning_details': None
+                'reasoning_details': None,
+                'prompt_tokens': prompt_eval_count,
+                'completion_tokens': eval_count,
             }
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Fixes #400

- [x] Extract `prompt_eval_count` and `eval_count` from Ollama API responses in `ollama_adapter.py`
- [x] Propagate `prompt_tokens` and `completion_tokens` through all 3 council stages
- [x] Accumulate total token usage across all stages in `run_full_council()` metadata
- [x] Add `_build_token_usage()` helper that uses actual Ollama counts when available
- [x] Fall back to character-based estimation (~4 chars/token) instead of word-split counting

## Why

The previous implementation used `len(text.split())` (word count) to estimate tokens, which significantly underestimates actual usage. Ollama's API already returns actual token counts (`prompt_eval_count`, `eval_count`) that were being discarded. This change captures and reports them accurately.

## Data flow

```
Ollama API response → ollama_adapter.py (extract counts)
  → council.py stage1/2/3 (preserve per-query counts)
  → run_full_council() metadata (accumulate totals)
  → main.py _build_token_usage() (report in OpenAI response)
```

## Test plan

- [x] Token counts appear in OpenAI-compatible response `usage` field
- [x] Values reflect actual Ollama counts (not word-split estimates)
- [x] Fallback estimation works when Ollama returns zero counts
- [x] Continue plugin displays response without errors


Made with [Cursor](https://cursor.com)
