### PR TITLE
Fix engine switch deleting Open WebUI database (#735)

### DIFF
--- a/lib/aixcl/commands/engine.sh
+++ b/lib/aixcl/commands/engine.sh
@@ -69,16 +69,6 @@ function engine() {
             fi
         fi
         
-        # Clear Open WebUI model cache to force re-discovery with new API settings
-        echo "[x] Clearing Open WebUI model cache..."
-        if docker ps --filter name=open-webui --format "{{.Names}}" | grep -q open-webui 2>/dev/null; then
-            # Open WebUI is running - clear its model cache via API
-            docker exec open-webui rm -f /app/backend/data/webui.db 2>/dev/null || true
-            echo "   Note: Open WebUI model cache cleared. Database will be recreated on next start."
-        else
-            echo "   Note: Open WebUI not running. Model cache will be cleared on next start."
-        fi
-        
         echo "Note: Stop and start the stack for the change to take effect:"
         echo "  ./aixcl stack stop && ./aixcl stack start"
     elif [ "$action" = "auto" ]; then
@@ -115,16 +105,6 @@ function engine() {
             echo "[x] Open WebUI Ollama API enabled (for full Ollama feature support)"
         else
             echo "[x] Open WebUI Ollama API disabled (using OpenAI-compatible API)"
-        fi
-        
-        # Clear Open WebUI model cache to force re-discovery with new API settings
-        echo "[x] Clearing Open WebUI model cache..."
-        if docker ps --filter name=open-webui --format "{{.Names}}" | grep -q open-webui 2>/dev/null; then
-            # Open WebUI is running - clear its model cache via API
-            docker exec open-webui rm -f /app/backend/data/webui.db 2>/dev/null || true
-            echo "   Note: Open WebUI model cache cleared. Database will be recreated on next start."
-        else
-            echo "   Note: Open WebUI not running. Model cache will be cleared on next start."
         fi
         
         # Clear opencode.json model when engine changes (model will need to be re-added)


### PR DESCRIPTION
Fixes #735

## Summary
Removes the destructive database deletion from the engine switch command that was destroying user chat history, prompts, and settings.

## Problem
The engine switch command (./aixcl engine set <engine>) was executing:


This deleted the entire Open WebUI SQLite database, destroying:
- User chat history and conversations
- Saved prompts
- User accounts
- Configuration settings

## Solution
Removed lines 72-80 (and duplicate in auto section) that performed this deletion. Open WebUI automatically re-discovers models on restart with new API settings, so this operation is unnecessary.

## Changes
- [x] Removed database deletion from "engine set" command
- [x] Removed database deletion from "engine auto" command
- [x] User data now persists across engine switches

## Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

## Testing
- Engine switch now preserves chat history
- Engine switch preserves user accounts
- Engine switch preserves settings
- Models are still correctly discovered after switch

## Related Issues
- Closes #735