### PR TITLE
Fix vLLM CUDA graph capture error (#681)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - VLLM_CUDA_GRAPH_CAPTURE=0
       - HF_HOME=/root/.cache/huggingface
       - TRANSFORMERS_CACHE=/root/.cache/huggingface
-    command: ["--model", "Qwen/Qwen2.5-Coder-0.5B-Instruct", "--gpu-memory-utilization", "0.8", "--max-model-len", "32768", "--port", "11434", "--enable-auto-tool-choice", "--tool-call-parser", "hermes"]
+    command: ["--model", "Qwen/Qwen2.5-Coder-0.5B-Instruct", "--gpu-memory-utilization", "0.8", "--max-model-len", "32768", "--port", "11434", "--enable-auto-tool-choice", "--tool-call-parser", "hermes", "--enforce-eager"]
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://127.0.0.1:11434/v1/models || exit 1"]
       interval: 10s


### PR DESCRIPTION
## Summary

Fixes #681

### Description of Changes

vLLM service was failing to start with CUDA stream capture errors in WSL2 environments. The service crashed during initialization when profiling CUDA graph memory.

### Root Cause

The error occurred during CUDA graph profiling phase:
- `cudaErrorStreamCaptureUnsupported` - operation not permitted when stream is capturing
- `cudaErrorStreamCaptureInvalidated` - previous error during capture

WSL2 detected with warning: "Not enough SMs to use max_autotune_gemm mode"

### Solution

Added `--enforce-eager` flag to vLLM command to disable CUDA graph optimization and force eager execution mode.

### Changes
- [x] Added `--enforce-eager` to vLLM command in `services/docker-compose.yml`

### Testing Notes

- Fix addresses WSL2 compatibility issue
- Disables CUDA graph capture which is incompatible with WSL2
- Maintains full vLLM functionality with eager execution

### Verification

To verify this change is complete:
- [x] vLLM container starts successfully
- [x] No CUDA graph capture errors in logs
- [x] Service responds to API requests
- [x] Health check passes

### Related Issues

- Closes #681