### PR TITLE
Preserve environment variables when switching to webui user (#772)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -88,9 +88,10 @@ if [ "$(id -u)" = "0" ]; then
     
     echo "Switching to webui user (UID: $USER_ID)..."
     # Re-run this script as the non-root user using su
-    # Use -c to execute command with the user's environment
+    # Preserve environment variables needed by OpenWebUI (DATABASE_URL, etc.)
+    # Using 'su' (not 'su -') preserves the environment
     export -n USER_ID GROUP_ID  # Don't export these to avoid confusion
-    exec su - webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
+    exec su webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
 fi
 
 # At this point, we should be running as non-root


### PR DESCRIPTION
Fixes #772

## Problem

The 'su - webui' command in the entrypoint script was clearing environment variables including DATABASE_URL. This caused OpenWebUI to fall back to SQLite instead of using PostgreSQL, even though DATABASE_URL was set correctly in docker-compose.yml.

## Root Cause

The '-' flag in 'su -' creates a login shell which clears the environment. OpenWebUI requires DATABASE_URL to be present to use PostgreSQL.

## Solution

Changed 'su - webui' to 'su webui' (without the hyphen) to preserve environment variables while still switching to the webui user.

## Changes

- scripts/runtime/openwebui-entrypoint.sh: Changed su command to preserve env

## Verification

- [x] DATABASE_URL is available after user switch
- [x] OpenWebUI uses PostgreSQL instead of SQLite
- [x] Tables are created in PostgreSQL
- [x] Conversations visible in pgAdmin

## Related Issues

- Closes #772
