### PR TITLE
Fix Docker volume handling for llama.cpp model downloads (#592)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -1444,7 +1444,7 @@ is_model_installed() {
             ;;
         llamacpp)
             # llama.cpp uses a flat models directory. Check if file exists in volume on host
-            local llamacpp_volume="${SERVICES_DIR:-services}_llamacpp-data"
+            local llamacpp_volume="services_llamacpp-data"
             local volume_path
             volume_path=$(${DOCKER_BIN:-docker} volume inspect -f '{{ .Mountpoint }}' "$llamacpp_volume" 2>/dev/null || echo "")
             if [ -n "$volume_path" ] && [ -d "$volume_path" ]; then
@@ -1553,51 +1553,72 @@ function add() {
                 local filename="${BASH_REMATCH[2]}"
                 echo "📥 Downloading $filename from $repo..."
                 
-                # Get the volume mount point
-                local llamacpp_volume="${SERVICES_DIR:-services}_llamacpp-data"
-                local volume_path
-                volume_path=$(${DOCKER_BIN:-docker} volume inspect -f '{{ .Mountpoint }}' "$llamacpp_volume" 2>/dev/null || echo "")
+                # For llama.cpp, we need to download the GGUF file to the Docker volume
+                # Since Docker volumes may not be directly accessible on the host filesystem,
+                # we download to a temp location and use docker run to copy to the volume
+                local llamacpp_volume="services_llamacpp-data"
+                local temp_dir="/tmp/aixcl-downloads-$$"
+                local downloaded_file="${temp_dir}/${filename}"
                 
-                if [ -n "$volume_path" ] && [ -d "$volume_path" ]; then
-                    echo "   Downloading to volume: $volume_path"
+                # Create temp directory
+                mkdir -p "$temp_dir"
+                
+                echo "   Downloading to temporary location..."
+                
+                # Download using available method
+                local download_success=false
+                
+                # Try huggingface-cli first
+                if command -v huggingface-cli >/dev/null 2>&1; then
+                    echo "   Attempting download with huggingface-cli..."
+                    if huggingface-cli download "$repo" "$filename" --local-dir "$temp_dir" --local-dir-use-symlinks False; then
+                        download_success=true
+                        echo "   ✓ huggingface-cli download successful"
+                    else
+                        echo "   ⚠ huggingface-cli download failed"
+                    fi
+                fi
+                
+                # Fall back to Python script
+                if [ "$download_success" = false ] && [ -f "${SCRIPT_DIR}/scripts/download-hf-model.py" ] && python3 -c "import huggingface_hub" 2>/dev/null; then
+                    echo "   Attempting download with Python fallback..."
+                    if python3 "${SCRIPT_DIR}/scripts/download-hf-model.py" "$repo" "$filename" --local-dir "$temp_dir" > /dev/null 2>&1; then
+                        download_success=true
+                        echo "   ✓ Python download successful"
+                    else
+                        echo "   ⚠ Python download failed"
+                    fi
+                fi
+                
+                # Last resort: curl
+                if [ "$download_success" = false ]; then
+                    echo "   Using curl to download..."
+                    if curl -L "https://huggingface.co/$repo/resolve/main/$filename" -o "$downloaded_file" --progress-bar 2>/dev/null; then
+                        download_success=true
+                    fi
+                fi
+                
+                if [ "$download_success" = false ]; then
+                    rm -rf "$temp_dir"
+                    echo "❌ Failed to download model: $model"
+                    echo "   Install huggingface-hub: pip install huggingface-hub"
+                    return 1
+                fi
+                
+                # Now copy to Docker volume using docker run
+                echo "   Copying to Docker volume..."
+                if ${DOCKER_BIN:-docker} run --rm \
+                    -v "${llamacpp_volume}:/models" \
+                    -v "${temp_dir}:/source:ro" \
+                    alpine:latest \
+                    cp "/source/${filename}" "/models/"; then
                     
-                    # Try huggingface-cli first
-                    if command -v huggingface-cli >/dev/null 2>&1; then
-                        if huggingface-cli download "$repo" "$filename" --local-dir "$volume_path" --local-dir-use-symlinks False; then
-                            echo "✅ Successfully downloaded model to volume: $filename"
-                        else
-                            echo "❌ Failed to download model: $model"
-                            return 1
-                        fi
-                    # Fall back to Python script
-                    elif [ -f "${SCRIPT_DIR}/scripts/download-hf-model.py" ] && python3 -c "import huggingface_hub" 2>/dev/null; then
-                        echo "   Using Python fallback for download..."
-                        if python3 "${SCRIPT_DIR}/scripts/download-hf-model.py" "$repo" "$filename" --local-dir "$volume_path" --docker-volume "$llamacpp_volume"; then
-                            echo "✅ Successfully downloaded model to volume: $filename"
-                        else
-                            echo "❌ Failed to download model: $model"
-                            return 1
-                        fi
-                    else
-                        echo "❌ huggingface-cli not found on host and Python fallback unavailable."
-                        echo "   Install huggingface-hub with: pip install huggingface-hub"
-                        return 1
-                    fi
+                    echo "✅ Successfully downloaded and copied model: $filename"
+                    rm -rf "$temp_dir"
                 else
-                    # Fallback: try downloading directly via curl to volume
-                    echo "   Downloading directly to volume..."
-                    if curl -L "https://huggingface.co/$repo/resolve/main/$filename" -o "/tmp/$filename" 2>/dev/null; then
-                        # Copy to volume using docker run
-                        ${DOCKER_BIN:-docker} run --rm -v "${llamacpp_volume}:/models" alpine:latest cp "/tmp/$filename" "/models/$filename" 2>/dev/null || {
-                            echo "❌ Failed to copy model to volume"
-                            return 1
-                        }
-                        rm -f "/tmp/$filename"
-                        echo "✅ Successfully downloaded model: $filename"
-                    else
-                        echo "❌ Failed to download model: $model"
-                        return 1
-                    fi
+                    echo "❌ Failed to copy model to Docker volume"
+                    rm -rf "$temp_dir"
+                    return 1
                 fi
             else
                 echo "❌ Invalid model format for llama.cpp. Expected: username/repo/model.gguf"

--- a/scripts/download-hf-model.py
+++ b/scripts/download-hf-model.py
@@ -6,7 +6,6 @@ Used when huggingface-cli is not available in PATH.
 import sys
 import os
 import argparse
-import subprocess
 
 try:
     from huggingface_hub import hf_hub_download
@@ -16,57 +15,22 @@ except ImportError:
     sys.exit(1)
 
 
-def download_model(repo_id: str, filename: str, local_dir: str, docker_volume: str = None) -> bool:
+def download_model(repo_id: str, filename: str, local_dir: str) -> bool:
     """Download a specific file from a Hugging Face repository."""
     try:
         print(f"Downloading {filename} from {repo_id}...", file=sys.stderr)
         
-        # Download to a temporary location first
-        temp_dir = "/tmp/aixcl-downloads"
-        os.makedirs(temp_dir, exist_ok=True)
+        # Ensure local directory exists
+        os.makedirs(local_dir, exist_ok=True)
         
         downloaded_path = hf_hub_download(
             repo_id=repo_id,
             filename=filename,
-            local_dir=temp_dir,
+            local_dir=local_dir,
             local_dir_use_symlinks=False,
         )
         
-        print(f"✅ Downloaded to temporary location: {downloaded_path}", file=sys.stderr)
-        
-        # If docker_volume is provided, copy to volume using docker
-        if docker_volume:
-            print(f"   Copying to Docker volume: {docker_volume}", file=sys.stderr)
-            result = subprocess.run(
-                [
-                    "docker", "run", "--rm",
-                    "-v", f"{docker_volume}:/models",
-                    "-v", f"{temp_dir}:/source:ro",
-                    "alpine:latest",
-                    "cp", f"/source/{filename}", "/models/"
-                ],
-                capture_output=True,
-                text=True
-            )
-            
-            if result.returncode != 0:
-                print(f"❌ Failed to copy to volume: {result.stderr}", file=sys.stderr)
-                return False
-            
-            print(f"✅ Successfully copied to volume", file=sys.stderr)
-            
-            # Clean up temp file
-            try:
-                os.remove(downloaded_path)
-            except OSError:
-                pass
-        else:
-            # Just move to the final destination
-            final_path = os.path.join(local_dir, filename)
-            os.makedirs(os.path.dirname(final_path), exist_ok=True)
-            os.rename(downloaded_path, final_path)
-            print(f"✅ Successfully moved to: {final_path}", file=sys.stderr)
-        
+        print(f"✅ Downloaded to: {downloaded_path}", file=sys.stderr)
         return True
     except Exception as e:
         print(f"❌ Failed to download: {e}", file=sys.stderr)
@@ -90,14 +54,10 @@ def main():
         required=True,
         help="Directory to save the file"
     )
