### PR TITLE
security: Run Ollama as non-root user (#707)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   ollama:
+    image: docker.io/ollama/ollama:0.20.5
+    container_name: ollama
+    pull_policy: if_not_present
+    user: "1000:1000"  # Run as ubuntu user (official image default)
     volumes:
-      - ollama:/root/.ollama
+      - ollama:/home/ubuntu/.ollama
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
       # Performance tuning for parallel model queries (configured via .env)
@@ -10,12 +14,9 @@ services:
       - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-1800}
       - OLLAMA_NUM_GPU=${OLLAMA_NUM_GPU:-1}
       - OLLAMA_NUM_THREAD=${OLLAMA_NUM_THREAD:-8}
-    container_name: ollama
-    pull_policy: if_not_present
     tty: true
     network_mode: host
     restart: unless-stopped
-    image: docker.io/ollama/ollama:0.20.5
     # GPU resources are configured in docker-compose.gpu.yml when available
     # ARM64 platform is configured in docker-compose.arm.yml when detected
     healthcheck:


### PR DESCRIPTION
## Summary

Run Ollama inference engine as non-root user (ubuntu, UID 1000) instead of root.

## Problem

Ollama was running as root (default) despite the official image including a ubuntu user capable of running the service with full GPU access.

## Solution

Added explicit user directive and updated volume path:

| Setting | Before | After |
|---------|--------|-------|
| user | (default: root) | 1000:1000 (ubuntu) |
| volume path | /root/.ollama | /home/ubuntu/.ollama |

## Testing

- [x] Stack starts with usr profile
- [x] Ollama process running as ubuntu user
- [x] Volume mounted at /home/ubuntu/.ollama
- [x] GPU access confirmed (tested earlier)
- [x] All health checks passing
- [x] 2/2 services healthy

## Verification

```
User: 1000:1000
Process: /bin/ollama serve (running as ubuntu)
Volume: /home/ubuntu/.ollama:rw
```

## Security Benefits

- Runtime core component no longer requires root
- Models and data owned by ubuntu user
- GPU inference works correctly with non-root user
- Aligns with security hardening initiative

Fixes #707
