### PR TITLE
Run PostgreSQL container as non-root user (#698)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -123,6 +123,7 @@ services:
     image: postgres:17.9
     container_name: postgres
     pull_policy: if_not_present
+    user: "999:999"  # Run as postgres user (official image default)
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-admin}
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD


### PR DESCRIPTION
Fixes #698 (partial)

## Summary
This PR adds the postgres user (UID 999) to run the PostgreSQL container as non-root instead of root.

## Changes
- Added user: 999:999 to postgres service in docker-compose.yml

## Security Benefits
- Container no longer runs as root
- Database files owned by postgres user
- Reduced attack surface
- Aligns with security best practices

## Testing Required
- [x] PostgreSQL service starts correctly
- [x] Health check passes
- [x] Database connections work
- [x] Open WebUI can connect to database
- [x] No permission errors in logs

## Related
- Part of container security hardening initiative (#698)
- PostgreSQL official image supports arbitrary user (since docker-library/postgres#253)
