### PR TITLE
Pre-create logs directory to prevent root ownership (#769)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -285,6 +285,19 @@ function start() {
         fi
     fi
     
+    # Pre-create logs directory with correct ownership to prevent root-owned directories
+    # Docker creates host directories for bind mounts using the container's user (root)
+    # which causes permission issues. By pre-creating with current user, we avoid this.
+    local logs_dir="${SCRIPT_DIR}/logs"
+    if [ ! -d "$logs_dir" ]; then
+        echo "Creating logs directory with current user ownership..."
+        mkdir -p "$logs_dir"
+        # Set ownership to current user
+        chown "$(id -u):$(id -g)" "$logs_dir" 2>/dev/null || true
+        chmod 755 "$logs_dir"
+        echo "   Created logs directory"
+    fi
+    
     # Get services for this profile
     local profile_services
     read -r -a profile_services <<< "$(get_profile_services "$profile")"


### PR DESCRIPTION
Fixes #769

## Summary

Docker creates host directories for bind mounts using the container user (root), causing the logs/ directory to be owned by root:root on fresh installs.

## Changes

- Pre-create logs directory with current user ownership before Docker starts
- Prevents root ownership issue on fresh installs
- No impact on existing installations

## Root Cause

- pgadmin container uses user: "0:0" (root)
- Volume mount creates ../logs/pgadmin:/var/log/pgadmin
- Docker creates host directory as root
- Container chown only affects files inside container, not host directory

## Verification

- [x] Fresh install creates logs/ as current user
- [x] pgadmin logs accessible without sudo
- [x] No functional impact on logging

## Related Issues

- Closes #769
