### PR TITLE
Harden pgAdmin container to run as non-root user (#777)

### DIFF
--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -1,8 +1,12 @@
-#!/bin/sh
-# PGAdmin Entrypoint Wrapper
-# Creates servers.json with correct permissions before starting pgAdmin
+#!/bin/bash
+# pgAdmin entrypoint wrapper - runs pgAdmin as non-root user
+# This script sets up permissions and runs pgAdmin with reduced privileges
 
-# Create the servers.json file with proper permissions
+set -e
+
+echo "=== pgAdmin Non-Root Entrypoint ==="
+
+# Create the servers.json file with proper permissions (required for pgAdmin to connect to PostgreSQL)
 cat > /pgadmin4/servers.json << 'EOF'
 {
   "Servers": {
@@ -21,8 +25,73 @@ cat > /pgadmin4/servers.json << 'EOF'
 }
 EOF
 
-chmod 644 /pgadmin4/servers.json
-chown pgadmin:root /pgadmin4/servers.json
+chmod 644 /pgadmin4/servers.json 2>/dev/null || true
 
-# Execute the original pgAdmin entrypoint
+# pgAdmin runs as pgadmin user (UID 5050) in official image
+USER_ID="${PGADMIN_USER_ID:-5050}"
+GROUP_ID="${PGADMIN_GROUP_ID:-5050}"
+
+echo "Target UID: $USER_ID"
+echo "Target GID: $GROUP_ID"
+
+# Check if running as root
+if [ "$(id -u)" = "0" ]; then
+    echo "Running as root - setting up permissions..."
+    
+    # Ensure session directory exists (required for pgAdmin to start)
+    mkdir -p /var/lib/pgadmin/sessions
+    mkdir -p /var/lib/pgadmin/storage
+    
+    # Create pgadmin group if it doesn't exist
+    if ! getent group pgadmin >/dev/null 2>&1; then
+        groupadd -g "$GROUP_ID" pgadmin 2>/dev/null || groupadd pgadmin 2>/dev/null || true
+    fi
+    
+    # Create pgadmin user if it doesn't exist
+    if ! id pgadmin >/dev/null 2>&1; then
+        useradd -u "$USER_ID" -g "$GROUP_ID" -s /bin/false -M pgadmin 2>/dev/null || \
+        useradd -u "$USER_ID" -g "$GROUP_ID" -s /bin/false -M pgadmin 2>/dev/null || true
+    fi
+    
+    # Fix permissions on pgAdmin directories
+    chown -R "$USER_ID:$GROUP_ID" /var/lib/pgadmin 2>/dev/null || true
+    chown -R "$USER_ID:$GROUP_ID" /var/log/pgadmin 2>/dev/null || true
+    chown "$USER_ID:$GROUP_ID" /pgadmin4/servers.json 2>/dev/null || true
+    
+    # Ensure the entrypoint script is executable
+    chmod +x /entrypoint.sh 2>/dev/null || true
+    
+    # Stop postfix if it's running (not needed for AIXCL)
+    if [ -f /usr/libexec/postfix/master ]; then
+        echo "Stopping postfix (not required for AIXCL)..."
+        # Kill postfix master process if running
+        pkill -f "postfix/master" 2>/dev/null || true
+    fi
+    
+    echo "Switching to pgadmin user (UID: $USER_ID)..."
+    
+    # Export environment variables for the pgadmin user
+    export PGADMIN_DEFAULT_EMAIL
+    export PGADMIN_DEFAULT_PASSWORD
+    export PGADMIN_LISTEN_PORT
+    export PGADMIN_LISTEN_ADDRESS
+    export PGADMIN_SERVER_JSON_FILE
+    export PGADMIN_REPLACE_SERVERS_ON_STARTUP
+    
+    # Re-run this script as the non-root user
+    exec su -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'
+fi
+
+# At this point, we should be running as non-root
+echo "Running as user: $(id -u):$(id -g)"
+
+# Verify we can access the pgAdmin directories
+if [ -w "/var/lib/pgadmin" ]; then
+    echo "✅ pgAdmin directories are writable"
+else
+    echo "⚠️  Warning: pgAdmin directories may not be writable"
+fi
+
+# Start pgAdmin with the official entrypoint
+echo "🚀 Starting pgAdmin..."
 exec /entrypoint.sh

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -192,26 +192,17 @@ services:
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1
       PGADMIN_SERVER_JSON_FILE: /pgadmin4/servers.json
-      # Force re-import of servers.json on every startup (needed when database already exists)
       PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
+      PGADMIN_USER_ID: "5050"
+      PGADMIN_GROUP_ID: "5050"
     volumes:
       - pgadmin-storage:/var/lib/pgadmin/storage
       - pgadmin-data:/var/lib/pgadmin
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
-    user: "0:0"  # Start as root to fix permissions
-    entrypoint:
-      - /bin/bash
-      - -c
-      - |
-        # Ensure session directory exists (required for pgAdmin to start)
-        mkdir -p /var/lib/pgadmin/sessions
-        
-        # Fix permissions on storage directories (pgadmin runs as UID 1000)
-        chown -R 1000:1000 /var/lib/pgadmin || true
-        chown -R 1000:1000 /var/log/pgadmin || true
-        
-        exec /entrypoint.sh
+      - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
+    user: "0:0"  # Start as root, entrypoint drops to pgadmin user
+    entrypoint: ["/usr/local/bin/pgadmin-entrypoint.sh"]
 
   prometheus:
     image: prom/prometheus:v3.11.1


### PR DESCRIPTION
Fixes #777

## Summary

pgAdmin container was running as root unnecessarily, creating security risk. This PR adds an entrypoint script that drops privileges to pgadmin user.

## Changes

- **scripts/runtime/pgadmin-entrypoint.sh**: Updated to:
 - Create pgadmin user (UID 5050) with proper permissions
 - Drop from root to pgadmin user before starting
 - Generate servers.json for PostgreSQL connection
 - Attempt to stop postfix (not needed for AIXCL)
  
- **services/docker-compose.yml**:
 - Changed entrypoint to use script
 - Added environment variables for user IDs
 - Added entrypoint script volume mount

## Security Improvements

- pgAdmin runs as non-root user (5050:5050)
- Maintains PostgreSQL connectivity
- UI access preserved
- Defense in depth with proper permissions

## Verification

- ✅ pgAdmin starts as pgadmin user (not root)
- ✅ Can connect to PostgreSQL
- ✅ UI accessible on localhost:5050
- ✅ All 12 services healthy

## Testing

```bash
./aixcl stack start
# Verify pgAdmin user
docker exec pgadmin ps aux
# Should show pgadmin user for gunicorn
```

## Related Issues

- Closes #777
- Related to #705 (Capability Restrictions)
