### PR TITLE
Fix Ollama volume permissions with entrypoint script (#726)

### DIFF
--- a/scripts/runtime/ollama-entrypoint.sh
+++ b/scripts/runtime/ollama-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Ollama entrypoint wrapper - ensures correct permissions for Ollama data directory
+
+set -e
+
+# Configuration
+OLLAMA_USER="ubuntu"
+OLLAMA_UID="1000"
+OLLAMA_HOME="/home/ubuntu"
+OLLAMA_DATA="$OLLAMA_HOME/.ollama"
+
+# Create ubuntu user if it doesn't exist
+if ! id "$OLLAMA_USER" &>/dev/null; then
+    echo "Creating $OLLAMA_USER user (UID: $OLLAMA_UID)..."
+    useradd -m -u "$OLLAMA_UID" "$OLLAMA_USER"
+fi
+
+# Ensure .ollama directory exists with correct ownership
+mkdir -p "$OLLAMA_DATA"
+chown -R "$OLLAMA_USER:$OLLAMA_USER" "$OLLAMA_HOME"
+
+# Add user to video and render groups for GPU access (if they exist)
+usermod -aG video,render "$OLLAMA_USER" 2>/dev/null || true
+
+echo "Starting Ollama as $OLLAMA_USER user..."
+
+# Switch to ubuntu user and execute ollama
+exec su - "$OLLAMA_USER" -c "exec ollama serve"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -3,9 +3,11 @@ services:
     image: docker.io/ollama/ollama:0.20.5
     container_name: ollama
     pull_policy: if_not_present
-    user: "1000:1000"  # Run as ubuntu user (official image default)
+    user: "0:0"  # Start as root to set permissions, entrypoint switches to ubuntu user
     volumes:
       - ollama:/home/ubuntu/.ollama
+      - ../scripts/runtime/ollama-entrypoint.sh:/ollama-entrypoint.sh:ro
+    entrypoint: ["/ollama-entrypoint.sh"]
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
       # Performance tuning for parallel model queries (configured via .env)


### PR DESCRIPTION
Fixes #726

## Summary
Adds an entrypoint script for Ollama to fix volume permission issues on fresh installs.

## Changes
- Created scripts/runtime/ollama-entrypoint.sh - ensures correct ownership of /home/ubuntu/.ollama
- Modified services/docker-compose.yml - use entrypoint script and start as root (switches to ubuntu user)
- Aligns with existing vLLM and llama.cpp entrypoint patterns

## Root Cause
Ollama container running as UID 1000:1000 but volume ownership was incorrect, causing permission denied on SSH key generation.

## Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-726/fix-ollama-permissions)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

## Testing Notes
Tested on fresh repository clone:
- ./aixcl stack start --profile usr
- Container starts without permission errors
- SSH key generates successfully
- Model downloads work correctly

## Verification
- [x] Fresh install: ./aixcl stack start --profile usr
- [x] Container starts without permission errors
- [x] SSH key generates successfully
- [x] Model downloads work correctly

## Related Issues
- Closes #726
- Similar pattern used in vllm-entrypoint.sh and llamacpp-entrypoint.sh