### PR TITLE
fix(security) secure JSON generation in openwebui.sh (#448)

### DIFF
--- a/scripts/openwebui.sh
+++ b/scripts/openwebui.sh
@@ -40,7 +40,7 @@ else
   # Fallback: use python3 to securely generate JSON payload
   # This prevents injection vulnerabilities from environment variables containing special characters
   if command -v python3 >/dev/null 2>&1; then
-    JSON_PAYLOAD=$(python3 -c "import json, os; print(json.dumps({'email': os.environ.get('OPENWEBUI_EMAIL'), 'password': os.environ.get('OPENWEBUI_PASSWORD'), 'name': 'Admin'}))")
+    JSON_PAYLOAD=$(python3 -c "import json, os; print(json.dumps({'email': os.environ.get('OPENWEBUI_EMAIL', ''), 'password': os.environ.get('OPENWEBUI_PASSWORD', ''), 'name': 'Admin'}))")
     curl \
       -X POST "http://localhost:8080/api/v1/auths/signup" \
       -H "accept: application/json" \


### PR DESCRIPTION
Fixes #448

## Changes
- Replaced insecure manual JSON construction in openwebui.sh with Python one-liner
- Added verification test scripts/security/test_openwebui_json.sh

## Testing
- Verified with new test script: PASSED

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes a startup script’s JSON payload construction and adds a shell test; behavior is mostly the same aside from requiring `jq` or `python3` for secure payload generation.
> 
> **Overview**
> **Hardens `scripts/openwebui.sh` against JSON injection when creating the initial admin user.** If `jq` is unavailable, the script now generates the signup payload via a `python3` `json.dumps` one-liner instead of manual string interpolation, and fails fast when neither `jq` nor `python3` is present.
> 
> Adds `tests/security/test_openwebui_json.sh` to validate the Python fallback produces valid JSON, properly escapes special characters, and serializes unset env vars as empty strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bbdcc9d46976560c0f80b58d30c5d28b12e71cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->