### PR TITLE
Add missing PostgreSQL init script for webui database (#631)

### DIFF
--- a/scripts/db/init/01-create-webui.sql
+++ b/scripts/db/init/01-create-webui.sql
@@ -1,0 +1,14 @@
+-- PostgreSQL initialization script for AIXCL
+-- Creates the webui database on first container startup
+-- This runs automatically before PostgreSQL reports as ready
+
+-- Create webui database if it doesn't exist
+-- Using IF NOT EXISTS makes this script idempotent
+SELECT 'CREATE DATABASE webui'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'webui')\gexec
+
+-- Grant permissions to the postgres user (adjust if using different user)
+-- Note: The database owner will be the user running init (usually postgres)
+-- The application user will need appropriate permissions
+
+-- The webui database is now ready before Open WebUI container starts


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #631 Fixes #617

### Description of Changes

Adds the missing `scripts/db/init/01-create-webui.sql` file that was supposed to be part of PR #618.

PR #618 added the docker-compose mount configuration to use PostgreSQL's `/docker-entrypoint-initdb.d/` feature, but the actual SQL initialization script was never created. This caused a regression where the webui database is not created on fresh stack starts, causing Open WebUI to crash.

**The fix:**
- Creates `scripts/db/init/01-create-webui.sql` with idempotent database creation
- The script uses PostgreSQL's `\gexec` meta-command to execute the CREATE DATABASE statement conditionally
- File is mounted read-only to `/docker-entrypoint-initdb.d/` in the postgres container
- Runs automatically before PostgreSQL reports as ready on first container startup

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (fix/631-missing-init-script)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

**Test Environment:** Local development, sys profile

**Steps to Verify:**

1. Stop all services: `./aixcl stack stop`
2. Remove postgres volume: `docker volume rm aixcl_postgres-data`
3. Start stack: `./aixcl stack start --profile sys`
4. Check status: `./aixcl stack status`
5. Expected: All services healthy (12/12)

### Verification

To verify this change is complete:

- [x] Fresh stack start completes with all services healthy
- [x] Open WebUI health endpoint returns `{\"status\":true}`
- [x] webui database exists in PostgreSQL
- [x] No manual database provisioning required
- [x] No regressions observed

### Related Issues

- Closes #631
- Closes #617
