### PR TITLE
Continue run cn without specifying config path (#442)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1858,26 +1858,22 @@ function continue_config() {
         grep -q "model: AUTODETECT" "$plugin_config" 2>/dev/null && extra="${extra:+$extra, }Autodetect"
         [[ -n "$extra" ]] && echo "Included ${extra} from plugin config."
     fi
-    # Launch Continue CLI with the generated config (replaces current process)
-    exec cn --config "$config_absolute"
+    echo "Use: cn --config ${config_absolute}"
 }
 
 function continue_cmd() {
-    if [[ $# -lt 1 ]]; then
-        echo "Usage: $0 continue {config}"
-        echo "  continue config   - Regenerate Continue CLI config (Ollama + Council/Autodetect from plugin)"
+    # "continue config" = regenerate config; "continue" or "continue -p ..." = run cn with repo config (no path needed)
+    if [[ "$1" == "config" ]]; then
+        continue_config
+        return
+    fi
+    local config_absolute
+    config_absolute="$(cd "$SCRIPT_DIR" && pwd)/.continue/cli-ollama.yaml"
+    if [[ ! -f "$config_absolute" ]]; then
+        echo "Config not found. Run: $0 continue config"
         return 1
     fi
-    case "$1" in
-        config)
-            continue_config
-            ;;
-        *)
-            echo "Error: Unknown continue action '$1'"
-            echo "Usage: $0 continue {config}"
-            return 1
-            ;;
-    esac
+    exec cn --config "$config_absolute" "$@"
 }
 
 function help_menu() {
@@ -1912,8 +1908,9 @@ function help_menu() {
     echo "  council configure                   - Configure council models and chairman"
     echo "  council status                      - Show council configuration and status"
     echo ""
-    echo "Continue CLI: continue <action>"
-    echo "  continue config                    - Regenerate Continue CLI config (Ollama + plugin alignment)"
+    echo "Continue CLI: continue [config] [cn options...]"
+    echo "  continue                            - Run Continue CLI with repo config (no path needed)"
+    echo "  continue config                     - Regenerate Continue CLI config (Ollama + plugin alignment)"
     echo ""
     echo "Dashboard: dashboard <name>"
     echo "  dashboard openwebui                 - Open Open WebUI"


### PR DESCRIPTION
Fixes #442

## Changes
- [x] `./aixcl continue` (no args) runs `cn` with repo `.continue/cli-ollama.yaml` so the config path is not needed.
- [x] `./aixcl continue <cn options>` passes options through to `cn` with repo config (e.g. `-p "prompt"`, `--auto`).
- [x] `./aixcl continue config` only regenerates the config (no CLI launch).
- [x] Help text updated for `continue [config] [cn options...]`.

## Testing
- Run `./aixcl continue`: CLI starts with repo config.
- Run `./aixcl continue config`: config is regenerated only.
- Run `./aixcl continue -p "hello"`: headless run with repo config.

## Additional Notes
- If config file is missing, `./aixcl continue` prints: Config not found. Run: ./aixcl continue config.