### PR TITLE
Document Docker socket security trade-offs #450

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -120,6 +120,9 @@ services:
         find /var/lib/pgadmin -type f -exec chmod 644 {} \;
         exec /entrypoint.sh
 
+  # SECURITY NOTE: watchtower requires Docker socket access for automatic updates.
+  # This is equivalent to root access on the host. See docs/reference/security.md
+  # section 6 for details and mitigation options.
   watchtower:
     image: containrrr/watchtower:latest
     container_name: watchtower
@@ -271,6 +274,9 @@ services:
       timeout: 10s
       retries: 3
 
+  # SECURITY NOTE: promtail requires Docker socket access for container log discovery.
+  # This is equivalent to root access on the host. See docs/reference/security.md
+  # section 6 for details and mitigation options.
   promtail:
     image: grafana/promtail:3.3.0
     container_name: promtail


### PR DESCRIPTION
Fixes #450

## Changes
- [x] Added comprehensive Docker socket security documentation
- [x] Created section 6 in security.md covering socket usage
- [x] Documented watchtower and promtail socket requirements
- [x] Added risk assessment for self-hosted deployments
- [x] Documented mitigation options including socket proxy
- [x] Added inline security warnings in docker-compose.yml
- [x] Linked documentation between compose file and security.md

## Security Improvement
This PR documents the security trade-offs of Docker socket mounts rather than implementing complex mitigations, which aligns with AIXCL local-first, self-hosted design philosophy.

## Rationale
- AIXCL is designed for single-node, trusted environments
- Docker socket proxy adds unnecessary complexity for target use case
- Documentation allows informed decision-making by users
- Users in strict environments can choose profiles without these services
