### PR TITLE
Remove 'Use: cn --config' line from continue config output (#444)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1858,7 +1858,6 @@ function continue_config() {
         grep -q "model: AUTODETECT" "$plugin_config" 2>/dev/null && extra="${extra:+$extra, }Autodetect"
         [[ -n "$extra" ]] && echo "Included ${extra} from plugin config."
     fi
-    echo "Use: cn --config ${config_absolute}"
 }
 
 function continue_cmd() {


### PR DESCRIPTION
Fixes #444

## Changes
- [x] Remove the "Use: cn --config ..." line from `./aixcl continue config` output

## Testing
- Run `./aixcl continue config`; output shows only update and plugin-include messages.

## Additional Notes
- None

Made with [Cursor](https://cursor.com)