### PR TITLE
[TASK] Pin unpinned Actions in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           scandir: '.'
 
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           ignore-unfixed: true


### PR DESCRIPTION
## Summary
This PR addresses security alerts #8 and #9 by pinning 3rd-party Actions to their specific, immutable commit SHAs in the security analysis workflow.

## Changes
- .github/workflows/codeql.yml: Pinned to commit hash .
- .github/workflows/codeql.yml: Pinned to commit hash .

Fixes #560
