### PR TITLE
Fix hardcoded assignee in issue templates (#606)

### DIFF
--- a/ai/templates/issue/bug_report.md
+++ b/ai/templates/issue/bug_report.md
@@ -3,7 +3,7 @@ name: "Bug Report"
 about: "Report an unexpected behavior or problem"
 title: "[BUG] "
 labels: ["priority:medium","profile:dev"]
-assignees: ["sbadakhc"]
+assignees: ["<assignee>"]
 ---
 
 ## Bug Summary

--- a/ai/templates/issue/feature_request.md
+++ b/ai/templates/issue/feature_request.md
@@ -3,7 +3,7 @@ name: "Feature Request"
 about: "Suggest a new feature or enhancement"
 title: "[FEATURE] "
 labels: ["enhancement"]
-assignees: ["sbadakhc"]
+assignees: ["<assignee>"]
 ---
 
 ## Feature Overview

--- a/ai/templates/issue/task.md
+++ b/ai/templates/issue/task.md
@@ -3,7 +3,7 @@ name: "Task / Investigation"
 about: "Capture a task or investigation work"
 title: "[TASK] "
 labels: ["maintenance"]
-assignees: ["sbadakhc"]
+assignees: ["<assignee>"]
 ---
 
 ## Task Summary


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #606

### Description of Changes
Replaces hardcoded GitHub username 'sbadakhc' with generic '<assignee>' placeholder in all three issue templates (bug_report.md, feature_request.md, task.md) per DEVELOPMENT.md Section 11 guidelines.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-606/fix-harcoded-assignee-templates)
- [x] Commit messages follow conventional style
- [x] All changes are template metadata only, no functional code changes

### Testing Notes
- Verified YAML frontmatter remains valid after changes
- Templates will now use generic placeholder instead of hardcoded username
- No breaking changes to template functionality

### Verification
- [x] All three templates updated with '<assignee>' placeholder
- [x] YAML frontmatter remains valid
- [x] No hardcoded usernames remain in templates
- [x] Templates render correctly in GitHub issue creation UI

### Related Issues
- Closes #606