### PR TITLE
Center and resize video thumbnail in README (#645)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-[![AIXCL](https://github.com/xencon/aixcl/raw/main/AIXCL.png)](https://youtu.be/YaBABt0TsPI)
+<p align="center">
+  <a href="https://youtu.be/YaBABt0TsPI">
+    <img src="https://github.com/xencon/aixcl/raw/main/AIXCL.png" alt="AIXCL Introduction Video" width="600"/>
+  </a>
+</p>
 
-# AIXCL
+<h1 align="center">AIXCL</h1>
 
-**A self-hosted, local-first AI stack for running and integrating LLMs.**
+<p align="center"><strong>A self-hosted, local-first AI stack for running and integrating LLMs.</strong></p>
 
 AIXCL is a privacy-focused platform for individuals and teams who want full control over their models. It provides a simple CLI, a web interface, and a containerized stack to run, manage, and integrate Large Language Models directly into your developer workflow.
 


### PR DESCRIPTION
## Summary

Completes #645 by centering and resizing the video thumbnail in the README.

### Changes

- Replaced markdown image link with HTML for better control
- Video thumbnail now centered with `align=center`
- Set width to 600px for consistent display across devices
- Also centered the AIXCL heading and tagline for better visual hierarchy

### Before
- Video thumbnail was left-aligned and full-width
- Heading and tagline were left-aligned

### After  
- Video thumbnail is centered and 600px wide
- Heading and tagline are centered

### Visual Preview

The README now has a more polished, centered layout that looks better on GitHub.

## Checklist

- [x] Video thumbnail centered
- [x] Video thumbnail resized to 600px
- [x] AIXCL heading centered
- [x] Tagline centered
- [x] All links functional

### Related Issues

References #645