### PR TITLE
Fix models add hardcoding VLLM model in docker-compose.yml (#755)

### DIFF
--- a/lib/aixcl/commands/models.sh
+++ b/lib/aixcl/commands/models.sh
@@ -244,15 +244,6 @@ function add() {
                 fi
             fi
             echo "   Updated VLLM_MODEL in .env to: $model"
-            
-            # Also update docker-compose.yml for immediate effect on next restart
-            # This updates the command line to use the specific model
-            if [ -f "$compose_file" ]; then
-                # Use a more specific sed pattern that only replaces the model value in the command array
-                sed -i "/vllm:/,/healthcheck:/s|\"--model\",$|\"--model\",|" "$compose_file"
-                sed -i "/vllm:/,/healthcheck:/s|\"\${VLLM_MODEL[^\"]*}\"|\"$model\"|" "$compose_file"
-                echo "   Updated $compose_file command to use model: $model"
-            fi
         elif [[ "$engine" == "llamacpp" ]]; then
             # Update llamacpp model via environment variable
             local model_filename="$model"


### PR DESCRIPTION
## Summary

Fixes #755

## Problem

The ./aixcl models add command was incorrectly modifying docker-compose.yml to hardcode the VLLM model value, breaking configurability.

| Before | After models add |
|--------|------------------|
| ${VLLM_MODEL:-Qwen/...} | Hardcoded model value |

This prevented users from changing models via .env file.

## Solution

Removed the code that hardcoded the model in docker-compose.yml. The .env file is the correct place for user configuration.

## Changes

- Removed sed commands that modified docker-compose.yml
- Keep only .env file update (which is sufficient)
- Docker-compose already uses ${VLLM_MODEL:-...} variable substitution

## Verification

- [x] After models add, docker-compose.yml still contains ${VLLM_MODEL:-...}
- [x] .env file is updated with new model
- [x] Stack restart uses new model from .env

## Files Modified

| File | Lines Changed |
|------|---------------|
| lib/aixcl/commands/models.sh | -9 lines (removed hardcoding) |