-    parser.add_argument(
-        "--docker-volume",
-        help="Docker volume name to copy file to after download"
-    )
 
     args = parser.parse_args()
 
-    success = download_model(args.repo_id, args.filename, args.local_dir, args.docker_volume)
+    success = download_model(args.repo_id, args.filename, args.local_dir)
     sys.exit(0 if success else 1)
 
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #592

### Description of Changes
This PR fixes the Docker volume permission issue for llama.cpp model downloads.

**Problem:** The original implementation tried to access the Docker volume mountpoint directly on the host filesystem, which requires root permissions and does not work in all environments.

**Solution:**
- Download models to a temporary directory on the host
- Use docker run with volume mounts to copy the file to the Docker volume
- This works without needing direct access to Docker internal filesystem
- Added multiple download methods (huggingface-cli, Python fallback, curl)
- Fixed volume name reference to use simple name instead of path-based name

### Changes Made
- Simplified volume handling in aixcl script
- Download to temp directory first, then copy via docker run
- Removed dependency on accessing volume mountpoint directly
- Fixed volume name reference from SERVICES_DIR to simple volume name

### Testing Notes
Tested with the smallest recommended model (~380MB). The workflow:
1. Set engine: ./aixcl config engine set llamacpp
2. Download model: ./aixcl models add bartowski/Qwen2.5-Coder-0.5B-Instruct-GGUF/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf
3. Restart stack: ./aixcl stack restart
4. Verify: Model loads and server starts successfully

### Verification
- [x] Model download works with Python fallback
- [x] File copied to Docker volume successfully
- [x] Container starts and loads model without errors
- [x] llama.cpp server responds to health checks

### Related Issues
- Closes #592
- Related to #590 (llama.cpp crash-loop fix)
- Related to #589 (README improvements)
