### PR TITLE
Fix engine-specific test skipping and aixcl-test UX improvements (#658)

### DIFF
--- a/tests/aixcl-test
+++ b/tests/aixcl-test
@@ -29,6 +29,7 @@ source "${TEST_SCRIPT_DIR}/lib/cleanup.sh"
 SCRIPT_DIR="$TEST_SCRIPT_DIR"
 
 # Configuration
+# shellcheck disable=SC2034
 REPORT_FILE="${SCRIPT_DIR}/test-results.md"
 COMPARISON_FILE="${SCRIPT_DIR}/comparison-results.md"
 TEST_DIR="${SCRIPT_DIR}/command-tests"
@@ -38,10 +39,12 @@ ENGINE="current"  # current, ollama, vllm, llamacpp, all
 MODEL=""
 TEST_RANGE="all"
 PROFILE="usr"
+# shellcheck disable=SC2034
 VERBOSE=false
 
 # Results tracking
 declare -A ENGINE_RESULTS
+# shellcheck disable=SC2034
 declare -A ENGINE_SCORES
 declare -A ENGINE_DURATIONS
 
@@ -146,6 +149,7 @@ parse_arguments() {
                 shift 2
                 ;;
             -v|--verbose)
+                # shellcheck disable=SC2034
                 VERBOSE=true
                 shift
                 ;;

--- a/tests/aixcl-test
+++ b/tests/aixcl-test
@@ -55,35 +55,70 @@ AIXCL Test Runner - Run tests against specific engines and models
 
 Usage: ./tests/aixcl-test [OPTIONS]
 
-Options:
-    -e, --engine <engine>    Engine to use: ollama, vllm, llamacpp, all, current (default: current)
-    -m, --model <model>      Model name (optional, uses first available if not specified)
-    -t, --test <range>       Test range: 1, 1-5, 1,3,5, all (default: all)
-    -p, --profile <profile>  Stack profile: sys, usr (default: usr)
-    -v, --verbose            Verbose output
-    -h, --help               Show this help
+OPTIONS
 
-Examples:
-    # Run test 13 with current engine
+    -e, --engine <engine>
+        Engine to use: ollama, vllm, llamacpp, all, current
+        Default: current (uses configured engine from .env)
+
+    -m, --model <model>
+        Model name (optional)
+        Uses first available model if not specified
+
+    -t, --test <range>
+        Test range selection
+        Formats: 1 (single), 1-5 (range), 1,3,5 (list), all
+        Default: all
+
+    -p, --profile <profile>
+        Stack profile: sys, usr
+        Default: usr
+
+    -v, --verbose
+        Enable verbose output
+
+    -h, --help
+        Show this help message
+
+ENGINES
+
+    ollama      Ollama inference engine (default, CPU/GPU)
+    vllm        vLLM inference engine (requires GPU)
+    llamacpp    llama.cpp engine (GGUF models)
+    all         Run tests against all engines sequentially
+    current     Use currently configured engine
+
+PROFILES
+
+    usr     User runtime (minimal footprint)
+    sys     System runtime (full stack)
+
+EXAMPLES
+
     ./tests/aixcl-test --test 13
+        Run test 13 with current engine
 
-    # Run test 13 with specific engine and model
+    ./tests/aixcl-test --engine ollama --test 13
+        Run test 13 with ollama engine
+
     ./tests/aixcl-test --engine ollama --model qwen2.5-coder:0.5b --test 13
+        Run test 13 with specific engine and model
 
-    # Run tests 1-14 with vLLM
     ./tests/aixcl-test --engine vllm --test 1-14
+        Run tests 1 through 14 with vLLM
 
-    # Run test 13 against all engines (comparison mode)
     ./tests/aixcl-test --engine all --test 13
+        Run test 13 against all engines (comparison mode)
 
-    # Run all tests against all engines
     ./tests/aixcl-test --engine all --test all
+        Run all tests against all engines
 
-Notes:
-    - Tests run sequentially for safety
-    - When using --engine all, each engine runs independently
-    - Comparison report generated at tests/comparison-results.md
-    - vLLM tests auto-skip if no GPU detected
+NOTES
+
+    [*] Tests run sequentially for safety
+    [*] Comparison report at tests/comparison-results.md (when using --engine all)
+    [*] vLLM tests auto-skip if no GPU detected
+    [*] Each engine run is independent with cleanup between runs
 EOF
 }
 

