### PR TITLE
Fix wrong CLI command in llm-council/TESTING.md (#425)

### DIFF
--- a/llm-council/TESTING.md
+++ b/llm-council/TESTING.md
@@ -4,7 +4,7 @@ This guide explains how to test the PostgreSQL integration for Continue plugin c
 
 ## Prerequisites
 
-1. Services must be running: `./aixcl start`
+1. Services must be running: `./aixcl stack start`
 2. PostgreSQL must be accessible
 3. Environment variables must be set in `.env`:
    - `POSTGRES_USER`
@@ -20,7 +20,7 @@ Test the API endpoints directly:
 
 ```bash
 # 1. Start services
-./aixcl start
+./aixcl stack start
 
 # 2. Wait for services to be ready (about 30 seconds)
 sleep 30
@@ -36,7 +36,7 @@ Test the database connection and operations:
 
 ```bash
 # 1. Start services
-./aixcl start
+./aixcl stack start
 
 # 2. Wait for services to be ready
 sleep 30


### PR DESCRIPTION
Fixes #425

## Changes
- [x] Fix TESTING.md: `./aixcl start` -> `./aixcl stack start` (T1, 3 occurrences)

## Testing
- [x] Verified no remaining `./aixcl start` in llm-council/TESTING.md
- [x] Doc reads correctly in context

## Additional Notes
Part of CLI/docs alignment (checklist item 2).

Made with [Cursor](https://cursor.com)