### PR TITLE
[TASK] Extract LLM Council to standalone repository (#476)

### DIFF
--- a/tests/platform-tests.sh
+++ b/tests/platform-tests.sh
@@ -532,6 +532,7 @@ test_llm_state() {
     # LLM State section no longer checks council configuration (moved to xencon/llm-council)
     print_success "LLM state section complete (council configuration is in xencon/llm-council repo)"
     record_test "pass" "LLM state check complete"
+}
 
 # ============================================================================
 # SECTION 3: DATABASE CONNECTION TESTS


### PR DESCRIPTION
## Summary
Extracted LLM Council to a standalone repository at xencon/llm-council.

## Changes
- Removed council service from docker-compose.yml
- Removed council references from common.sh and profile.sh
- Removed council subcommands and status checks from the aixcl CLI
- Cleaned up README.md and removed council-specific tests

Fixes #476