### PR TITLE
Fix pgAdmin permission errors by using named volumes (#753)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -185,13 +185,10 @@ services:
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1
       PGADMIN_SERVER_JSON_FILE: /pgadmin4/servers.json
-      # Use /tmp for sessions to avoid permission issues with persistent volumes
-      PGADMIN_CONFIG_SESSION_DB_PATH: /tmp/pgadmin_sessions
-      PGADMIN_CONFIG_SQLITE_PATH: /tmp/pgadmin.db
     volumes:
-      - ../pg-backup:/var/lib/pgadmin/storage
+      - pgadmin-storage:/var/lib/pgadmin/storage
+      - pgadmin-data:/var/lib/pgadmin
       - ../logs/pgadmin:/var/log/pgadmin
-      - ../pgadmin-data:/var/lib/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
     network_mode: host
     depends_on:
@@ -207,20 +204,9 @@ services:
       - /bin/bash
       - -c
       - |
-        # In rootless mode, the container root maps to the host user.
-        # We ensure the directories are owned by the user pgAdmin runs as (5050).
-        # If chown fails (e.g., in rootless mode), we still try to ensure directories exist.
-        
+        # With named volumes, Docker handles permissions automatically
         # Ensure session directory exists (required for pgAdmin to start)
-        mkdir -p /var/lib/pgadmin/sessions 2>/dev/null || true
-        
-        # Try to set ownership - may fail in some environments but that's ok
-        chown -R 5050:5050 /var/lib/pgadmin/storage /var/lib/pgadmin 2>/dev/null || true
-        chmod -R 755 /var/lib/pgadmin/storage /var/lib/pgadmin 2>/dev/null || true
-        find /var/lib/pgadmin/storage -type d -exec chmod 755 {} \; 2>/dev/null || true
-        find /var/lib/pgadmin/storage -type f -exec chmod 644 {} \; 2>/dev/null || true
-        find /var/lib/pgadmin -type d -exec chmod 755 {} \; 2>/dev/null || true
-        find /var/lib/pgadmin -type f -exec chmod 644 {} \; 2>/dev/null || true
+        mkdir -p /var/lib/pgadmin/sessions
         
         exec /entrypoint.sh
 
@@ -388,3 +374,5 @@ volumes:
   grafana-data:
   loki-data:
   alloy-data:
+  pgadmin-storage:
+  pgadmin-data:


### PR DESCRIPTION
## Summary

Fixes #753

## Problem

pgAdmin container was failing to start due to permission errors when using host bind mounts:
- Container runs as UID 5050 (pgadmin user)
- Host directories had root:root ownership (1000:1000)
- In rootless Docker mode, chown fails because container lacks actual root privileges
- This caused ./aixcl stack status to hang when checking pgAdmin health

## Solution

Replaced host bind mounts with named Docker volumes:
- ../pg-backup:/var/lib/pgadmin/storage → pgadmin-storage:/var/lib/pgadmin/storage
- ../pgadmin-data:/var/lib/pgadmin → pgadmin-data:/var/lib/pgadmin

Named volumes are automatically managed by Docker with correct permissions.

## Changes

- Changed volume mounts from host paths to named volumes in pgadmin service
- Simplified entrypoint script - removed complex chown/chmod logic
- Added pgadmin-storage and pgadmin-data volume declarations

## Verification

- [x] ./aixcl stack status returns within 10 seconds
- [x] pgAdmin shows healthy status
- [x] All services report correctly (12/12 healthy)
- [x] No permission errors in pgAdmin logs

## Testing

Tested with sys profile on Ubuntu 24.04 with rootless Docker:
1. Stopped and removed pgAdmin container
2. Applied changes to docker-compose.yml
3. Started stack with ./aixcl stack start --profile sys
4. Verified all services healthy with ./aixcl stack status