### PR TITLE
Run Grafana container as non-root user (#698)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -231,7 +231,6 @@ services:
       - prometheus
       - loki
     restart: unless-stopped
-    user: root
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
       interval: 30s


### PR DESCRIPTION
Fixes #698 (partial)

## Summary
This PR removes the user: root directive from the Grafana service to allow it to run as the default grafana user (UID 472), improving security posture.

## Changes
- Removed user: root from grafana service in docker-compose.yml

## Security Benefits
- Container no longer runs as root
- Dashboards and data owned by grafana user
- Reduced attack surface
- Aligns with security best practices

## Technical Details
The Grafana official image (v8+) runs as grafana user (UID 472) by default when no user directive is specified. Removing our override allows the image to use its secure default.

## Testing Required
- [x] Grafana service starts correctly
- [x] Health check passes
- [x] Dashboards accessible
- [x] Prometheus and Loki data sources work
- [x] No permission errors in logs

## Related
- Part of container security hardening initiative (#698)
