### PR TITLE
Add ASCII output skill to prevent Unicode in agent responses (#614)

### DIFF
--- a/ai/skills/ascii_output.md
+++ b/ai/skills/ascii_output.md
@@ -1,0 +1,28 @@
+# ASCII Output Skill
+
+Enforces plain ASCII output for cross-platform consistency.
+
+## Requirements
+
+Per DEVELOPMENT.md Section 6:
+
+- Use markdown checkboxes: `- [x]` for completed items
+- NEVER use Unicode checkmarks, emoji, or special characters
+- NEVER use `✅`, `✓`, `☐`, or similar symbols
+- Use plain ASCII for cross-platform consistency
+
+## Examples
+
+| Incorrect | Correct |
+|-----------|---------|
+| `✅ Complete` | `[x] Complete` |
+| `☐ Pending` | `[ ] Pending` |
+| `Item ✓` | `Item [x]` |
+
+## Verification
+
+Before submitting any response:
+
+- [ ] No Unicode emoji present
+- [ ] Checkboxes use `- [x]` format
+- [ ] Only plain ASCII characters used

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,8 @@
 
   "instructions": [
     "AGENTS.md",
-    "DEVELOPMENT.md"
+    "DEVELOPMENT.md",
+    "ai/skills/ascii_output.md"
   ],
 
   "permission": {


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #614

### Description of Changes

Creates a new skill file to remind agents to use plain ASCII output only, preventing Unicode emoji and special characters in responses.

Changes:
- Created `ai/skills/ascii_output.md` with ASCII-only guidelines and examples
- Updated `opencode.json` to load this skill in the instructions array
- Follows DEVELOPMENT.md Section 6 formatting requirements

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-614/...)
- [x] Commit messages follow conventional style
- [x] No tests needed (documentation/skill addition)

### Testing Notes

Verified:
- File created at correct path
- opencode.json updated with new instruction entry
- Markdown syntax uses `- [x]` checkboxes (not Unicode)

### Verification

To verify this change is complete:

- [x] Behavior works as expected - skill will be loaded automatically
- [x] No regressions observed - existing instructions unchanged
- [x] File follows project structure (ai/skills/)

### Related Issues

- Closes #614