### PR TITLE
docs: Document network_mode: host as intentional architectural choice

### DIFF
--- a/docs/architecture/governance/00_invariants.md
+++ b/docs/architecture/governance/00_invariants.md
@@ -110,7 +110,33 @@ The AIXCL CLI is a **control plane**, not a decision engine.
 
 ---
 
-## 7. Evolution and Enforcement
+## 7. Network Mode (Strict)
+
+AIXCL uses `network_mode: host` for all services.
+
+**Rationale:**
+- AIXCL is designed as a **local-first, single-node platform**
+- `host` networking simplifies service discovery and cross-service communication
+- No need for Docker DNS resolution, port mapping management, or network aliases
+- Provides the "clone and run" experience central to AIXCL's value proposition
+
+**Invariants:**
+- All services use `network_mode: host` by default
+- No custom Docker networks for internal service communication
+- Port configuration is managed at the service level, not via Docker port mappings
+- This is **intentional** and not considered a security vulnerability for AIXCL's target use case
+
+**Security Context:**
+- AIXCL targets developers running on localhost or trusted networks
+- Users have full control over their own infrastructure
+- The alternative (custom Docker networks) adds operational complexity without meaningful security benefit for single-node deployments
+
+**Not a Bug:**
+Issues suggesting to change from `network_mode: host` to custom Docker networks should be closed with reference to this invariant.
+
+---
+
+## 8. Evolution and Enforcement
 
 These invariants are:
 - **Strict for the runtime core**
@@ -118,7 +144,7 @@ These invariants are:
 
 ---
 
-## 8. AI Assistant Guidance (Normative)
+## 9. AI Assistant Guidance (Normative)
 
 AI assistants interacting with this repository must:
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -57,3 +57,57 @@ We thank all security researchers and users who report vulnerabilities. If you w
 
 **Note:** This file is located in `docs/reference/security.md` and should be linked from the main README.
 
+
+## 7. Network Mode Design
+
+### 7.1  is Intentional
+
+AIXCL uses  for all Docker services. This is an **intentional architectural decision**, not a security vulnerability.
+
+### 7.2 Rationale
+
+| Aspect | Design Choice |
+|--------|---------------|
+| **Networking** |  |
+| **Purpose** | Simplified local development |
+| **Target** | Single-node, self-hosted deployments |
+
+**Benefits:**
+- No Docker DNS resolution complexity
+- No port mapping management
+- No network aliases needed
+- Direct localhost access for all services
+- Clone
+
+## 7. Network Mode Design
+
+### 7.1 network_mode: host is Intentional
+
+AIXCL uses network_mode: host for all Docker services. This is an **intentional architectural decision**, not a security vulnerability.
+
+### 7.2 Rationale
+
+| Aspect | Design Choice |
+|--------|---------------|
+| **Networking** | network_mode: host |
+| **Purpose** | Simplified local development |
+| **Target** | Single-node, self-hosted deployments |
+
+**Benefits:**
+- No Docker DNS resolution complexity
+- No port mapping management
+- No network aliases needed
+- Direct localhost access for all services
+- Clone and run simplicity
+
+### 7.3 Security Context
+
+**Not a vulnerability because:**
+- AIXCL is designed for **localhost/trusted network** deployments
+- Users have **full control** over their infrastructure
+- All services run on the **same host**
+- Alternative (custom networks) adds complexity without security benefit for single-node use
+
+### 7.4 Architecture Reference
+
+See docs/architecture/governance/00_invariants.md section 7 for the formal architectural invariant.


### PR DESCRIPTION
- Added section 7 to 00_invariants.md formalizing network_mode: host invariant
- Documented rationale: local-first, single-node, simplicity-focused design
- Added section 7 to security.md explaining why this is not a vulnerability
- Clarified security context for localhost/trusted network deployments
- Linked between architecture and security documentation

Fixes #449
