### PR TITLE
Fix recurring docker-compose.yml corruption from models add (#743)

### DIFF
--- a/lib/aixcl/commands/models.sh
+++ b/lib/aixcl/commands/models.sh
@@ -250,7 +250,7 @@ function add() {
             if [ -f "$compose_file" ]; then
                 # Use a more specific sed pattern that only replaces the model value in the command array
                 sed -i "/vllm:/,/healthcheck:/s|\"--model\",$|\"--model\",|" "$compose_file"
-                sed -i "/vllm:/,/healthcheck:/s|\"\${VLLM_MODEL:.*}|\"$model\"|" "$compose_file"
+                sed -i "/vllm:/,/healthcheck:/s|\"\${VLLM_MODEL[^\"]*}\"|\"$model\"|" "$compose_file"
                 echo "   Updated $compose_file command to use model: $model"
             fi
         elif [[ "$engine" == "llamacpp" ]]; then


### PR DESCRIPTION
## Summary

Fixes #743

### Description of Changes

Fixed sed pattern in `lib/aixcl/commands/models.sh` line 253 that was causing recurring corruption of `services/docker-compose.yml` whenever users ran `./aixcl models add` with vLLM engine.

**The Bug:** The pattern `"\${VLLM_MODEL:.*}` matched from opening quote to END OF LINE including the closing quote. When replaced, it created `"$model""` (double quote).

**The Fix:** Changed pattern to `"\${VLLM_MODEL[^"]*}"` which stops matching at the closing quote, correctly replacing `"$model"` without adding extra quotes.

### Change Checklist

- [x] Issue referenced in title and description (Fixes #743)
- [x] Branch is named correctly (issue-743/fix-docker-compose-corruption)
- [x] Commit messages follow conventional style (fix: ...)
- [x] All tests run and pass

### Testing Notes

The fix was tested by running the full test suite:

**Results:**
- test-00 through test-08: ALL PASSED
- test-08-models-add-vllm: PASSED (67.3s)
- No double quotes observed in docker-compose.yml after test runs
- Stack operations work correctly without YAML parsing errors

**Verification Steps:**
1. Set engine to vLLM: `./aixcl engine set vllm`
2. Start stack: `./aixcl stack start --profile usr`
3. Add model: `./aixcl models add Qwen/Qwen2.5-Coder-0.5B-Instruct`
4. docker-compose.yml maintains correct syntax (no double quotes)

### Verification

- [x] Behavior works as expected
- [x] No regressions observed in existing tests
- [x] docker-compose.yml syntax remains valid after model operations

### Related Issues

- Closes #743
