### PR TITLE
Fix llama.cpp API model path handling by creating symlink (#727)

### DIFF
--- a/scripts/runtime/llamacpp-entrypoint.sh
+++ b/scripts/runtime/llamacpp-entrypoint.sh
@@ -14,7 +14,9 @@ if [ -z "$MODEL_FILE" ]; then
     exit 0
 fi
 
-MODEL_PATH="/models/${MODEL_FILE}"
+# Extract just the filename from full path (e.g., "Qwen/.../model.gguf" -> "model.gguf")
+MODEL_BASENAME="$(basename "$MODEL_FILE")"
+MODEL_PATH="/models/${MODEL_BASENAME}"
 
 if [ ! -f "$MODEL_PATH" ]; then
     echo "⚠️  Model file not found: ${MODEL_PATH}"
@@ -26,7 +28,21 @@ if [ ! -f "$MODEL_PATH" ]; then
     exit 0
 fi
 
-echo "✅ Model found: ${MODEL_FILE}"
+echo "✅ Model found: ${MODEL_BASENAME}"
+
+# Create a symlink with the original full path name if it differs from basename
+# This ensures API calls work with either the short name or full path
+if [ "$MODEL_FILE" != "$MODEL_BASENAME" ] && [ ! -f "/models/${MODEL_FILE}" ]; then
+    # Create directory structure for the full path if needed
+    MODEL_DIR="$(dirname "/models/${MODEL_FILE}")"
+    if [ "$MODEL_DIR" != "/models" ]; then
+        mkdir -p "$MODEL_DIR"
+    fi
+    # Create symlink from full path to actual file
+    ln -sf "$MODEL_PATH" "/models/${MODEL_FILE}"
+    echo "   Created symlink: ${MODEL_FILE} -> ${MODEL_BASENAME}"
+fi
+
 echo "🚀 Starting llama.cpp server..."
 
 # Start the actual llama.cpp server with the model


### PR DESCRIPTION
Fixes #727

## Summary
Fixes the issue where llama.cpp API required the full HuggingFace path for model parameter instead of just the filename.

## Changes
- Modified scripts/runtime/llamacpp-entrypoint.sh to:
 - Extract basename from INFERENCE_MODEL (e.g., 'model.gguf')
 - Create a symlink from the full HuggingFace path to the actual model file
 - Support API calls using either short or full path model names

## Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-727/fix-llamacpp-model-name)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

## Testing Notes
Tested with llama.cpp engine:
- Added model: ./aixcl models add Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf
- Verified symlink created in container
- Tested API with both paths:
 - Full path: Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF/qwen2.5-coder-0.5b-instruct-q4_k_m.gguf ✅
 - Short name: qwen2.5-coder-0.5b-instruct-q4_k_m.gguf ✅

## Verification
- [x] Container starts without errors
- [x] Symlink created successfully
- [x] API accepts full HF path
- [x] API accepts short model name
- [x] Inference works with both paths

## Related Issues
- Closes #727
- Makes llama.cpp API behavior consistent with Ollama and vLLM
