### PR TITLE
Ensure CLI profile flag updates .env on fresh install (#765)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -253,6 +253,27 @@ function start() {
                 echo "   .env file not found. Copying from .env.example..."
                 cp "$env_example" "$env_file"
                 echo "[x] Created .env file from .env.example"
+                
+                # If profile was specified via CLI, update .env to match
+                if [ "$profile_specified" = true ] && [ -n "$profile" ]; then
+                    if grep -qE "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null; then
+                        # Update existing PROFILE line
+                        if [[ "$(uname)" == "Darwin" ]]; then
+                            sed -i '' "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
+                        else
+                            sed -i "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
+                        fi
+                    else
+                        # Add PROFILE line at the end
+                        {
+                            echo ""
+                            echo "# Default profile for stack commands"
+                            echo "PROFILE=$profile"
+                        } >> "$env_file"
+                    fi
+                    echo "   Updated PROFILE in .env to match CLI: $profile"
+                fi
+                
                 # Reload environment variables after creating .env file
                 load_env_file "$env_file"
             else


### PR DESCRIPTION
Fixes #765

## Summary
When starting AIXCL with -p \u003cprofile\u003e on a vanilla system (no .env file), the code would copy .env.example to .env but never update the PROFILE value to match the CLI-specified profile. This caused ./aixcl stack status to report usr profile even when starting with sys.

## Changes
- lib/aixcl/commands/stack.sh: Added logic to update PROFILE in .env immediately after creating it from .env.example when a profile is specified via CLI

## Verification
- CLI profile flag is now honored on fresh install
- Status reports correct profile after start
- All services from specified profile are displayed
- Existing .env files remain unaffected