### PR TITLE
Run Prometheus container as non-root user (#698)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -200,7 +200,6 @@ services:
       - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml
       - prometheus-data:/prometheus
-    user: root
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'


### PR DESCRIPTION
Fixes #698 (partial)

## Summary
This PR removes the user: root directive from the Prometheus service to allow it to run as the default nobody user (UID 65534), improving security posture.

## Changes
- Removed user: root from prometheus service in docker-compose.yml

## Security Benefits
- Container no longer runs as root
- Metrics data owned by nobody user
- Reduced attack surface
- Aligns with security best practices

## Technical Details
The Prometheus official image (v3.11.1) runs as nobody user (65534) by default when no user directive is specified. Removing our override allows the image to use its secure default.

## Testing Required
- [x] Prometheus service starts correctly
- [x] Health check passes
- [x] Metrics collection works
- [x] No permission errors in logs
- [x] Grafana can access Prometheus data

## Related
- Part of container security hardening initiative (#698)
