### PR TITLE
Add PostgreSQL readiness check to Open WebUI startup (#767)

### DIFF
--- a/scripts/runtime/openwebui.sh
+++ b/scripts/runtime/openwebui.sh
@@ -20,6 +20,33 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=$(cat "$KEY_FILE")
 fi
 
+# Wait for PostgreSQL to be ready (if DATABASE_URL is set)
+if [ -n "${DATABASE_URL:-}" ]; then
+  echo "Waiting for PostgreSQL to be ready..."
+  # Extract host and port from DATABASE_URL
+  # Format: postgresql://user:pass@host:port/dbname
+  pg_host=$(echo "$DATABASE_URL" | sed -n 's/.*@\([^:]*\):.*/\1/p')
+  pg_port=$(echo "$DATABASE_URL" | sed -n 's/.*:\([0-9]*\)\/.*/\1/p')
+  pg_host="${pg_host:-127.0.0.1}"
+  pg_port="${pg_port:-5432}"
+  
+  # Wait for PostgreSQL with timeout (60 seconds)
+  pg_ready=false
+  for i in {1..30}; do
+    if timeout 2 bash -c "echo > /dev/tcp/$pg_host/$pg_port" 2>/dev/null; then
+      pg_ready=true
+      echo "PostgreSQL is ready!"
+      break
+    fi
+    echo "Waiting for PostgreSQL... ($i/30)"
+    sleep 2
+  done
+  
+  if [ "$pg_ready" = false ]; then
+    echo "Warning: PostgreSQL did not become ready, Open WebUI may fall back to SQLite"
+  fi
+fi
+
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
 webui_pid=$!
 echo "Waiting for webui to start..."


### PR DESCRIPTION
Fixes #767

## Summary

Open WebUI was initializing with SQLite instead of PostgreSQL on fresh installs because PostgreSQL wasn't ready when Open WebUI started. This prevented conversations from being persisted to PostgreSQL and accessible via pgAdmin.

## Changes

- Added PostgreSQL readiness check in scripts/runtime/openwebui.sh
- Waits up to 60 seconds for PostgreSQL to accept connections
- Extracts host/port from DATABASE_URL environment variable
- Falls back gracefully with a warning if PostgreSQL isn't ready

## Verification

- [x] PostgreSQL tables are created in webui database
- [x] Conversations appear in pgAdmin
- [x] No SQLiteImpl messages in Open WebUI logs
- [x] Open WebUI connects to PostgreSQL on startup

## Related Issues

- Closes #767
