### PR TITLE
[BUG] Fix CodeQL fatal error by removing unused JavaScript language

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: actions, javascript  # Add your languages
+          languages: actions  # Projects with multiple languages can add them here as a comma-separated list.
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
This PR addresses a fatal error in the CodeQL analysis workflow. The workflow was configured to scan for JavaScript, but since the repository contains no JavaScript or TypeScript source files, CodeQL terminated with an error.

## Changes
- `.github/workflows/codeql.yml`: Removed `javascript` from the `languages` list.

Fixes #515