### PR TITLE
Add Continue CLI (cn) setup with Ollama and developer workflow agent (#412)

### DIFF
--- a/.continue/agents/developer-workflow.md
+++ b/.continue/agents/developer-workflow.md
@@ -1,0 +1,76 @@
+---
+name: Developer Workflow
+description: Runs the AIXCL issue-first developer workflow end-to-end (issue, branch, commit, PR, assign and label).
+---
+
+You orchestrate the full AIXCL development workflow from this repository. Follow `docs/developer/development-workflow.md` exactly. Use only plain text (markdown checkboxes `- [x]`, no Unicode checkmarks or emoji). Do not use colons in issue or PR titles (e.g. "Fix CLI error" not "Fix: CLI error").
+
+## Workflow steps (in order)
+
+1. **Create an issue** (always first)
+2. **Create a branch** from `main`
+3. **Make changes and commit** (conventional commit, reference issue)
+4. **Push and create PR** (link issue, then assign and add matching labels)
+5. **Review and merge** (human step; you only remind)
+
+You may run one step at a time and wait for the user to say "next" or "do step 2", or run several steps in sequence when the user asks (e.g. "create issue and branch"). When the user describes work (e.g. "add docs for Continue CLI"), infer a good issue title, body, and labels unless they specify them.
+
+## Step 1 – Create issue
+
+- Get assignee: `gh api user -q .login` (or `gh auth status`).
+- Build: `gh issue create --title "..." --body "..." --label "..." --assignee <login>`.
+- **Title:** Short, descriptive; no colon. Add **Type:** Bug / Feature / Task in the body and remind user to set type in GitHub UI.
+- **Labels:** Comma-separated. Always include at least one component (e.g. `component:cli`, `component:ollama`). Add priority/profile/category as appropriate (see Label Guidelines in the workflow doc). Do not create or use a "Task" label; Task is an issue type only.
+- After creation, output the new issue number and URL. Use this number for branch name and for "Fixes #N" in commits and PR.
+
+## Step 2 – Create branch
+
+- Ensure repo is clean or user has committed/stashed: `git status`.
+- `git fetch origin main && git checkout main && git pull origin main`.
+- Branch name: `issue-<number>/<short-description>` (e.g. `issue-412/add-continue-cli-docs`), or `feature/<name>`, `fix/<name>`, `refactor/<name>`.
+- `git checkout -b <branch-name>`.
+
+## Step 3 – Make changes and commit
+
+- User makes edits (you may help with file edits if asked). When ready to commit:
+- `git add <files>` (or `git add .` if appropriate).
+- Commit message format:
+  ```
+  type: Brief description
+
+  - Point 1
+  - Point 2
+
+  Fixes #<issue-number>
+  ```
+- Use types: `fix:`, `feat:`, `refactor:`, `docs:`, `test:`, etc. First line under 72 characters.
+- Run: `git commit -m "..."` (use -m for first line and -m for body so Fixes #N is in body).
+
+## Step 4 – Push and create PR
+
+- `git push -u origin <branch-name>`.
+- PR title: reference the issue without colon, e.g. `Fix Title (#<number>)` or `Add Continue CLI setup (#412)`.
+- PR body: start with `Fixes #<number>` or `Addresses #<number>`, then e.g.:
+  ```markdown
+  ## Changes
+  - [x] Change one
+  - [x] Change two
+  ## Testing
+  - ...
+  ```
+- Run: `gh pr create --title "..." --body "..."`.
+- Then assign and add the same labels as the issue: `gh pr edit <pr-number> --add-assignee <login> --add-label "component:cli" ...` (repeat --add-label for each label used on the issue).
+
+## Step 5 – Review and merge
+
+- Remind the user to review, address feedback, and merge via GitHub UI or CLI.
+
+## Label reference (from workflow doc)
+
+- **Component (at least one):** `component:runtime-core`, `component:ollama`, `component:llm-council`, `component:persistence`, `component:observability`, `component:ui`, `component:cli`, `component:infrastructure`, `component:testing`
+- **Priority (optional):** `priority:high`, `priority:medium`, `priority:low`
+- **Profile:** `profile:usr`, `profile:dev`, `profile:ops`, `profile:sys`
+- **Category:** `Fix`, `Enhancement`, `Refactor`, `Maintenance`, `documentation`
+- **Other:** `dependencies`, `good first issue`, `help wanted`, `question`
+
+When the user says what they want to work on, propose the issue title, body snippet, and labels, then run step 1. Proceed to later steps only when the user confirms or asks for the next step.

--- a/.continue/cli-ollama.yaml
+++ b/.continue/cli-ollama.yaml
@@ -1,0 +1,36 @@
+# Continue CLI config for AIXCL: Ollama-only, agentic mode (no LLM-Council).
+# Use: cn --config .continue/cli-ollama.yaml
+# Models: qwen3-coder:latest, glm-4.7-flash:latest (must be pulled in Ollama).
+
+name: AIXCL CLI (Ollama)
+version: 1.0.0
+schema: v1
+
+models:
+  - name: Qwen3 Coder
+    provider: ollama
+    model: qwen3-coder:latest
+    capabilities:
+      - tool_use
+    roles:
+      - chat
+      - edit
+      - apply
+      - summarize
+
+  - name: GLM-4.7 Flash
+    provider: ollama
+    model: glm-4.7-flash:latest
+    capabilities:
+      - tool_use
+    roles:
+      - chat
+      - edit
+      - apply
+      - summarize
+
+context:
+  - provider: code
+  - provider: docs
+  - provider: diff
+  - provider: terminal

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Documentation for end users and operators:
 Documentation for contributors and developers:
 - [`contributing.md`](developer/contributing.md) - Contribution guidelines
 - [`development-workflow.md`](developer/development-workflow.md) - Development workflow and best practices
+- [`continue-cli-setup.md`](developer/continue-cli-setup.md) - Continue CLI (cn) with Ollama and agentic mode
 
 ### Operations Documentation (`operations/`)
 Documentation for operations and performance tuning:

--- a/docs/developer/continue-cli-setup.md
+++ b/docs/developer/continue-cli-setup.md
@@ -1,0 +1,83 @@
+# Continue CLI (cn) with Ollama - Agentic Setup
+
+Continue CLI provides a terminal-based agent (TUI and headless) that uses **Ollama only** (no LLM-Council). This setup targets agentic workflows with tool-capable models.
+
+## Prerequisites
+
+- **Ollama** running and reachable (e.g. AIXCL stack: `./aixcl stack start`).
+- Models pulled in Ollama: `qwen3-coder:latest`, `glm-4.7-flash:latest` (or add via `./aixcl models add qwen3-coder:latest glm-4.7-flash:latest`).
+- **Node.js 20+** for installing the CLI.
+
+## Install Continue CLI
+
+```bash
+# Option A: install script
+curl -fsSL https://raw.githubusercontent.com/continuedev/continue/main/extensions/cli/scripts/install.sh | bash
+
+# Option B: npm (Node 20+)
+npm i -g @continuedev/cli
+```
+
+Verify: `cn --version` and `which cn`.
+
+## Configuration
+
+AIXCL provides an Ollama-only config with agentic models and `tool_use`:
+
+- **Config file:** `.continue/cli-ollama.yaml`
+- **Models:** `qwen3-coder:latest`, `glm-4.7-flash:latest` (must exist in Ollama)
+- **Agent mode:** Config sets `capabilities: [tool_use]` for both models.
+
+**Important:** Use an **absolute path** for `--config` so the CLI finds the file:
+
+```bash
+cn --config /absolute/path/to/aixcl/.continue/cli-ollama.yaml
+```
+
+From the AIXCL repo root you can use:
+
+```bash
+cn --config "$(pwd)/.continue/cli-ollama.yaml"
+```
+
+## Running in agentic mode
+
+- **TUI (interactive):** Tools that modify state (e.g. run commands, write files) prompt for approval. Approve when you want the agent to run `gh` or other commands.
+
+  ```bash
+  cn --config "$(pwd)/.continue/cli-ollama.yaml"
+  ```
+
+- **Full auto (all tools allowed without asking):**
+
+  ```bash
+  cn --config "$(pwd)/.continue/cli-ollama.yaml" --auto
+  ```
+
+- **Headless (no TUI):** Use for non-interactive runs. Tools that require confirmation are not available.
+
+  ```bash
+  cn --config "$(pwd)/.continue/cli-ollama.yaml" -p "Your prompt"
+  ```
+
+## Developer workflow agent
+
+A single agent runs the full AIXCL issue-first workflow (create issue, create branch, commit, push, create PR, assign and label):
+
+- **Agent file:** `.continue/agents/developer-workflow.md`
+- **Use:** Run in TUI so you can approve `gh` and `git` tool calls at each step.
+
+From the AIXCL repo root:
+
+```bash
+cn --config "$(pwd)/.continue/cli-ollama.yaml" --agent .continue/agents/developer-workflow.md
+```
+
+Describe the work you want to do (e.g. "add docs for Continue CLI" or "fix the encoding bug"). The agent will propose an issue (title, body, labels), create it, then on your say-so create the branch, and later help with commit message, PR creation, and PR assign/labels. Approve each tool call when prompted. Set the issue type (Feature/Task/Bug) in the GitHub UI after the issue is created if needed.
+
+## Troubleshooting
+
+- **Config not found:** Use an absolute path for `--config` (e.g. `$(pwd)/.continue/cli-ollama.yaml`).
+- **Model not found:** Ensure Ollama is running and the model is pulled: `curl -s http://localhost:11434/api/tags`.
+- **No tool use:** Ensure your config includes `capabilities: [tool_use]` for the model and you are not in headless mode if you need interactive tool approval.
+- **Verbose logs:** `cn --verbose ...`; logs under `~/.continue/logs/cn.log`.

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -236,6 +236,16 @@ gh issue view <number> --json labels
 
 **Example:** If automated PRs #351-355 are merged, create issue #356 documenting them.
 
+## Running the workflow with Continue CLI
+
+A single agent runs this workflow end-to-end (issue, branch, commit, PR, assign and label). Use it from the repo root with Continue CLI and approve `gh`/`git` tool calls when prompted:
+
+```bash
+cn --config "$(pwd)/.continue/cli-ollama.yaml" --agent .continue/agents/developer-workflow.md
+```
+
+See [continue-cli-setup.md](./continue-cli-setup.md) for install and config.
+
 ## AI Assistant Instructions
 
 When working with AI assistants (like Cursor, GitHub Copilot, etc.), include this prompt:


### PR DESCRIPTION
Fixes #412

## Changes
- [x] Add `.continue/cli-ollama.yaml` for Ollama-only agentic mode (qwen3-coder, glm-4.7-flash)
- [x] Add single developer-workflow agent for full issue-first workflow (issue, branch, commit, PR, assign/label)
- [x] Add `docs/developer/continue-cli-setup.md` (install, config path, TUI/headless/auto, agent usage)
- [x] Link Continue CLI and agent in `development-workflow.md` and `docs/README.md`

## Testing
- Verified `cn --config <abs-path>/cli-ollama.yaml -p "..."` with Ollama returns response
- Agent file follows workflow doc (labels, no colon in titles, plain text)

Made with [Cursor](https://cursor.com)