### PR TITLE
Move PostgreSQL wait to entrypoint script (#767)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -12,6 +12,35 @@ echo "=== Open WebUI Non-Root Entrypoint ==="
 echo "Target UID: $USER_ID"
 echo "Target GID: $GROUP_ID"
 
+# Wait for PostgreSQL to be ready before starting Open WebUI
+# This prevents Open WebUI from falling back to SQLite
+if [ -n "${DATABASE_URL:-}" ]; then
+    echo "Waiting for PostgreSQL to be ready..."
+    # Extract host and port from DATABASE_URL
+    # Format: postgresql://user:pass@host:port/dbname
+    # Use '#' as delimiter to avoid conflict with '/' in URL
+    pg_host=$(echo "$DATABASE_URL" | sed -n 's#.*@\([^:]*\):.*#\1#p')
+    pg_port=$(echo "$DATABASE_URL" | sed -n 's#.*:\([0-9]*\)/.*#\1#p')
+    pg_host="${pg_host:-127.0.0.1}"
+    pg_port="${pg_port:-5432}"
+
+    # Wait for PostgreSQL with timeout (60 seconds)
+    pg_ready=false
+    for i in {1..30}; do
+        if timeout 2 bash -c "echo > /dev/tcp/$pg_host/$pg_port" 2>/dev/null; then
+            pg_ready=true
+            echo "PostgreSQL is ready!"
+            break
+        fi
+        echo "Waiting for PostgreSQL... ($i/30)"
+        sleep 2
+    done
+
+    if [ "$pg_ready" = false ]; then
+        echo "Warning: PostgreSQL did not become ready, Open WebUI may fall back to SQLite"
+    fi
+fi
+
 # Check if running as root (required for permission setup)
 if [ "$(id -u)" = "0" ]; then
     echo "Running as root - setting up permissions..."

--- a/scripts/runtime/openwebui.sh
+++ b/scripts/runtime/openwebui.sh
@@ -20,32 +20,8 @@ if test "$WEBUI_SECRET_KEY $WEBUI_JWT_SECRET_KEY" = " "; then
   WEBUI_SECRET_KEY=$(cat "$KEY_FILE")
 fi
 
-# Wait for PostgreSQL to be ready (if DATABASE_URL is set)
-if [ -n "${DATABASE_URL:-}" ]; then
-  echo "Waiting for PostgreSQL to be ready..."
-  # Extract host and port from DATABASE_URL
-  # Format: postgresql://user:pass@host:port/dbname
-  pg_host=$(echo "$DATABASE_URL" | sed -n 's/.*@\([^:]*\):.*/\1/p')
-  pg_port=$(echo "$DATABASE_URL" | sed -n 's/.*:\([0-9]*\)\/.*/\1/p')
-  pg_host="${pg_host:-127.0.0.1}"
-  pg_port="${pg_port:-5432}"
-  
-  # Wait for PostgreSQL with timeout (60 seconds)
-  pg_ready=false
-  for i in {1..30}; do
-    if timeout 2 bash -c "echo > /dev/tcp/$pg_host/$pg_port" 2>/dev/null; then
-      pg_ready=true
-      echo "PostgreSQL is ready!"
-      break
-    fi
-    echo "Waiting for PostgreSQL... ($i/30)"
-    sleep 2
-  done
-  
-  if [ "$pg_ready" = false ]; then
-    echo "Warning: PostgreSQL did not become ready, Open WebUI may fall back to SQLite"
-  fi
-fi
+# PostgreSQL wait is now handled in the entrypoint script
+# This ensures it runs as root before switching to webui user
 
 WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*' &
 webui_pid=$!


### PR DESCRIPTION
Fixes #767

## Problem

PostgreSQL wait code was in openwebui.sh which runs after switching to the webui user via "su - webui". The "-" flag clears the environment, so DATABASE_URL wasn't available.

Open WebUI would fall back to SQLite because PostgreSQL wasn't confirmed ready before startup.

## Solution

Move the PostgreSQL wait code to the entrypoint script which runs as root first, ensuring DATABASE_URL is available and PostgreSQL is ready before Open WebUI initializes.

## Changes

- scripts/runtime/openwebui-entrypoint.sh: Added PostgreSQL wait code
- scripts/runtime/openwebui.sh: Removed duplicate PostgreSQL wait code

## Verification

- PostgreSQL wait executes as root before switching users
- DATABASE_URL is available in root context
- Open WebUI uses PostgreSQL instead of SQLite

## Related Issues

- Closes #767
