### PR TITLE
Add Goose CLI agent with GitHub MCP server (#408)

### DIFF
--- a/.continue/mcpServers/github-mcp.yaml
+++ b/.continue/mcpServers/github-mcp.yaml
@@ -1,0 +1,12 @@
+name: GitHub MCP Server
+version: 0.0.1
+schema: v1
+
+mcpServers:
+  - name: GitHub
+    command: npx
+    args:
+      - "-y"
+      - "@modelcontextprotocol/server-github"
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}

--- a/.continue/rules/aixcl-workflow.md
+++ b/.continue/rules/aixcl-workflow.md
@@ -1,0 +1,18 @@
+---
+name: AIXCL Development Workflow
+---
+
+Follow the AIXCL Issue-First Development workflow for all changes:
+
+1. Always create a GitHub issue before starting work using `gh issue create` with appropriate labels and `--assignee sbadakhc`
+2. Create a branch with format `issue-<number>/<description>` from main
+3. Commit using conventional format: `type: Description` with `Fixes #<number>` in the body
+4. Push and create a PR referencing the issue with `gh pr create`
+5. Assign the PR and add labels matching the issue
+
+Use plain text formatting. Use markdown checkboxes `- [x]` instead of Unicode characters.
+PR titles should NOT include colons.
+
+Do not modify runtime core components (Ollama, LLM-Council, Continue).
+Do not introduce dependencies from runtime core to operational services.
+Prefer declarative configuration over imperative logic.

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ build/
 .continue/config.json
 !.continue/config.json.example
 
+# Goose CLI agent
+.goose/
+
 # LLM-Council runtime data
 llm-council-data/
 

--- a/.goosehints
+++ b/.goosehints
@@ -1,0 +1,57 @@
+# AIXCL Project Hints for Goose
+
+## Project Overview
+
+AIXCL is a self-hosted AI development platform with a fixed runtime core (Ollama, LLM-Council, Continue).
+See docs/architecture/governance/ for architectural invariants.
+
+## Development Workflow (MANDATORY)
+
+Follow the Issue-First Development workflow:
+
+1. **Always create an issue first** before starting any work:
+   ```
+   gh issue create --title "Brief description" --body "Description" --label "component:cli" --assignee sbadakhc
+   ```
+
+2. **Create a branch** from main:
+   ```
+   git checkout -b issue-<number>/<short-description>
+   ```
+
+3. **Commit** with conventional format:
+   ```
+   git commit -m "type: Description
+
+   Fixes #<number>"
+   ```
+
+4. **Push and create PR** that references the issue:
+   ```
+   gh pr create --title "Fix Title (#<number>)" --body "Fixes #<number>"
+   gh pr edit <number> --add-assignee sbadakhc --add-label "component:..."
+   ```
+
+## Label Guidelines
+
+- Component: component:runtime-core, component:ollama, component:llm-council, component:cli, component:persistence, component:observability, component:ui, component:infrastructure, component:testing
+- Priority: P1 (high), P2 (medium), P3 (low)
+- Category: Feature, Fix, Refactor, Maintenance, Enhancement
+- Profile: profile:usr, profile:dev, profile:ops, profile:sys
+
+## Commit Types
+
+fix:, feat:, refactor:, docs:, test:, chore:
+
+## Architectural Rules
+
+- Do NOT modify runtime core components (Ollama, LLM-Council, Continue)
+- Do NOT introduce dependencies from runtime core to operational services
+- Prefer declarative configuration over imperative logic
+- Keep changes small and reversible
+
+## Formatting
+
+- Use markdown checkboxes: `- [x]` not Unicode checkmarks
+- PR titles should NOT include colons
+- Keep commit first line under 72 characters

