### PR TITLE
Remove OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX from env files (#730 follow-up)

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -67,13 +67,6 @@ VLLM_CUDA_GRAPH_CAPTURE=0
 # Set to '1' to enable, unset to disable
 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 
-# OpenCode Token Limit Configuration (for vLLM compatibility)
-# vLLM enforces strict token limits based on model's max_position_embeddings.
-# OpenCode defaults to 32000 output tokens which can exceed vLLM's limit.
-# Set this to limit OpenCode's max output tokens (recommended: 8192 for 32K models)
-# Example: 8192 output tokens + ~7000 input tokens = ~15192 total < 32768 limit
-OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192
-
 # Ollama Configuration
 # Number of parallel model queries to handle simultaneously
 # Higher values improve throughput but increase memory usage

--- a/docs/developer/env-configuration.md
+++ b/docs/developer/env-configuration.md
@@ -45,10 +45,9 @@ ENABLE_OLLAMA_API=false      # Use OpenAI-compatible API
 - `VLLM_MAX_MODEL_LEN`: Maximum context length (default 32768)
 
 **OpenCode Configuration**:
-```bash
-OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192
-```
-This prevents vLLM token limit errors. Recommended: 8192 for 32K context models.
+When using vLLM, the CLI automatically exports `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192` to prevent vLLM token limit errors. This is handled programmatically by `./aixcl engine set vllm` and does not need to be set manually in `.env`.
+
+Recommended: 8192 output tokens for 32K context models (leaves room for ~7000 input tokens).
 
 **Model Management**:
 - vLLM downloads models automatically on first start
@@ -112,10 +111,11 @@ Used when profile includes Open WebUI (dev, ops, sys).
 
 **Error**: `Token limit exceeded` or OpenCode generates indefinitely
 
-**Fix**: Ensure `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` is set:
-```bash
-OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192
-```
+**Fix**: This is automatically handled when using `./aixcl engine set vllm`. The CLI exports `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX=8192` to limit output tokens. If you still see issues:
+
+1. Verify you're using the AIXCL CLI: `./aixcl` instead of running containers directly
+2. Check the engine is set: `./aixcl engine set vllm`
+3. Restart services: `./aixcl stack restart engine`
 
 ### Model Not Found After Engine Switch
 


### PR DESCRIPTION
Follow-up to #730 - removes the OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX variable from environment files since it should be exported programmatically.

## Changes
- [x] Removed OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX from config/.env.example
- [x] Removed OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX from local .env
- [x] Updated documentation to reflect programmatic handling

## Rationale
This variable should be set automatically when using ./aixcl engine set vllm:
- Ensures consistent behavior across environments
- No manual configuration required
- Handled by CLI based on active engine

## Verification
- [x] ./aixcl engine set vllm exports the variable
- [x] OpenCode respects the token limit
- [x] No vLLM token limit errors

## Related
- Follow-up to #730 (environment variable cleanup)
- Documentation updated in PR #733