### PR TITLE
Run Loki container as non-root user (#698)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -301,7 +301,6 @@ services:
     volumes:
       - ../loki/loki-config.yml:/etc/loki/loki-config.yml
       - loki-data:/loki
-    user: root
     command: -config.file=/etc/loki/loki-config.yml
     network_mode: host
     restart: unless-stopped


### PR DESCRIPTION
Fixes #698 (partial)

## Summary
This PR removes the user: root directive from the Loki service to allow it to run as the default loki user (UID 10001), improving security posture.

## Changes
- Removed user: root from loki service in docker-compose.yml

## Security Benefits
- Container no longer runs as root
- Log data owned by loki user
- Reduced attack surface
- Aligns with security best practices

## Technical Details
The Loki official image (3.3.0) runs as loki user (UID 10001) by default when no user directive is specified. Removing our override allows the image to use its secure default.

## Testing Required
- [x] Loki service starts correctly
- [x] Health check passes
- [x] Logs are being collected
- [x] No permission errors in logs

## Related
- Part of container security hardening initiative (#698)
