### PR TITLE
Align manpage with aixcl CLI (#427)

### DIFF
--- a/docs/reference/manpage.txt
+++ b/docs/reference/manpage.txt
@@ -17,22 +17,26 @@ DESCRIPTION
        docs/architecture/governance/ for architectural documentation.
 
 COMMANDS
-       stack start [--profile <profile>]
+       stack start [--profile|-p <profile>]
               Start all services. Uses PROFILE from .env file if set, otherwise
-              shows available profiles. Use --profile to specify a profile explicitly.
+              shows available profiles. Use --profile or -p to specify a profile explicitly.
 
        stack stop
               Stop all services
 
-       stack restart [--profile <profile>]
-              Restart the entire stack. Uses PROFILE from .env file if set,
-              otherwise --profile is required.
+       stack restart [--profile|-p <profile>] [service1] [service2] ...
+              Restart the entire stack or specific services. With no service names,
+              uses PROFILE from .env file if set, otherwise --profile is required.
+              With service names (e.g. ollama llm-council), restarts only those
+              services; profile is not required.
 
        stack status
               Show service status
 
        stack logs [svc] [n]
-              Show logs for all or one service, optional line count
+              Show logs for all services (last 100 lines then follow), or for one
+              service with optional line count n (default 50, range 1-10000),
+              then follow.
 
        stack clean
               Remove unused Docker resources
@@ -50,11 +54,11 @@ COMMANDS
 
               Note: Continue is a VS Code plugin, not a containerized service.
 
-       models <add|remove|list> [name]
+       models <add|remove|list> [name ...]
               Manage LLM models
 
-              add     Add a model
-              remove  Remove a model
+              add     Add one or more models (e.g. models add a b c)
+              remove  Remove one or more models
               list    List installed models
 
        council <configure|status>
@@ -70,11 +74,20 @@ COMMANDS
               openwebui  Open Open WebUI interface
               pgadmin    Open pgAdmin database administration
 
+       continue config
+              Regenerate Continue CLI config from current Ollama models.
+
        utils check-env
               Validate environment setup
 
        utils bash-completion
               Install bash completion support
+
+       check-env
+              Same as utils check-env (top-level alias)
+
+       bash-completion
+              Same as utils bash-completion (top-level alias)
 
        help
               Show help message
@@ -87,6 +100,9 @@ EXAMPLES
 
        Restart a single service:
               aixcl service restart postgres
+
+       Restart specific stack services (no profile needed):
+              aixcl stack restart ollama llm-council
 
        Add a new LLM model:
               aixcl models add phi3
@@ -121,13 +137,15 @@ ENVIRONMENT
               Model used as chairman (synthesizes final response)
 
 FILES
-       ~/.env
-              Main configuration file (automatically created)
+       .env (in project directory)
+              Main configuration file (automatically created in the same
+              directory as the aixcl script, typically the repository root).
+              Not ~/.env.
 
-       ~/.env.example
+       .env.example (in project directory)
               Template configuration file
 
-       ~/.env.local
+       .env.local (in project directory)
               Local overrides (optional, ignored by git)
 
 ARCHITECTURE


### PR DESCRIPTION
Fixes #427

## Changes
- [x] M7: FILES section - project-directory .env, not ~/.env
- [x] M1: Add `continue config` command section
- [x] M3: `stack restart` documents `[--profile|-p <profile>] [service1] [service2] ...`
- [x] M2: Document `-p` for `stack start`
- [x] M4: `stack logs` - default 50, range 1-10000, follow behavior
- [x] M5: `models add|remove` - multiple names
- [x] M6: Top-level `check-env` and `bash-completion`
- [x] Example: `aixcl stack restart ollama llm-council`

## Testing
- [x] Manpage reads correctly; all CLI commands/options reflected
- [x] FILES section describes project-directory .env

## Additional Notes
Checklist items 3-9. Part of CLI/docs alignment.

Made with [Cursor](https://cursor.com)