### PR TITLE
Fix operational service permission errors (#748)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -37,6 +37,16 @@ if [ "$(id -u)" = "0" ]; then
         fi
     done
     
+    # Open WebUI also uses /app/backend/open_webui for static files
+    # This directory must be writable by the non-root user
+    for dir in /app/backend/open_webui /app/backend/open_webui/static; do
+        if [ -d "$dir" ]; then
+            echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
+            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
+            chmod 755 "$dir" 2>/dev/null || true
+        fi
+    done
+    
     # Ensure the startup script is executable (ignore errors if read-only mount)
     if [ -f "/app/backend/openwebui.sh" ]; then
         chmod +x /app/backend/openwebui.sh 2>/dev/null || true

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -185,6 +185,9 @@ services:
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1
       PGADMIN_SERVER_JSON_FILE: /pgadmin4/servers.json
+      # Use /tmp for sessions to avoid permission issues with persistent volumes
+      PGADMIN_CONFIG_SESSION_DB_PATH: /tmp/pgadmin_sessions
+      PGADMIN_CONFIG_SQLITE_PATH: /tmp/pgadmin.db
     volumes:
       - ../pg-backup:/var/lib/pgadmin/storage
       - ../logs/pgadmin:/var/log/pgadmin
@@ -206,12 +209,19 @@ services:
       - |
         # In rootless mode, the container root maps to the host user.
         # We ensure the directories are owned by the user pgAdmin runs as (5050).
-        chown -R 5050:5050 /var/lib/pgadmin/storage /var/lib/pgadmin
-        chmod -R 755 /var/lib/pgadmin/storage /var/lib/pgadmin
-        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \;
-        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \;
-        find /var/lib/pgadmin -type d -exec chmod 755 {} \;
-        find /var/lib/pgadmin -type f -exec chmod 644 {} \;
+        # If chown fails (e.g., in rootless mode), we still try to ensure directories exist.
+        
+        # Ensure session directory exists (required for pgAdmin to start)
+        mkdir -p /var/lib/pgadmin/sessions 2>/dev/null || true
+        
+        # Try to set ownership - may fail in some environments but that's ok
+        chown -R 5050:5050 /var/lib/pgadmin/storage /var/lib/pgadmin 2>/dev/null || true
+        chmod -R 755 /var/lib/pgadmin/storage /var/lib/pgadmin 2>/dev/null || true
+        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \; 2>/dev/null || true
+        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \; 2>/dev/null || true
+        find /var/lib/pgadmin -type d -exec chmod 755 {} \; 2>/dev/null || true
+        find /var/lib/pgadmin -type f -exec chmod 644 {} \; 2>/dev/null || true
+        
         exec /entrypoint.sh
 
   prometheus:


### PR DESCRIPTION
## Summary
Fixes #748

## Problem
Open WebUI and pgAdmin were failing to start due to permission denied errors when accessing their persistent volumes. The containers run as non-root users but the host directories may have incorrect ownership or permissions.

## Solution
Made permission handling more robust with the following changes:

**pgAdmin Changes:**
1. Made chown/chmod commands non-fatal with 2>/dev/null || true
2. Added session directory creation before permission setup
3. Configured pgAdmin to use /tmp for sessions and SQLite database
4. This avoids permission issues with persistent volumes entirely

**Open WebUI Changes:**
1. Added ownership setup for /app/backend/open_webui directory
2. This directory contains static files that Open WebUI needs to modify

## Changes
- Modified pgAdmin entrypoint in docker-compose.yml
- Added environment variables for pgAdmin session/database paths
- Updated openwebui-entrypoint.sh to handle additional static directory

## Verification
- [x] pgAdmin handles permission failures gracefully
- [x] Open WebUI entrypoint sets correct ownership on static directories
- [x] Services can start even when host volume permissions are incorrect