### PR TITLE
security: Run postgres-exporter as non-root user (#710)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -275,6 +275,7 @@ services:
     image: prometheuscommunity/postgres-exporter:v0.19.1
     container_name: postgres-exporter
     pull_policy: if_not_present
+    user: "65534:65534"  # nobody user - official image default
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}?sslmode=disable"
     network_mode: host


### PR DESCRIPTION
## Summary

Add explicit user: 65534:65534 (nobody) directive to postgres-exporter service.

The official prometheuscommunity/postgres-exporter:v0.19.1 image already defaults to the nobody user. This change makes the non-root execution explicit, improving security documentation and ensuring the security posture is clear.

## Changes
- [x] Added user: 65534:65534 to postgres-exporter service in docker-compose.yml

## Security Benefits
- Explicit non-root execution documented
- TCP-only connections require no special privileges
- Aligns with container security hardening initiative
- Reduces attack surface

## Testing
- [x] All services start successfully (10/10 healthy)
- [x] postgres-exporter running as nobody user (confirmed via docker inspect)
- [x] Process running as nobody (confirmed via ps aux in container)
- [x] Metrics endpoint responding on :9187
- [x] No regressions observed

Fixes #710