### PR TITLE
Add --enforce-eager flag to vLLM for WSL compatibility (#694)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - "--enable-auto-tool-choice"
       - "--tool-call-parser"
       - "hermes"
+      - "--enforce-eager"
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://127.0.0.1:11434/v1/models || exit 1"]
       interval: 10s


### PR DESCRIPTION
Fixes #694

## Summary
This PR adds the --enforce-eager flag to the vLLM startup command in docker-compose.yml to disable CUDA graph capture, which fails on WSL environments with limited GPU memory.

## Problem
vLLM was failing to initialize on systems with 8GB GPU memory running in WSL with the error cudaErrorStreamCaptureInvalidated during CUDA graph profiling. Even with reduced GPU memory utilization (0.8-0.9), vLLM could not complete initialization.

## Solution
Added --enforce-eager flag to the vLLM command in services/docker-compose.yml. This flag disables CUDA graph capture completely and prevents the profiling phase that causes the initialization failure.

## Changes
- services/docker-compose.yml: Added --enforce-eager to vLLM startup command

## Testing
- Verified vLLM now starts successfully with Qwen/Qwen2.5-Coder-0.5B-Instruct
- Service becomes healthy and responds to API requests
- All 12 services in sys profile are running correctly

## Benefits
- Allows vLLM to run on 8GB consumer GPUs
- Enables vLLM on WSL environments
- Improves compatibility with a wider range of hardware configurations