### PR TITLE
Fix llama.cpp model configuration and documentation (#719)

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -103,6 +103,6 @@ OLLAMA_NUM_THREAD=8
 # llama.cpp Configuration
 # Model file to load when using llama.cpp engine (must be .gguf format)
 # Place model files in the llamacpp-data volume or mount them
-# Default: qwen2.5-coder-1.5b-instruct-q4_k_m.gguf
+# Default: qwen2.5-coder-0.5b-instruct-q4_k_m.gguf (matches INFERENCE_MODEL default)
 # Example models: https://huggingface.co/models?library=gguf
-LLAMACPP_MODEL=qwen2.5-coder-1.5b-instruct-q4_k_m.gguf
+LLAMACPP_MODEL=qwen2.5-coder-0.5b-instruct-q4_k_m.gguf

--- a/scripts/runtime/llamacpp-entrypoint.sh
+++ b/scripts/runtime/llamacpp-entrypoint.sh
@@ -19,7 +19,7 @@ MODEL_PATH="/models/${MODEL_FILE}"
 if [ ! -f "$MODEL_PATH" ]; then
     echo "⚠️  Model file not found: ${MODEL_PATH}"
     echo "   Download a model using: ./aixcl models add <path/to/model.gguf>"
-    echo "   Example: ./aixcl models add bartowski/Qwen2.5-Coder-0.5B-Instruct-GGUF/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf"
+    echo "   Example: ./aixcl models add Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf"
     echo ""
     echo "   Container will exit gracefully (no crash-loop)"
     echo "   Run models add, then the container will auto-restart with the model"


### PR DESCRIPTION
Fixes #719

## Summary
Synchronizes llama.cpp model configuration defaults and updates documentation to match README.md.

## Changes
- [x] config/.env.example: Changed LLAMACPP_MODEL default from 1.5b to 0.5b to match INFERENCE_MODEL
- [x] scripts/runtime/llamacpp-entrypoint.sh: Updated error message example to match README documented model path
- [x] Updated comments to reference correct default values

## Problem
1. Configuration mismatch between INFERENCE_MODEL (0.5b) and LLAMACPP_MODEL (1.5b)
2. Error message suggested bartowski repo instead of Qwen repo (README documented)

## Solution
1. Aligned LLAMACPP_MODEL with INFERENCE_MODEL default (0.5b)
2. Updated error message to use correct repo path and lowercase filename

## Verification
- [x] Container will find correct model after fresh start
- [x] Error message matches README documentation
- [x] Both .env.example and runtime script are consistent

Fixes #719