### PR TITLE
Use named volume for Hugging Face cache to avoid permission issues (#696)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     network_mode: host
     restart: unless-stopped
     volumes:
-      - ~/.cache/huggingface:/root/.cache/huggingface
+      - huggingface-cache:/root/.cache/huggingface
     environment:
       # vLLM runtime configuration (configured via .env)
       - VLLM_ALLOW_LONG_MAX_MODEL_LEN=${VLLM_ALLOW_LONG_MAX_MODEL_LEN:-1}
@@ -332,6 +332,7 @@ services:
 
 volumes:
   ollama:
+  huggingface-cache:
   vllm-data:
   llamacpp-data:
   open-webui:


### PR DESCRIPTION
Fixes #696

## Summary
This PR replaces the bind mount for Hugging Face cache with a named Docker volume to prevent permission conflicts between the container (running as root) and the host user.

## Problem
The vLLM service used a bind mount `~/.cache/huggingface:/root/.cache/huggingface` which caused permission issues:
- Container runs as root (uid=0)
- Host directory owned by user (uid=1000)
- Files written by container were owned by root on host
- Created permission mismatches and security concerns

## Solution
Replaced bind mount with a named Docker volume `huggingface-cache`:
- Docker manages permissions properly for named volumes
- No permission conflicts between container and host
- Data persists across container restarts
- Better security isolation

## Changes
- services/docker-compose.yml: Replaced bind mount with named volume
- Added `huggingface-cache` to volumes section

## Benefits
- Eliminates root-owned files in user home directory
- Prevents permission mismatches
- Cleaner separation between container and host
- No manual permission fixes needed

## Testing
- vLLM service starts without permission errors
- Models can be downloaded and cached correctly
- Volume persists across container restarts