### PR TITLE
Run pgAdmin container as non-root user (#698)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -167,7 +167,6 @@ services:
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-data:/var/lib/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
-    user: "0:0"
     network_mode: host
     depends_on:
       - postgres


### PR DESCRIPTION
Fixes #698 (partial)

## Summary
This PR removes the user: 0:0 directive from the pgAdmin service to allow it to run as the default pgadmin user (UID 5050), improving security posture.

## Changes
- Removed user: 0:0 from pgadmin service in docker-compose.yml

## Security Benefits
- Container no longer runs as root
- Configuration and data owned by pgadmin user
- Reduced attack surface

## Technical Details
The pgAdmin official image (9.14.0) runs as pgadmin user (UID 5050) by default when no user directive is specified. The existing entrypoint already handles permissions correctly.

## Testing Required
- [x] pgAdmin service starts correctly
- [x] Health check passes
- [x] Can connect to PostgreSQL
- [x] No permission errors in logs

## Related
- Part of container security hardening initiative (#698)
