### PR TITLE
Add Phase 3 security hardening options to services (#788)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -210,9 +210,14 @@ services:
     pull_policy: if_not_present
     cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
     volumes:
-      - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml
+      - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -234,9 +239,11 @@ services:
     pull_policy: if_not_present
     cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - grafana-data:/var/lib/grafana
-      - ../grafana/provisioning:/etc/grafana/provisioning
+      - ../grafana/provisioning:/etc/grafana/provisioning:ro
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
@@ -279,6 +286,11 @@ services:
     user: "65534:65534"  # node-exporter user (official image default) - avoids 'nobody' ambiguity
     cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -298,6 +310,11 @@ services:
     user: "65534:65534"  # postgres-exporter user (official image default) - avoids 'nobody' ambiguity
     cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}?sslmode=disable"
     network_mode: host
@@ -323,8 +340,10 @@ services:
     pull_policy: if_not_present
     cap_drop:
       - ALL
+    security_opt:
+      - no-new-privileges:true
     volumes:
-      - ../loki/loki-config.yml:/etc/loki/loki-config.yml
+      - ../loki/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki-data:/loki
     command: -config.file=/etc/loki/loki-config.yml
     network_mode: host


### PR DESCRIPTION
Fixes #788

Completes Phase 3 of capability restrictions by adding defense-in-depth security options to hardened services.

## Services Updated

| Service | Additions | read_only | no-new-privileges | tmpfs |
|---------|-----------|-----------|-------------------|-------|
| prometheus | :ro mounts, tmpfs | Yes | Yes | /tmp 100m |
| grafana | :ro mounts | No* | Yes | - |
| loki | :ro mounts | No* | Yes | - |
| node-exporter | tmpfs | Yes | Yes | /tmp 100m |
| postgres-exporter | tmpfs | Yes | Yes | /tmp 100m |

\* grafana and loki need write access to their data volumes

## Verification

All 7 Prometheus targets healthy:
| Target | Status |
|--------|--------|
| alloy | up |
| cadvisor | up |
| loki | up |
| node-exporter | up |
| nvidia-gpu | up |
| postgres-exporter | up |
| prometheus | up |

## Related

- Closes #788
- Completes #705 Phase 3
- Parent: #698 (Security Hardening Initiative)