### PR TITLE
fix: require container toolkit for GPU inference detection (#577)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1839,8 +1839,8 @@ function config_cmd() {
                     cp "${SCRIPT_DIR}/.env.example" "${SCRIPT_DIR}/.env"
                 fi
                 
-                if has_nvidia; then
-                    echo "NVIDIA GPU detected. Setting engine to vLLM for optimized performance."
+                if has_nvidia_container_toolkit; then
+                    echo "NVIDIA GPU and Container Toolkit detected. Setting engine to vLLM for optimized performance."
                     if grep -q "^INFERENCE_ENGINE=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
                         sed -i "s/^INFERENCE_ENGINE=.*/INFERENCE_ENGINE=vllm/" "${SCRIPT_DIR}/.env"
                     else

--- a/lib/env_check.sh
+++ b/lib/env_check.sh
@@ -120,8 +120,8 @@ check_env() {
             elif [ -e /dev/dxg ]; then
                 print_success "NVIDIA GPU hardware exposed via /dev/dxg"
                 has_gpu_hardware=1
-            elif has_nvidia; then
-                print_success "NVIDIA GPU support detected via Docker runtime checks"
+            elif has_nvidia_container_toolkit; then
+                print_success "NVIDIA GPU support detected via Container Toolkit"
                 has_gpu_hardware=1
             else
                 print_info "Unable to confirm NVIDIA GPU support in WSL."


### PR DESCRIPTION
## Summary

Fixes #577

### Description of Changes

- Change aixcl engine auto-detection to require has_nvidia_container_toolkit() instead of just has_nvidia()
- Update env_check.sh to check toolkit availability instead of general GPU detection
- Stack now correctly falls back to CPU mode when NVIDIA hardware is present but Container Toolkit is missing

### Problem

The original code used has_nvidia() which detects hardware OR toolkit. This caused the stack to fail when GPU hardware existed but the toolkit was not installed, because vLLM was selected as the inference engine but could not access the GPU.

### Solution

Require the Container Toolkit to be present before selecting vLLM. This ensures:
1. Stack starts successfully with GPU hardware but no toolkit (falls back to Ollama)
2. GPU monitoring services (nvidia-gpu-exporter) only start when toolkit is available
3. Docker GPU overrides only apply when toolkit is present

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-577/fix-gpu-detection-toolkit-requirement)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- Verify stack starts on system with NVIDIA hardware but no toolkit
- Verify engine falls back to Ollama when toolkit missing
- Verify vLLM selected when both hardware and toolkit present

### Verification

To verify this change is complete:

- [x] Stack starts on hardware-only NVIDIA system
- [x] No nvidia-gpu-exporter service attempted without toolkit
- [x] Engine auto-selects correctly based on toolkit presence

### Related Issues

- Closes #577
