### PR TITLE
Remove clean from ./aixcl stack bash completion (#761)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -70,7 +70,7 @@ _aixcl_complete() {
     # Handle subcommands
     case "$prev" in
         'stack')
-            local stack_actions="start stop restart status logs clean"
+            local stack_actions="start stop restart status logs"
             mapfile -t COMPREPLY < <(compgen -W "$stack_actions" -- "$cur")
             return 0
             ;;


### PR DESCRIPTION
## Summary

Fixes #761

## Problem

The bash completion incorrectly showed 'clean' as a subcommand for './aixcl stack', but the actual 'clean' command is under './aixcl utils'.

## Changes

- completion/aixcl.bash: Removed 'clean' from stack_actions variable (line 73)

## Before



## After



The clean command remains available via:


## Verification

- [x] Stack completion no longer shows 'clean'
- [x] Utils completion still shows 'clean'
- [x] No functional changes to commands