### PR TITLE
[HOTFIX] Fix vLLM command syntax error in docker-compose.yml

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     # Use custom entrypoint to run as non-root user
     entrypoint: ["/vllm-entrypoint.sh"]
     # vLLM startup command with configurable model and memory settings
-    command: ["--model", "Qwen/Qwen2.5-Coder-0.5B-Instruct", "--gpu-memory-utilization", "0.8", "--max-model-len", "32768", "--port", "11434", "--enable-auto-tool-choice", "--tool-call-parser", "hermes", "--enforce-eager"]
+    command:
       - "--model"
       - "${VLLM_MODEL:-Qwen/Qwen2.5-Coder-0.5B-Instruct}"
       - "--gpu-memory-utilization"


### PR DESCRIPTION
## Description

Fixes YAML syntax error in vLLM service command that broke stack operations.

## Problem

PR #731 introduced a malformed vLLM command section with duplicate/mixed array formats:


This caused:


## Fix

Converted to proper YAML list format:


## Verification
- [x] docker compose config validates successfully
- [x] ./aixcl stack stop works correctly
- [x] ./aixcl stack start works correctly

## Emergency Fix
This is a hotfix for broken main branch.