### PR TITLE
Fix .env.example path in start_service function (#633)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -654,11 +654,11 @@ function start_service() {
     log_info "Starting service: $service..."
     
     # Check for .env file if needed (for services that require it)
-    if [ ! -f .env ] && { [ "$service" = "open-webui" ] || [ "$service" = "postgres" ] || [ "$service" = "pgadmin" ]; }; then
-        if [ -f .env.example ]; then
-            log_warning ".env file not found. Copying from .env.example..."
-            cp .env.example .env
-            load_env_file ".env"
+    if [ ! -f "${SCRIPT_DIR}/.env" ] && { [ "$service" = "open-webui" ] || [ "$service" = "postgres" ] || [ "$service" = "pgadmin" ]; }; then
+        if [ -f "${SCRIPT_DIR}/config/.env.example" ]; then
+            log_warning ".env file not found. Copying from config/.env.example..."
+            cp "${SCRIPT_DIR}/config/.env.example" "${SCRIPT_DIR}/.env"
+            load_env_file "${SCRIPT_DIR}/.env"
         else
             log_error ".env file required for service '$service'"
             return 1


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #633

### Description of Changes

The start_service function in lib/aixcl/commands/stack.sh was checking for .env.example at the wrong path after it was moved to config/.env.example in issue #628. This caused service start/restart commands to fail for services requiring environment files (open-webui, postgres, pgadmin).

**Changes:**
- Updated path check from .env.example to \${SCRIPT_DIR}/config/.env.example
- Updated copy destination from .env to \${SCRIPT_DIR}/.env
- Updated load_env_file call to use full path \${SCRIPT_DIR}/.env

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (fix/633-env-example-path-service)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

**Test Environment:** Local development

**Steps to Verify:**

1. Stop a service: ./aixcl service stop ollama
2. Start the service: ./aixcl service start ollama
3. Expected: Service starts successfully without hanging

### Verification

To verify this change is complete:

- [x] ./aixcl service restart ollama works correctly
- [x] ./aixcl service restart open-webui works correctly
- [x] No regressions in other service commands

### Related Issues

- Closes #633