### PR TITLE
fix: Add read_only and tmpfs to Alloy security configuration

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -314,7 +314,9 @@ services:
   # Docker socket access grants full root access on the host. Security mitigations applied:
   # - Runs as root within container (required for Docker socket access)
   # - Uses no-new-privileges to prevent privilege escalation
-  # - Read-only bind mounts for configuration files
+  # - Read-only root filesystem prevents runtime modifications
+  # - Writable data volume for Alloy state, tmpfs for temporary files
+  # - All bind mounts are read-only (:ro suffix)
   # - Docker socket path auto-detected (supports rootless via DOCKER_SOCK env var)
   # See docs/operations/security.md section 6 for details.
   alloy:
@@ -324,6 +326,9 @@ services:
     user: "0:0"  # root required for Docker socket access
     security_opt:
       - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
     volumes:
       - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
       - alloy-data:/data-alloy


### PR DESCRIPTION
## Summary

Fixes missing security settings from PR #715 - adds read_only: true and tmpfs to Alloy service.

## Changes

- Added read_only: true for immutable root filesystem
- Added tmpfs: /tmp for temporary writable space
- Updated security documentation comments

## Why This Matters

The original PR #715 was supposed to include these settings but they were omitted. Without read_only: true, the container has a writable root filesystem which increases attack surface.

## Testing

- [x] All services start successfully (10/10 healthy)
- [x] Alloy container running with read_only: true
- [x] Log collection functional (verified in logs)
- [x] No permission errors
- [x] tmpfs mounted at /tmp

## Verification



Relates to #704 Follow-up to #715
