### PR TITLE
security: Harden Alloy container security configuration (#704)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -275,6 +275,7 @@ services:
     image: prometheuscommunity/postgres-exporter:v0.19.1
     container_name: postgres-exporter
     pull_policy: if_not_present
+    user: "65534:65534"  # nobody user - official image default
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}?sslmode=disable"
     network_mode: host
@@ -309,18 +310,26 @@ services:
       timeout: 10s
       retries: 3
 
-  # SECURITY NOTE: alloy requires Docker socket access for container log discovery.
-  # This is equivalent to root access on the host. See docs/reference/security.md
-  # section 6 for details and mitigation options.
+  # SECURITY NOTE: Alloy requires Docker socket access for container log discovery.
+  # Docker socket access grants full root access on the host. Security mitigations applied:
+  # - Runs as root within container (required for Docker socket access)
+  # - Uses no-new-privileges to prevent privilege escalation
+  # - Read-only bind mounts for configuration files
+  # - Docker socket path auto-detected (supports rootless via DOCKER_SOCK env var)
+  # See docs/operations/security.md section 6 for details.
   alloy:
     image: grafana/alloy:v1.15.0
     container_name: alloy
     pull_policy: if_not_present
+    user: "0:0"  # root required for Docker socket access
+    security_opt:
+      - no-new-privileges:true
     volumes:
-      - ../alloy/config.alloy:/etc/alloy/config.alloy
+      - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - alloy-data:/data-alloy
       - /var/log:/var/log:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
+      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:ro
     command: run /etc/alloy/config.alloy
     network_mode: host
     depends_on:
@@ -338,3 +347,4 @@ volumes:
   prometheus-data:
   grafana-data:
   loki-data:
+  alloy-data:


### PR DESCRIPTION
## Summary

Add security hardening to Alloy service to mitigate risks from Docker socket access.

## Problem

Alloy requires Docker socket access for container log discovery, which grants full root access to the host if compromised.

## Solution

Applied defense-in-depth security measures:

### Changes

| Setting | Before | After | Purpose |
|---------|--------|-------|---------|
| user | (default) | 0:0 | Explicit root with justification |
| security_opt | - | no-new-privileges:true | Prevents privilege escalation |
| config mount | - | :ro | Read-only configuration |
| docker.sock mount | - | :ro | Read-only socket (write not needed) |
| data volume | - | alloy-data:/data-alloy | Writable data directory |

### Security Benefits

- **No-new-privileges**: Container cannot gain additional capabilities
- **Read-only mounts**: Configuration files cannot be modified at runtime
- **Named volume**: Data persistence without host bind mounts
- **Explicit documentation**: Clear security trade-offs documented

## Testing

- [x] All services start successfully (9/10 healthy - Loki still starting)
- [x] Alloy container running with security options
- [x] Log collection functional (verified in logs)
- [x] Container logs show file tailing active
- [x] No permission errors

## Verification



**Note**: Docker socket access still grants full host root, but these mitigations limit container escape vectors.

Relates to #698 Fixes #704
