### PR TITLE
Fix pgAdmin network and permission issues (#763)

### DIFF
--- a/scripts/runtime/configure-openwebui-direct-connections.sh
+++ b/scripts/runtime/configure-openwebui-direct-connections.sh
@@ -9,12 +9,14 @@ echo "=== Open WebUI Direct Connections Auto-Configuration ==="
 
 # Wait for Open WebUI to be ready
 echo "Waiting for Open WebUI to start..."
-for i in {1..30}; do
+i=1
+while [ $i -le 30 ]; do
     if curl -s http://127.0.0.1:8080/api/version >/dev/null 2>&1; then
         echo "Open WebUI is ready"
         break
     fi
     sleep 2
+    i=$((i + 1))
 done
 
 # Check if Direct Connections are already configured

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -185,6 +185,7 @@ services:
     image: dpage/pgadmin4:9.14.0
     container_name: pgadmin
     pull_policy: if_not_present
+    network_mode: host
     environment:
       PGADMIN_DEFAULT_EMAIL: $PGADMIN_EMAIL
       PGADMIN_DEFAULT_PASSWORD: $PGADMIN_PASSWORD
@@ -198,12 +199,17 @@ services:
       - pgadmin-data:/var/lib/pgadmin
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
+    user: "0:0"  # Start as root to fix permissions
     entrypoint:
       - /bin/bash
       - -c
       - |
         # Ensure session directory exists (required for pgAdmin to start)
         mkdir -p /var/lib/pgadmin/sessions
+        
+        # Fix permissions on storage directories (pgadmin runs as UID 1000)
+        chown -R 1000:1000 /var/lib/pgadmin || true
+        chown -R 1000:1000 /var/log/pgadmin || true
         
         exec /entrypoint.sh
 


### PR DESCRIPTION
Fixes #763

## Summary
Fix pgAdmin container startup issues by adding proper network configuration and fixing permission errors.

## Changes
- [x] Added \`network_mode: host\` to allow host access to pgAdmin on port 5050
- [x] Added \`user: \"0:0\"\` to start container as root for permission management
- [x] Added chown commands in entrypoint to fix ownership of storage directories for pgadmin user (UID 1000)

## Testing
- pgAdmin now starts successfully and is accessible on http://127.0.0.1:5050
- Container health checks pass
- No permission errors in logs