### PR TITLE
[TASK] Add ShellCheck source directives for environment files

### DIFF
--- a/scripts/db/check_db.sh
+++ b/scripts/db/check_db.sh
@@ -8,6 +8,7 @@
 if [ -f .env ]; then
     set -a
     # shellcheck disable=SC1091
+    # shellcheck source=/dev/null
     source .env
     set +a
 fi

--- a/scripts/db/create_databases.sh
+++ b/scripts/db/create_databases.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [ -f "${SCRIPT_DIR}/.env" ]; then
     set -a
     # shellcheck disable=SC1091
+    # shellcheck source=/dev/null
     source "${SCRIPT_DIR}/.env"
     set +a
 fi

--- a/scripts/db/diagnose_migration.sh
+++ b/scripts/db/diagnose_migration.sh
@@ -8,6 +8,7 @@ set -e
 if [ -f .env ]; then
     set -a
     # shellcheck disable=SC1091
+    # shellcheck source=/dev/null
     source .env
     set +a
 fi

--- a/scripts/db/reset_database.sh
+++ b/scripts/db/reset_database.sh
@@ -6,6 +6,7 @@
 if [ -f .env ]; then
     set -a
     # shellcheck disable=SC1091
+    # shellcheck source=/dev/null
     source .env
     set +a
 fi


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #506

### Description of Changes
Added `source=/dev/null` directives for scripts that source the `.env` file to suppress ShellCheck notes about not being able to find or follow data files. This specifically targets the database scripts that were still reporting these notes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (`task/506-shellcheck-final-polish`)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes
- Performed ShellCheck on `scripts/db/*.sh`.
- Verified that "cannot follow" notes are suppressed.

### Verification
To verify this change is complete:
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (ShellCheck verification)

### Related Issues
- Closes #506
