### PR TITLE
Fix stack status timeout by adding connect-timeout (#746)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1099,12 +1099,12 @@ function status() {
         if [ "$container_running" = "true" ] && [ -n "$health_check_type" ]; then
             case "$health_check_type" in
                 curl)
-                    health_result=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$health_check_arg" 2>/dev/null || echo "000")
+                    health_result=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 3 "$health_check_arg" 2>/dev/null || echo "000")
                     if [ "$health_result" = "404" ] || [ "$health_result" = "000" ]; then
                         local base_url="${health_check_arg%/health}"
                         base_url="${base_url%/}"
                         local root_result
-                        root_result=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 "$base_url/" 2>/dev/null || echo "000")
+                        root_result=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 3 "$base_url/" 2>/dev/null || echo "000")
                         if [ "$root_result" = "200" ] || [ "$root_result" = "302" ] || [ "$root_result" = "307" ]; then
                             health_result="$root_result"
                         fi


### PR DESCRIPTION
## Summary
Fixes #746

## Problem
The `./aixcl stack status` command was timing out because curl commands in the health check function lacked `--connect-timeout`. Without this, when services like pgAdmin are not responding, curl would wait the full `--max-time` duration before failing.

## Solution
Added `--connect-timeout 2` to both curl commands in the `check_service_status` function to limit connection establishment time to 2 seconds.

## Changes
- Line 1102: Added `--connect-timeout 2` to primary health check curl
- Line 1107: Added `--connect-timeout 2` to fallback root URL check

## Verification
- [x] `./aixcl stack status` now returns within 10 seconds
- [x] All service health states are displayed correctly
- [x] Handles non-responsive services gracefully