### PR TITLE
Fix cAdvisor container metrics for overlayfs storage driver (#586)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -208,7 +208,7 @@ services:
       retries: 3
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor
     volumes:
       - /:/rootfs:ro
@@ -223,6 +223,7 @@ services:
     restart: unless-stopped
     command:
       - '--port=8081'
+      - '--docker_only=true'
 
   node-exporter:
     image: prom/node-exporter:v1.8.2


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #586

### Description of Changes

Upgrades cAdvisor to v0.55.1 and adds configuration flag to fix container metrics not appearing in Grafana when using overlayfs storage driver on WSL2.

The root cause was cAdvisor v0.49.1 being incompatible with Docker's overlayfs storage driver on WSL2, causing all container metrics to lack container_name labels.

### Changes

- **cAdvisor version:** v0.49.1 → v0.55.1 (latest available with overlayfs fixes)
- **Added flag:** `--docker_only=true` - Focus monitoring on Docker containers only

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] Tested on WSL2 with overlayfs - VERIFIED WORKING

### Testing Results

**Before fix:**
- Grafana dashboard shows "No data" for container metrics
- cAdvisor logs show: `failed to identify the read-write layer ID`
- Prometheus queries return 0 results for containers with names

**After fix:**
- ✅ cAdvisor healthy (12/12 services)
- ✅ Container metrics visible in Prometheus
- ✅ Container names available: alloy, cadvisor, grafana, loki, node-exporter, nvidia-gpu-exporter, open-webui, pgadmin, postgres, postgres-exporter, prometheus, vllm
- ✅ No layer ID errors in cAdvisor logs
- ✅ Prometheus scraping successfully: `Job: cadvisor, State: up`

### Verification

```bash
# 1. Stack restarted with new cAdvisor
./aixcl stack restart

# 2. New image verified
docker ps | grep cadvisor  # Shows v0.55.1

# 3. cAdvisor logs clean
./aixcl stack logs cadvisor | grep -i "error\|fail"  # No layer ID errors

# 4. Container metrics available
curl http://localhost:9090/api/v1/label/name/values
# Returns: alloy, cadvisor, grafana, loki, node-exporter, nvidia-gpu-exporter, open-webui, pgadmin, postgres, postgres-exporter, prometheus, vllm

# 5. Grafana dashboard should now show container data
# Open: http://localhost:3000/d/aixcl-docker/aixcl-docker-containers
```

### Related Issues

- Closes #586