--- a/docs/developer/goose-setup.md
+++ b/docs/developer/goose-setup.md
@@ -1,0 +1,171 @@
+# Goose CLI Agent Setup
+
+Goose is a terminal-based AI agent from [Block](https://github.com/block/goose) that connects to local Ollama models and provides shell command execution, MCP server integration, and configurable permission controls.
+
+This complements the Continue plugin by providing a pure terminal experience for AI-assisted development workflows.
+
+## Prerequisites
+
+- Ollama running locally (part of AIXCL runtime core)
+- Node.js (for the GitHub MCP server via npx)
+- GitHub CLI (`gh`) authenticated
+- A GitHub Personal Access Token with `repo` scope
+
+## Installation
+
+Install the Goose CLI:
+
+```bash
+curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+```
+
+Verify the installation:
+
+```bash
+goose --version
+```
+
+## Configuration
+
+### Goose Global Config
+
+The Goose configuration lives at `~/.config/goose/config.yaml`. The AIXCL setup configures:
+
+- **Provider**: Ollama (local LLM inference)
+- **Model**: `qwen2.5:14b-instruct` (or any Ollama model with tool-calling support)
+- **Mode**: `smart_approve` (auto-approves reads, prompts for writes)
+- **Extensions**:
+  - `developer` (built-in) -- shell access, file editing
+  - `github` (MCP server) -- structured GitHub API operations
+
+### Setting the GitHub Token
+
+Goose reads the GitHub token from the `GITHUB_TOKEN` environment variable. Set it in your shell profile:
+
+```bash
+export GITHUB_TOKEN="ghp_your_token_here"
+```
+
+Or use the token from `gh` CLI:
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+```
+
+### Project-Level Configuration
+
+The `.goosehints` file in the project root provides AIXCL-specific guidance to Goose, including:
+
+- Issue-first development workflow
+- Label guidelines
+- Commit message format
+- Architectural invariants
+
+## Usage
+
+### Starting a Session
+
+Navigate to the AIXCL project directory and start a Goose session:
+
+```bash
+cd /path/to/aixcl
+goose session
+```
+
+### Example Workflows
+
+**Create an issue and start working on it:**
+```
+Create a GitHub issue for fixing the logging format in the CLI,
+then create a branch and start implementing the fix.
+```
+
+**Review and triage issues:**
+```
+List all open issues and summarize them by component label.
+```
+
+**Create a PR for current changes:**
+```
+Create a pull request for the current branch referencing issue #123.
+```
+
+### Permission Modes
+
+Goose supports four permission modes:
+
+| Mode | Description |
+|------|-------------|
+| `auto` | Full autonomy -- no confirmation needed |
+| `smart_approve` | Auto-approves reads, confirms writes (recommended) |
+| `approve` | Confirms all tool usage |
+| `chat` | Conversation only, no tool execution |
+
+Change mode mid-session:
+```
+/mode smart_approve
+```
+
+### Adding Extensions Mid-Session
+
+Enable the GitHub extension for a single session:
+```bash
+goose session --with-extension "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_TOKEN} npx -y @modelcontextprotocol/server-github"
+```
+
+## Model Recommendations
+
+For tool-calling workflows (issues, PRs, shell commands), use models with strong function-calling support:
+
+| Model | Tool Calling | Notes |
+|-------|-------------|-------|
+| `qwen2.5:14b-instruct` | Good | Recommended default |
+| `qwen2.5-coder:7b` | Good | Smaller, code-focused |
+| `llama3.1:8b` | Limited | Basic tool support |
+| `gemma3:12b` | Limited | May struggle with complex tool chains |
+
+Models without tool-calling support can only be used in chat mode (`/mode chat`).
+
+## Updating Goose
+
+```bash
+goose update
+```
+
+## Troubleshooting
+
+### Ollama Not Reachable
+
+Ensure Ollama is running:
+```bash
+aixcl start   # starts the AIXCL stack including Ollama
+```
+
+Or start Ollama directly:
+```bash
+ollama serve
+```
+
+### GitHub Token Issues
+
+Verify your token has the required scopes:
+```bash
+gh auth status
+```
+
+Required scopes: `repo`, `read:org` (minimum for issue/PR operations).
+
+### Extension Timeout
+
+If the GitHub MCP server times out, increase the timeout in `~/.config/goose/config.yaml`:
+```yaml
+  github:
+    timeout: 600  # 10 minutes
+```
+
+## Related Documentation
+
+- [Development Workflow](development-workflow.md) -- Issue-first development process
+- [Contributing](contributing.md) -- General contribution guidelines
+- [Goose Documentation](https://block.github.io/goose/docs/getting-started/installation) -- Official Goose docs
+- [MCP Protocol](https://modelcontextprotocol.io/introduction) -- Model Context Protocol specification


### PR DESCRIPTION
Fixes #408

## Changes
- [x] Add Goose CLI agent setup for terminal-based LLM workflows via Ollama
- [x] Configure GitHub MCP server extension for structured GitHub operations (issues, PRs, labels)
- [x] Add Continue MCP server config for GitHub integration (shared MCP approach)
- [x] Add Continue rules file encoding the issue-first development workflow
- [x] Add .goosehints for project-level Goose guidance (workflow, labels, architectural rules)
- [x] Update .gitignore for Goose runtime data (.goose/)
- [x] Add developer setup documentation (docs/developer/goose-setup.md)

## Testing
- Verified Goose CLI v1.23.2 installs and runs on Linux (WSL2)
- Goose global config sets Ollama provider, smart_approve mode, and GitHub MCP extension
- Continue MCP server config follows documented YAML schema
- Continue permissions configured with read-allow/write-ask/delete-exclude tiers

## Additional Notes
- Goose is a client-side tool connecting to the runtime core (like Continue), not a Docker-managed service
- smart_approve mode auto-approves read operations, prompts for write operations
- Models require tool-calling support for MCP integration (qwen2.5:14b-instruct recommended)
- GitHub token sourced from GITHUB_TOKEN environment variable

Made with [Cursor](https://cursor.com)