### PR TITLE
Clarify runtime persistence and Postgres in governance docs (#418)

### DIFF
--- a/docs/architecture/governance/00_invariants.md
+++ b/docs/architecture/governance/00_invariants.md
@@ -63,7 +63,9 @@ AIXCL services are divided into two categories:
 **Invariants:**
 - Runtime core must be runnable **without** any operational services
 - Operational services may depend on runtime core
-- Runtime core must **never** depend on operational services
+- Runtime core must **never** depend on operational services (monitoring, logging, UI, automation)
+
+**Runtime persistence:** The runtime may use persistence (e.g. for conversation storage) implemented via a shared database. That does not violate the boundary: the prohibition is on depending on operational *capabilities* (observability, UI, automation), not on using the same persistence technology or instance when persistence is a documented runtime requirement.
 
 ---
 

--- a/docs/architecture/governance/service_contracts/runtime/llm-council.md
+++ b/docs/architecture/governance/service_contracts/runtime/llm-council.md
@@ -8,11 +8,11 @@ Coordinates inference requests and orchestrates model calls.
 
 ## Depends On
 - Runtime core (Ollama)
-- Runtime persistence (for Continue conversation storage; may be file-based or database)
+- Runtime persistence (for Continue conversation storage; may be file-based or database; may use the same database instance as operational services, e.g. PostgreSQL)
 
 ## Exposes
 - Aggregated inference results
 - Plugin interface to Continue
 
 ## Must Not Depend On
-- Operational services
+- Operational services (monitoring, logging, UI, automation). Using a shared database for runtime persistence does not violate this; the boundary prohibits dependency on operational *capabilities*, not on the persistence technology.


### PR DESCRIPTION
Fixes #418

## Changes
- [x] `00_invariants.md`: Clarified that runtime may use shared DB for persistence; boundary prohibits dependency on monitoring/logging/UI/automation, not on persistence technology
- [x] `service_contracts/runtime/llm-council.md`: Explicitly allow shared database for runtime persistence; clarify Must Not Depend On refers to operational capabilities

## Testing
- Documentation only; no code changes

Made with [Cursor](https://cursor.com)