### PR TITLE
Run Open WebUI as non-root user (#706)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Open WebUI Non-Root Entrypoint
+# This script sets up proper permissions and then runs Open WebUI as non-root user
+
+set -e
+
+# Default user/group IDs
+USER_ID="${USER_ID:-1000}"
+GROUP_ID="${GROUP_ID:-1000}"
+
+echo "=== Open WebUI Non-Root Entrypoint ==="
+echo "Target UID: $USER_ID"
+echo "Target GID: $GROUP_ID"
+
+# Check if running as root (required for permission setup)
+if [ "$(id -u)" = "0" ]; then
+    echo "Running as root - setting up permissions..."
+    
+    # Create non-root user if it doesn't exist
+    if ! id "webui" &>/dev/null; then
+        groupadd -g "$GROUP_ID" -o webui 2>/dev/null || true
+        useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
+    fi
+    
+    # Ensure data directories exist and have correct ownership
+    # These are the volumes mounted from docker-compose
+    for dir in /app/backend/data /app/data; do
+        if [ -d "$dir" ]; then
+            echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
+            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
+            chmod 755 "$dir" 2>/dev/null || true
+        fi
+    done
+    
+    # Ensure the startup script is executable
+    if [ -f "/app/backend/openwebui.sh" ]; then
+        chmod +x /app/backend/openwebui.sh
+        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh
+    fi
+    
+    # Ensure the entrypoint can write to /tmp (uvicorn needs this)
+    chown -R "$USER_ID:$GROUP_ID" /tmp 2>/dev/null || true
+    chmod 1777 /tmp
+    
+    echo "Switching to webui user (UID: $USER_ID)..."
+    # Re-run this script as the non-root user using su
+    # Use -c to execute command with the user's environment
+    exec su - webui -c "exec /usr/local/bin/openwebui-entrypoint.sh '$@'"
+fi
+
+# At this point, we should be running as non-root
+CURRENT_UID="$(id -u)"
+CURRENT_GID="$(id -g)"
+echo "Running as user: $CURRENT_UID:$CURRENT_GID"
+
+# Change to backend directory
+cd /app/backend || exit 1
+
+# Execute the original Open WebUI startup script
+echo "Starting Open WebUI..."
+exec bash /app/backend/openwebui.sh "$@"

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -24,9 +24,14 @@ if [ "$(id -u)" = "0" ]; then
     
     # Ensure data directories exist and have correct ownership
     # These are the volumes mounted from docker-compose
-    for dir in /app/backend/data /app/data; do
+    for dir in /app/backend/data /app/data /app/backend/data/static; do
         if [ -d "$dir" ]; then
             echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
+            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
+            chmod 755 "$dir" 2>/dev/null || true
+        else
+            echo "Creating directory $dir"
+            mkdir -p "$dir" 2>/dev/null || true
             chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
             chmod 755 "$dir" 2>/dev/null || true
         fi

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -32,10 +32,10 @@ if [ "$(id -u)" = "0" ]; then
         fi
     done
     
-    # Ensure the startup script is executable
+    # Ensure the startup script is executable (ignore errors if read-only mount)
     if [ -f "/app/backend/openwebui.sh" ]; then
-        chmod +x /app/backend/openwebui.sh
-        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh
+        chmod +x /app/backend/openwebui.sh 2>/dev/null || true
+        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh 2>/dev/null || true
     fi
     
     # Ensure the entrypoint can write to /tmp (uvicorn needs this)

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -54,8 +54,16 @@ CURRENT_UID="$(id -u)"
 CURRENT_GID="$(id -g)"
 echo "Running as user: $CURRENT_UID:$CURRENT_GID"
 
-# Change to backend directory
-cd /app/backend || exit 1
+# Ensure data directory exists and is writable
+DATA_DIR="/app/backend/data"
+if [ ! -d "$DATA_DIR" ]; then
+    echo "Error: Data directory $DATA_DIR does not exist"
+    exit 1
+fi
+
+# Change to data directory where the secret key will be stored
+cd "$DATA_DIR" || exit 1
+echo "Working directory: $(pwd)"
 
 # Execute the original Open WebUI startup script
 echo "Starting Open WebUI..."

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -45,7 +45,8 @@ if [ "$(id -u)" = "0" ]; then
     echo "Switching to webui user (UID: $USER_ID)..."
     # Re-run this script as the non-root user using su
     # Use -c to execute command with the user's environment
-    exec su - webui -c "exec /usr/local/bin/openwebui-entrypoint.sh '$@'"
+    export -n USER_ID GROUP_ID  # Don't export these to avoid confusion
+    exec su - webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
 fi
 
 # At this point, we should be running as non-root

--- a/scripts/runtime/openwebui.sh
+++ b/scripts/runtime/openwebui.sh
@@ -2,7 +2,9 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "$SCRIPT_DIR" || exit
 
-KEY_FILE=.webui_secret_key
+# Store secret key in data directory (writable by non-root user)
+DATA_DIR="${DATA_DIR:-/app/backend/data}"
+KEY_FILE="$DATA_DIR/.webui_secret_key"
 PORT="${PORT:-8080}"
 HOST="${HOST:-127.0.0.1}"
 if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -95,10 +95,12 @@ services:
     image: ghcr.io/open-webui/open-webui:v0.8.12
     container_name: open-webui
     pull_policy: if_not_present
+    user: "0:0"  # Start as root for permission setup, entrypoint switches to non-root
     volumes:
       - open-webui:/app/backend/data
       - open-webui-data:/app/data
       - ../scripts/runtime/openwebui.sh:/app/backend/openwebui.sh
+      - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
     environment:
       - DATA_DIR=/app/data
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}
@@ -110,13 +112,16 @@ services:
       - OPENWEBUI_PASSWORD=${OPENWEBUI_PASSWORD}
       - RAG_EMBEDDING_ENGINE=ollama
       - RAG_EMBEDDING_MODEL=nomic-embed-text
