### PR TITLE
Fix engine set to clear opencode.json models consistently (#747)

### DIFF
--- a/lib/aixcl/commands/engine.sh
+++ b/lib/aixcl/commands/engine.sh
@@ -82,6 +82,20 @@ function engine() {
             fi
         fi
         
+        # Clear opencode.json model when engine changes (model will need to be re-added)
+        local opencode_config="${SCRIPT_DIR}/opencode.json"
+        if [ -f "$opencode_config" ]; then
+            if command -v jq >/dev/null 2>&1; then
+                local temp_json
+                temp_json=$(mktemp)
+                # Clear the models dictionary - user will need to add a model for the new engine
+                jq '.provider."aixcl-local".models = {} | .model = "aixcl-local/"' "$opencode_config" > "$temp_json" && mv "$temp_json" "$opencode_config"
+                echo "   Note: Model configuration cleared in opencode.json. Please add a model for the new engine."
+            else
+                echo "   Note: Install jq to auto-clear model config in opencode.json"
+            fi
+        fi
+        
         echo "Note: Stop and start the stack for the change to take effect:"
         echo "  ./aixcl stack stop && ./aixcl stack start"
     elif [ "$action" = "auto" ]; then


### PR DESCRIPTION
## Summary
Fixes #747

## Problem
The `./aixcl engine set <engine>` command was not clearing the model configuration in opencode.json, while `./aixcl engine auto` did. This created inconsistent behavior and violated the README documentation which states that models are cleared when switching engines.

## Solution
Added the same model clearing logic to the `set` action that already existed in the `auto` action. When jq is available:
1. Clears the models dictionary in the provider
2. Resets the model field to "aixcl-local/"

This ensures users must re-add a model appropriate for the new engine, preventing configuration mismatches.

## Changes
- Lines 85-97: Added model clearing logic to `engine set` command
- Provides consistent user notification about needing to re-add models

## Verification
- [x] `./aixcl engine set llamacpp` clears opencode.json models
- [x] `./aixcl engine set ollama` clears opencode.json models
- [x] User is notified that models need to be re-added
- [x] Behavior is now consistent between `set` and `auto` subcommands