### PR TITLE
Add CRLF line ending prevention with .gitattributes and CI check (#612)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Force LF line endings for common text files
+*.md text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.py text eol=lf
+*.sql text eol=lf
+*.conf text eol=lf
+*.config text eol=lf
+*.ini text eol=lf
+
+# Mark binary files (do not convert line endings)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary
+*.7z binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary

--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -22,3 +22,25 @@ jobs:
 
       - name: Run aixcl check-env
         run: ./aixcl utils check-env
+
+  check-line-endings:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Check for Windows line endings (CRLF)
+        run: |
+          echo "Checking for CRLF line endings..."
+          CRLF_FILES=$(find . -type f -not -path "./.git/*" -not -path "./pgadmin-data/*" -not -path "./logs/*" -exec file {} \; 2>/dev/null | grep -i "with CRLF" | cut -d: -f1 | sed 's|^\./||')
+          if [ -n "$CRLF_FILES" ]; then
+            echo "ERROR: Found files with Windows line endings (CRLF):"
+            echo "$CRLF_FILES"
+            echo ""
+            echo "Please convert these files to Unix line endings (LF) before committing."
+            echo "You can use: sed -i 's/\\r$//' <file>"
+            exit 1
+          else
+            echo "✓ No CRLF files found - all line endings are Unix style (LF)"
+          fi

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -227,7 +227,31 @@ gh issue view <number> --json labels
 - Use emoji in technical documentation
 - Use special Unicode characters that may not render consistently
 
-## Handling Automated PRs
+## Line Endings
+
+All text files in this repository must use **Unix-style line endings (LF)**, not Windows-style (CRLF).
+
+### Why This Matters
+- Cross-platform compatibility
+- Consistent diffs and reviews
+- Git best practices
+
+### Automatic Handling
+The repository includes a `.gitattributes` file that automatically converts line endings for most contributors.
+
+### Manual Conversion (if needed)
+If you accidentally commit files with CRLF line endings, convert them before submitting a PR:
+
+```bash
+# Convert a single file
+sed -i 's/\r$//' <filename>
+
+# Convert all files in a directory
+find . -type f -name "*.md" -exec sed -i 's/\r$//' {} \;
+```
+
+### CI Check
+The CI workflow automatically checks for CRLF line endings and will fail the build if any are found.
 
 **GitHub Code Quality AI findings and automated fixes:**
 - Automated PRs from GitHub Code Quality (Copilot Autofix) may bypass the Issue-First workflow


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #612

### Description of Changes
Implements automated linting to prevent Windows-style CRLF line endings from being introduced into the repository.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-612/add-crlf-linters)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Changes Made

1. **.gitattributes file** (new):
 - Sets `* text=auto` for automatic line ending detection
 - Explicitly marks text files (.md, .yml, .json, .sh, .py, etc.) to use LF
 - Marks binary files (.png, .jpg, etc.) to prevent conversion
 - Works automatically for all contributors without local setup

2. **CI workflow** (.github/workflows/bash-ci.yml):
 - Added `check-line-endings` job
 - Uses `file` command to detect CRLF line terminators
 - Fails build with helpful error message if CRLF found
 - Excludes .git/, pgadmin-data/, and logs/ directories

3. **Documentation** (docs/developer/development-workflow.md):
 - Added "Line Endings" section under Formatting Guidelines
 - Explains why Unix line endings are required
 - Shows manual conversion commands (sed)
 - References the CI check

### Testing Notes
- CI check verified against empty CRLF list (currently 0 files)
- .gitattributes will take effect on next checkout/clone
- Documentation section follows existing format

### Verification
- [x] .gitattributes file created with proper settings
- [x] CI workflow includes check-line-endings job
- [x] Documentation updated with line ending guidelines
- [x] All files pass current CRLF check

### Related Issues
- Closes #612
