### PR TITLE
Update Open WebUI to v0.8.0 (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed service/container from `llm-council` to `council` across codebase and documentation (Fixes #433). Directory `llm-council/` and volume path `council-data/`; display name "Council". Service contract file `llm-council.md` renamed to `council.md`; script `build_and_push_llm_council.sh` renamed to `build_and_push_council.sh`.
+- Updated Open WebUI to v0.8.0 (Fixes #454)
 
 ---
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       start_period: 30s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.7.2
+    image: ghcr.io/open-webui/open-webui:v0.8.0
     container_name: open-webui
     pull_policy: always
     volumes:


### PR DESCRIPTION
Fixes #454

## Changes
- [x] Updated Open WebUI image version from v0.7.2 to v0.8.0 in docker-compose.yml
- [x] Updated CHANGELOG.md with version change entry

## Testing
- Version update verified in docker-compose.yml
- Changelog entry added to Unreleased section

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple container image version bump plus documentation update; risk is limited to potential upstream Open WebUI behavior changes.
> 
> **Overview**
> Updates the `open-webui` service image in `services/docker-compose.yml` from `v0.7.2` to `v0.8.0`.
> 
> Adds an Unreleased changelog entry noting the Open WebUI version bump (Fixes #454).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a462eaa134eafe148238e3784cf44c997ddcb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->