### PR TITLE
security: Run node-exporter as non-root user (#709)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -260,6 +260,7 @@ services:
     image: prom/node-exporter:v1.11.1
     container_name: node-exporter
     pull_policy: if_not_present
+    user: "65534:65534"  # nobody user - official image default
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro


### PR DESCRIPTION
## Summary

Add explicit user: 65534:65534 (nobody) directive to node-exporter service.

## Problem

node-exporter was running as root (default) despite the official image defaulting to nobody user.

## Solution

Added explicit user directive matching the official image default.

| Setting | Before | After |
|---------|--------|-------|
| user | (default: root) | 65534:65534 (nobody) |

## Testing

- [x] Stack starts successfully with ops profile
- [x] node-exporter running as nobody user (verified via docker inspect)
- [x] Process running as nobody (verified via ps aux)
- [x] Metrics endpoint responding on :9100
- [x] Host metrics collection functional
- [x] No permission errors with RO mounts

## Verification



Fixes #709