--- a/tests/aixcl-test
+++ b/tests/aixcl-test
@@ -427,6 +427,12 @@ EOF
 # ============================================================================
 
 main() {
+    # Show help if no arguments provided
+    if [[ $# -eq 0 ]]; then
+        show_help
+        exit 0
+    fi
+
     parse_arguments "$@"
 
     echo "=========================================="

--- a/tests/command-tests/test-14-opencode-vllm.sh
+++ b/tests/command-tests/test-14-opencode-vllm.sh
@@ -10,6 +10,13 @@ source "${SCRIPT_DIR}/tests/lib/state-capture.sh"
 
 log_test_start "test-14-opencode-vllm"
 
+# Skip if not running on vLLM engine
+CURRENT_ENGINE=$(grep "^ENGINE=" "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2 || echo "ollama")
+if [[ "$CURRENT_ENGINE" != "vllm" ]]; then
+    log_test_skip "Test requires vLLM engine (current: $CURRENT_ENGINE)"
+    exit 0
+fi
+
 # Skip if no GPU
 if ! has_nvidia_gpu; then
     log_test_skip "No NVIDIA GPU - vLLM requires GPU"

--- a/tests/command-tests/test-15-opencode-llamacpp.sh
+++ b/tests/command-tests/test-15-opencode-llamacpp.sh
@@ -10,6 +10,13 @@ source "${SCRIPT_DIR}/tests/lib/state-capture.sh"
 
 log_test_start "test-15-opencode-llamacpp"
 
+# Skip if not running on llama.cpp engine
+CURRENT_ENGINE=$(grep "^ENGINE=" "${SCRIPT_DIR}/.env" 2>/dev/null | cut -d'=' -f2 || echo "ollama")
+if [[ "$CURRENT_ENGINE" != "llamacpp" ]]; then
+    log_test_skip "Test requires llama.cpp engine (current: $CURRENT_ENGINE)"
+    exit 0
+fi
+
 # Capture state before test
 BACKUP_DIR=$(capture_state "test-15-opencode-llamacpp")
 export BACKUP_DIR


### PR DESCRIPTION
## Summary

Fixes #658

This PR contains three related improvements to the aixcl-test command:

1. **Feature**: Add aixcl-test command for engine/model-specific test execution (#655)
2. **Refactor**: Update help format to match aixcl CLI style (cosmetic)
3. **Fix**: Show help when called with no arguments (#657)
4. **Fix**: Engine-specific tests skip when running wrong engine (#658)

## Description of Changes

### Engine-Specific Test Skipping (Primary Fix)

Added engine checks to test-14 and test-15 to skip when not the intended engine:
- test-14-opencode-vllm.sh: Skip if ENGINE != vllm
- test-15-opencode-llamacpp.sh: Skip if ENGINE != llamacpp

This fixes the issue where running `--engine all --test all` would fail on engine-specific tests.

### aixcl-test UX Improvements

- Added no-argument check to show help instead of executing tests
- Reorganized help output with proper sections (OPTIONS, ENGINES, PROFILES, EXAMPLES, NOTES)
- Matched style with ./aixcl --help output

## Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (fix/engine-specific-test-skipping)
- [x] Commit messages follow conventional style
- [x] All changes tested

## Testing Notes

Manual testing performed:
- `./tests/aixcl-test` - Shows help ✅
- `./tests/aixcl-test --test 13` - Runs test 13 ✅
- `./tests/aixcl-test --engine ollama --test 13` - Runs with ollama ✅
- `./tests/aixcl-test --engine all --test all` - Comparison mode (improved with skips)

## Verification

- [x] test-14 skips on ollama
- [x] test-14 skips on llamacpp
- [x] test-14 runs on vllm (with GPU)
- [x] test-15 skips on ollama
- [x] test-15 skips on vllm
- [x] test-15 runs on llamacpp
- [x] test-13 runs on all engines
- [x] No regressions observed
- [x] All existing tests still pass

## Files Changed

- `tests/aixcl-test` - Main test runner (NEW + fixes)
- `tests/command-tests/test-13-opencode-prompts.sh` - Modified to respect configured engine
- `tests/command-tests/test-14-opencode-vllm.sh` - NEW + engine skip logic
- `tests/command-tests/test-15-opencode-llamacpp.sh` - NEW + engine skip logic

## Related Issues

- Closes #655 (feature - aixcl-test command)
- Closes #656 ([OVERRIDE] documentation)
- Closes #657 (no-arg help fix)
- Closes #658 (engine-specific test skipping)

---

**Assignee:** sbadakhc