### PR TITLE
Fix Grafana image tag to use latest stable 12.4.2 (#679)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -200,7 +200,7 @@ services:
       retries: 3
 
   grafana:
-    image: grafana/grafana:13.1.0
+    image: grafana/grafana:12.4.2
     container_name: grafana
     pull_policy: if_not_present
     volumes:


### PR DESCRIPTION
## Summary

Fixes #679

The Grafana image tag `13.1.0` doesn't exist on Docker Hub. Grafana 13.x uses build-timestamp format tags (e.g., `13.1.0-24220292042`), not simple semver.

### Changes
- [x] Updated Grafana image from `grafana/grafana:13.1.0` to `grafana/grafana:12.4.2` (latest stable with proper semver tag)
- [x] Verified image exists on Docker Hub
- [x] Image supports amd64, arm64, and arm architectures

### Testing
- Image tag verified via Docker Hub API
- Tag exists and is actively maintained

### Verification
- [x] Pull request created and assigned
- [x] CI checks pass
- [x] Image pulls successfully
