### PR TITLE
Continue command no-args fallback to show usage (#446)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1861,7 +1861,18 @@ function continue_config() {
 }
 
 function continue_cmd() {
-    # "continue config" = regenerate config; "continue" or "continue -p ..." = run cn with repo config (no path needed)
+    # Fallback: no args -> show usage (same as stack, council, etc.)
+    if [[ $# -lt 1 ]]; then
+        echo "Error: continue action or cn options required"
+        echo "Usage: $0 continue {config} [cn options...]"
+        echo "  $0 continue config       - Regenerate Continue CLI config (Ollama + plugin alignment)"
+        echo "  $0 continue --           - Run cn with repo config (interactive TUI)"
+        echo "  $0 continue -p \"prompt\" - Run cn headless with repo config"
+        echo "  $0 continue --auto      - Run cn with repo config (all tools allowed)"
+        echo ""
+        echo "Config file: .continue/cli-ollama.yaml (create with: $0 continue config)"
+        return 1
+    fi
     if [[ "$1" == "config" ]]; then
         continue_config
         return
@@ -1907,9 +1918,10 @@ function help_menu() {
     echo "  council configure                   - Configure council models and chairman"
     echo "  council status                      - Show council configuration and status"
     echo ""
-    echo "Continue CLI: continue [config] [cn options...]"
-    echo "  continue                            - Run Continue CLI with repo config (no path needed)"
+    echo "Continue CLI: continue {config} [cn options...]"
     echo "  continue config                     - Regenerate Continue CLI config (Ollama + plugin alignment)"
+    echo "  continue --                         - Run cn with repo config (interactive TUI)"
+    echo "  continue -p \"prompt\" / --auto      - Pass-through to cn (headless / all tools)"
     echo ""
     echo "Dashboard: dashboard <name>"
     echo "  dashboard openwebui                 - Open Open WebUI"

--- a/docs/developer/continue-cli-setup.md
+++ b/docs/developer/continue-cli-setup.md
@@ -40,6 +40,8 @@ From the AIXCL repo root you can use:
 cn --config "$(pwd)/.continue/cli-ollama.yaml"
 ```
 
+**Using aixcl:** `./aixcl continue` with no arguments shows usage (same fallback as `./aixcl stack` or `./aixcl council`). Use `./aixcl continue config` to regenerate config, `./aixcl continue --` for the interactive TUI, or pass-through options (e.g. `./aixcl continue -p "prompt"`, `./aixcl continue --auto`).
+
 ## Running in agentic mode
 
 - **TUI (interactive):** Tools that modify state (e.g. run commands, write files) prompt for approval. Approve when you want the agent to run `gh` or other commands.


### PR DESCRIPTION
Fixes #446

## Changes
- [x] `./aixcl continue` with no args shows usage and exits 1 (same fallback as stack/council)
- [x] `./aixcl continue config` regenerates config; `./aixcl continue --` runs TUI; pass-through for `-p`, `--auto`
- [x] Updated help menu and docs/developer/continue-cli-setup.md

## Testing
- Ran `./aixcl continue`: exit 1, usage printed
- Ran `./aixcl continue config`: config regenerated
- Verified help menu lists continue options correctly

Made with [Cursor](https://cursor.com)