### PR TITLE
[TASK] Implement 'engine' alias for CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Manage all services as a unified stack:
 ./aixcl stack restart [--profile sys]    # Restart all services (uses PROFILE from .env if set)
 ./aixcl stack status                     # Check service status
 ./aixcl stack logs                       # View logs for all services
-./aixcl stack logs <service>             # View logs for specific service
-./aixcl stack logs <service> 100         # Last 100 lines for a service (default 50, then follow)
+./aixcl stack logs engine                # View logs for the active inference engine
+./aixcl stack logs engine 100            # Last 100 lines for the active engine (default 50, then follow)
 ./aixcl stack clean                      # Remove unused Docker resources
 ```
 
@@ -150,9 +150,10 @@ Manage all services as a unified stack:
 Manage specific services independently:
 
 ```bash
-./aixcl service start postgres    # Start a specific service
-./aixcl service restart <service>  # Restart a service
-./aixcl service stop grafana      # Stop a service
+./aixcl service start engine    # Start the inference engine (active in .env)
+./aixcl restart engine          # Shortcut to restart the active engine
+./aixcl service stop engine     # Stop the inference engine
+./aixcl service start postgres  # Start a specific service
 ```
 
 ### Model Management

--- a/aixcl
+++ b/aixcl
@@ -552,8 +552,14 @@ function restart() {
         
         # Check if any remaining args are valid service names
         for arg in "${remaining_args[@]}"; do
-            if is_valid_service "$arg"; then
-                service_names+=("$arg")
+            # Resolve 'engine' alias to active INFERENCE_ENGINE
+            local service_to_check="$arg"
+            if [[ "$arg" == "engine" ]]; then
+                service_to_check="${INFERENCE_ENGINE:-ollama}"
+            fi
+
+            if is_valid_service "$service_to_check"; then
+                service_names+=("$service_to_check")
             else
                 echo "⚠️  Warning: '$arg' is not a valid service name, ignoring" >&2
             fi
@@ -683,12 +689,18 @@ function start_service() {
     
     local service="$1"
     local force_recreate="${2:-false}"  # Optional second parameter to force recreate
+
+    # Resolve 'engine' alias
+    local actual_service="$service"
+    if [[ "$service" == "engine" ]]; then
+        actual_service=$(get_container_name "engine")
+    fi
     
     # Validate service name
     if ! is_valid_service "$service"; then
         echo "❌ Error: Unknown service '$service'"
         echo ""
-        echo "Runtime Core Services (always enabled): ${INFERENCE_ENGINE:-ollama}"
+        echo "Runtime Core Services (always enabled): engine (${INFERENCE_ENGINE:-ollama})"
         echo "Operational Services (profile-dependent): ${ALL_SERVICES[*]}"
         echo ""
         echo "For service contracts and profiles, see: docs/architecture/governance/service_contracts/"
@@ -709,8 +721,8 @@ function start_service() {
     
     # Remove any existing containers (running or stopped) to avoid ContainerConfig errors
     # This is especially important after rebuilds when docker-compose tries to recreate containers
-    echo "Cleaning up any existing containers for $service..."
-    run_compose rm -f "$service" 2>/dev/null || true
+    echo "Cleaning up any existing containers for $actual_service..."
+    run_compose rm -f "$actual_service" 2>/dev/null || true
     
     # Also remove hash-prefixed containers directly via docker (handles edge cases)
     local hash_prefixed
@@ -747,14 +759,14 @@ function start_service() {
     # Start the specific service
     # Use --force-recreate if explicitly requested (e.g., after a rebuild)
     if [ "$force_recreate" = "true" ]; then
-        if run_compose up -d --force-recreate --no-deps "$service"; then
+        if run_compose up -d --force-recreate --no-deps "$actual_service"; then
             echo "✅ Successfully started service: $service (recreated)"
         else
             echo "❌ Failed to start service: $service"
             return 1
         fi
     else
-        if run_compose up -d "$service"; then
+        if run_compose up -d "$actual_service"; then
             echo "✅ Successfully started service: $service"
         else
             echo "❌ Failed to start service: $service"
@@ -787,13 +799,19 @@ function stop_service() {
     fi
     
     local service="$1"
+
+    # Resolve 'engine' alias
+    local actual_service="$service"
+    if [[ "$service" == "engine" ]]; then
+        actual_service=$(get_container_name "engine")
+    fi
     
     # Validate service name
     if ! is_valid_service "$service"; then
         echo "❌ Error: Unknown service '$service'"
         echo ""
-        echo "Runtime Core Services (always enabled): \${INFERENCE_ENGINE:-ollama} (supported: ollama, vllm, llamacpp)"
-        echo "Operational Services (profile-dependent): \${ALL_SERVICES[*]}"
+        echo "Runtime Core Services (always enabled): engine (${INFERENCE_ENGINE:-ollama})"
+        echo "Operational Services (profile-dependent): ${ALL_SERVICES[*]}"
         echo ""
         echo "For service contracts and profiles, see: docs/architecture/governance/service_contracts/"
         return 1
@@ -814,7 +832,7 @@ function stop_service() {
     echo "Stopping service: $service..."
     
     # Stop the specific service
-    if run_compose stop "$service"; then
+    if run_compose stop "$actual_service"; then
         echo "✅ Successfully stopped service: $service"
         
         # Clean up pgAdmin configuration if stopping pgadmin
@@ -840,8 +858,8 @@ function service() {
         echo "Error: Service action and name are required"
         echo "Usage: $0 service {start|stop|restart} <service-name>"
         echo ""
-        echo "Runtime Core Services (always enabled): \${INFERENCE_ENGINE:-ollama} (supported: ollama, vllm, llamacpp)"
-        echo "Operational Services (profile-dependent): \${ALL_SERVICES[*]}"
+        echo "Runtime Core Services (always enabled): engine (${INFERENCE_ENGINE:-ollama})"
+        echo "Operational Services (profile-dependent): ${ALL_SERVICES[*]}"
         echo ""
         echo "Note: Continue is a VS Code plugin, not a containerized service"
         echo "For service contracts and profiles, see: docs/architecture/governance/service_contracts/"
@@ -1011,7 +1029,7 @@ function logs() {
             echo "Error: Unknown container '$container'"
             echo ""
             echo "Runtime Core Services (Active: ${INFERENCE_ENGINE:-ollama}):"
-            echo "  ollama, vllm, llamacpp"
+            echo "  engine (ollama, vllm, llamacpp)"
             echo ""
             echo "Operational Services:"
             echo "  ${ALL_SERVICES[*]}"
@@ -1718,8 +1736,10 @@ function help_menu() {
     echo "  config engine set <engine>          - Set the inference engine (ollama, vllm, llamacpp)"
     echo "  config engine auto                  - Auto-detect optimal engine based on hardware"
     echo ""
+    echo "Restart: restart [service]             - Short form for 'stack restart'"
+    echo ""
     echo "Service: service <action> <name>"
-    echo "  Runtime Core (always enabled): ${INFERENCE_ENGINE:-ollama}"
+    echo "  Runtime Core (always enabled): engine (${INFERENCE_ENGINE:-ollama})"
     echo ""
     echo "Models: models <action> [name]"
     echo "  models add <name>                   - Add model(s) to Ollama/vLLM/llama.cpp"
@@ -1983,6 +2003,10 @@ function main() {
         stack)
             shift
             stack_cmd "$@"
+            ;;
+        restart)
+            shift
+            restart "$@"
             ;;
 
         *)

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -46,7 +46,7 @@ _aixcl_complete() {
     # Service categorization per AIXCL governance model (docs/architecture/governance/00_invariants.md)
     # Runtime Core (Strict): Always enabled, required for AIXCL to function
     # Note: Continue is a VS Code plugin, not a containerized service
-    local runtime_core_services="ollama"
+    local runtime_core_services="ollama vllm llamacpp"
     
     # Operational Services (Guided): Profile-dependent, support/observe runtime
     # - Persistence: postgres, pgadmin
@@ -56,8 +56,8 @@ _aixcl_complete() {
     local operational_services="open-webui postgres pgadmin watchtower prometheus grafana cadvisor node-exporter postgres-exporter nvidia-gpu-exporter loki promtail"
     
     # Combined list of all services (for backward compatibility and general completion)
-    # Must match ALL_SERVICES in lib/common.sh
-    local services="$runtime_core_services $operational_services"
+    # Includes 'engine' alias for convenience
+    local services="$runtime_core_services $operational_services engine"
     
     # Valid profiles (must match VALID_PROFILES in cli/lib/profile.sh)
     local profiles="usr dev ops sys"

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -135,8 +135,11 @@ See [`docs/operations/model-recommendations.md`](../operations/model-recommendat
 ### Troubleshooting
 
 ```bash
