### PR TITLE
[HOTFIX] Create pgadmin user in entrypoint before switching

### DIFF
--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -4,10 +4,16 @@
 set -e
 
 # pgAdmin runs as user 5050 (pgadmin)
-PGADMIN_USER="5050"
+PGADMIN_UID="5050"
 PGADMIN_HOME="/var/lib/pgadmin"
 
 echo "Setting up pgAdmin directories..."
+
+# Create pgadmin user if it doesn't exist
+if ! id "$PGADMIN_UID" &>/dev/null; then
+    echo "Creating pgadmin user (UID: $PGADMIN_UID)..."
+    useradd -m -u "$PGADMIN_UID" pgadmin
+fi
 
 # Create required directories if they don't exist
 mkdir -p "$PGADMIN_HOME/sessions"
@@ -15,15 +21,15 @@ mkdir -p "$PGADMIN_HOME/storage"
 mkdir -p "/var/log/pgadmin"
 
 # Ensure correct ownership (pgadmin user is 5050)
-chown -R "$PGADMIN_USER:$PGADMIN_USER" "$PGADMIN_HOME"
-chown -R "$PGADMIN_USER:$PGADMIN_USER" "/var/log/pgadmin"
+chown -R "$PGADMIN_UID:$PGADMIN_UID" "$PGADMIN_HOME"
+chown -R "$PGADMIN_UID:$PGADMIN_UID" "/var/log/pgadmin"
 
 # Set proper permissions
 chmod 755 "$PGADMIN_HOME"
 chmod 700 "$PGADMIN_HOME/sessions"
 chmod 755 "$PGADMIN_HOME/storage"
 
-echo "Starting pgAdmin as user $PGADMIN_USER..."
+echo "Starting pgAdmin as user $PGADMIN_UID..."
 
 # Switch to pgadmin user and run the original entrypoint
-exec su - "$PGADMIN_USER" -c "exec /entrypoint.sh"
+exec su - pgadmin -c "exec /entrypoint.sh"


### PR DESCRIPTION
Hotfix for pgadmin entrypoint - creates the user before attempting to switch.

## Problem
pgadmin container was failing with:
```
su: unknown user 5050
```

The pgadmin user didn't exist in the container.

## Fix
Added user creation to entrypoint:
- Create pgadmin user with UID 5050 if it doesn't exist
- Then switch to that user

## Changes
- Updated scripts/runtime/pgadmin-entrypoint.sh to create user before switching