+      - USER_ID=1000
+      - GROUP_ID=1000
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
       - postgres
     network_mode: host
     restart: always
-    command: ["/bin/bash", "-c", "chmod +x openwebui.sh && bash openwebui.sh"]
+    entrypoint: ["/usr/local/bin/openwebui-entrypoint.sh"]
+    command: []
     healthcheck:
       # Try /health first, fallback to root endpoint if /health doesn't exist
       test: ["CMD-SHELL", "curl -f http://127.0.0.1:8080/health > /dev/null 2>&1 || curl -f http://127.0.0.1:8080/ > /dev/null 2>&1"]

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
     environment:
       - DATA_DIR=/app/data
+      - STATIC_DIR=/app/backend/data/static
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}
       - WEBUI_NAME=AIXCL
       - OLLAMA_BASE_URL=http://127.0.0.1:11434


### PR DESCRIPTION
## Summary

Fixes #706

### Description of Changes

This PR implements non-root execution for Open WebUI, addressing the security requirement to run containers with reduced privileges.

### Changes

- [services/docker-compose.yml]:
 - Added `user: "0:0"` directive with entrypoint-based privilege dropping
 - Added entrypoint configuration pointing to custom script
 - Added `STATIC_DIR` environment variable for writable static files
 - Added USER_ID and GROUP_ID environment variables for configurability

- [scripts/runtime/openwebui-entrypoint.sh]: Created new entrypoint script that:
 - Starts as root to set up permissions
 - Creates webui user with UID 1000:GID 1000
 - Sets ownership of data directories (`/app/backend/data`, `/app/data`)
 - Creates `STATIC_DIR` with proper permissions
 - Switches to non-root user using `su`
 - Executes Open WebUI as webui user

- [scripts/runtime/openwebui.sh]: Modified to:
 - Store WEBUI_SECRET_KEY in `DATA_DIR` instead of current directory
 - Ensures non-root user can write secret key

### Security Benefits

- Open WebUI now runs as non-root user (UID 1000) instead of root
- Data directories have proper ownership restrictions
- Static files written to writable location
- Follows defense-in-depth security principles
- Aligns with container security best practices (CIS Docker Benchmark)

### Testing Results

Tested with Open WebUI v0.8.12:
- [x] Container starts with root user for permission setup
- [x] webui user (UID 1000) created successfully
- [x] Data directories ownership changed to webui:webui
- [x] STATIC_DIR created with proper ownership
- [x] Secret key generation succeeds in data directory
- [x] Process switches to non-root user
- [x] Database migrations run successfully
- [x] Open WebUI starts and runs as UID 1000

### Implementation Pattern

This follows the same successful pattern used for:
- PostgreSQL (UID 999) - #699
- Prometheus (nobody) - #700
- Grafana (grafana user) - #701
- Loki (UID 10001) - #702
- pgAdmin (UID 5050) - #703

### Verification

- [x] All CI checks passing (Shell Script Linting, Dependency Review, Security Tests, Validate Shell Scripts)
- [x] Container builds and starts correctly
- [x] Non-root execution confirmed in logs
- [x] Data directories have correct ownership
- [x] No permission errors during startup

### Related Issues

- Parent: #698 (Container Security Hardening Initiative)
- Related: #699-#703 (Successful non-root implementations)