-# Check service logs
-./aixcl stack logs ollama 50
+# Check service logs for the engine
+./aixcl stack logs engine 50
+
+# Restart the engine
+./aixcl restart engine
 
 # Restart a specific service
 ./aixcl service restart postgres
@@ -145,7 +148,7 @@ See [`docs/operations/model-recommendations.md`](../operations/model-recommendat
 ./aixcl stack restart [--profile sys]
 
 # Restart specific services only (no profile needed)
-./aixcl stack restart ollama
+./aixcl stack restart engine
 
 # Clean up and start fresh
 ./aixcl stack clean
@@ -165,7 +168,7 @@ See [`docs/operations/model-recommendations.md`](../operations/model-recommendat
 ./aixcl service stop prometheus
 
 # Restart a service
-./aixcl service restart ollama
+./aixcl service restart engine
 ```
 
 ### Viewing Logs
@@ -175,7 +178,7 @@ See [`docs/operations/model-recommendations.md`](../operations/model-recommendat
 ./aixcl stack logs
 
 # Specific service, last 50 lines (default; n in range 1-10000), then follow
-./aixcl stack logs ollama 50
+./aixcl stack logs engine 50
 
 # Specific service, last 100 lines, follow
 ./aixcl stack logs postgres 100
@@ -234,7 +237,7 @@ docker-compose pull
 
 2. **Use logs for debugging:**
    ```bash
-   ./aixcl stack logs <service> 100
+   ./aixcl stack logs engine 100
    ```
 
 3. **Test Continue integration:**

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -59,6 +59,7 @@ load_env_file() {
 
 # Define all services from docker-compose.yml
 ALL_SERVICES=(
+    "engine"
     "ollama"
     "vllm"
     "llamacpp"
@@ -91,6 +92,9 @@ is_valid_service() {
 get_container_name() {
     local service="$1"
     case "$service" in
+        "engine")
+            echo "${INFERENCE_ENGINE:-ollama}"
+            ;;
         "open-webui")
             echo "open-webui"
             ;;

--- a/tests/platform-tests.sh
+++ b/tests/platform-tests.sh
@@ -589,8 +589,47 @@ test_llm_state() {
 }
 
 # ============================================================================
-# COMPONENT-BASED TEST FUNCTIONS
+# SECTION 5: CLI ALIAS TESTS
 # ============================================================================
+test_cli_aliases() {
+    start_section "CLI - Alias Resolution"
+    
+    echo "Testing 'engine' alias resolution..."
+    
+    # Test logs alias
+    echo "1. Testing: ./aixcl stack logs engine --tail 1"
+    if ./aixcl stack logs engine 1 2>&1 | grep -q "Fetching logs for ${INFERENCE_ENGINE:-ollama}"; then
+        print_success "Logs alias resolved correctly to ${INFERENCE_ENGINE:-ollama}"
+        record_test "pass" "CLI 'engine' alias resolved for logs"
+    else
+        print_error "Logs alias resolution failed"
+        record_test "fail" "CLI 'engine' alias failed for logs"
+    fi
+    
+    # Test status alias (if applicable, though status is usually global)
+    # Testing get_container_name logic via service status check internally
+    echo "2. Testing: ./aixcl service status engine"
+    # Note: 'service status' isn't a command, but 'stack status' shows it.
+    # We can test if 'is_valid_service engine' returns 0 by running start with it (dry run-ish)
+    if is_valid_service "engine"; then
+        print_success "is_valid_service identifies 'engine' as valid"
+        record_test "pass" "Common library recognizes 'engine' as a valid service"
+    else
+        print_error "is_valid_service failed to recognize 'engine'"
+        record_test "fail" "Common library failed to recognize 'engine'"
+    fi
+
+    # Test get_container_name resolution
+    local resolved_name
+    resolved_name=$(get_container_name "engine")
+    if [ "$resolved_name" = "${INFERENCE_ENGINE:-ollama}" ]; then
+        print_success "get_container_name 'engine' -> $resolved_name"
+        record_test "pass" "Container name resolution for 'engine' works"
+    else
+        print_error "get_container_name 'engine' -> $resolved_name (expected ${INFERENCE_ENGINE:-ollama})"
+        record_test "fail" "Container name resolution for 'engine' failed"
+    fi
+}
 
 # Test runtime core services
 test_component_runtime_core() {
@@ -846,6 +885,7 @@ test_profile_usr() {
     test_component_runtime_core
     test_component_database
     test_llm_state
+    test_cli_aliases
 }
 
 # Test dev profile (runtime core + database + UI)
@@ -859,6 +899,7 @@ test_profile_dev() {
     test_component_database
     test_component_ui
     test_llm_state
+    test_cli_aliases
 }
 
 # Test ops profile (runtime core + database + monitoring + logging)
@@ -873,17 +914,18 @@ test_profile_ops() {
     test_component_monitoring
     test_component_logging
     test_llm_state
+    test_cli_aliases
 }
 
 # Test sys profile (all services)
 test_profile_sys() {
     echo "Running tests for profile: sys"
     echo "Profile includes: all services"
-    echo ""
-    
+    # Run tests for each section
     test_environment_check
     test_stack_status
     test_llm_state
+    test_cli_aliases
 }
 
 # ============================================================================


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #519

### Description of Changes
This PR implements a generic `engine` alias in the `aixcl` CLI to simplify interactions with the active inference engine (vLLM, Ollama, or llama.cpp). It also adds a top-level `restart` shortcut and enhances bash completion.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes
- Verified `./aixcl restart engine` resolves to the active engine container.
- Verified `./aixcl stack logs engine` fetches the correct logs.
- Verified tab completion shows `engine`, `vllm`, and `llamacpp`.
- Ran `./tests/platform-tests.sh --profile sys` and confirmed alias resolution tests pass.

### Verification
To verify this change is complete:
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #519
