### PR TITLE
Add container security hardening documentation to security.md (#790)

### DIFF
--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -68,3 +68,101 @@ If services fail to start in rootless mode:
 1. Verify `DOCKER_SOCK` is correctly identified: `./aixcl stack status` (it logs the socket path).
 2. Check if `slirp4netns` or `pasta` is installed for rootless networking.
 3. Ensure your user's lingering is enabled for persistent services: `loginctl enable-linger $USER`
+
+---
+
+## 6. Container Security Hardening
+
+AIXCL implements defense-in-depth security controls for all observability services. This section documents the container hardening measures applied to minimize attack surface.
+
+### 6.1 Security Controls Overview
+
+The following security controls are applied to services where applicable:
+
+| Control | Purpose | Services |
+|---------|---------|----------|
+| `cap_drop: ALL` | Remove all Linux capabilities | 6 observability services |
+| `no-new-privileges:true` | Prevent privilege escalation | 6 observability services |
+| `read_only: true` | Make root filesystem read-only | 4 services |
+| `tmpfs` mounts | Writable temporary space | 4 services |
+| `:ro` bind mounts | Read-only config mounts | All services |
+
+### 6.2 Service Security Matrix
+
+| Service | User | cap_drop | no-new-priv | read_only | tmpfs | :ro Mounts |
+|---------|------|----------|-------------|-----------|-------|------------|
+| **prometheus** | default | ALL | ✅ | ✅ | ✅ | 2 |
+| **grafana** | default | ALL | ✅ | ❌* | - | 1 |
+| **loki** | default | ALL | ✅ | ❌* | - | 2 |
+| **postgres-exporter** | 65534:65534 | ALL | ✅ | ✅ | ✅ | 0 |
+| **node-exporter** | 65534:65534 | ALL | ✅ | ✅ | ✅ | 3 |
+| **alloy** | 12345:12345 | ALL | ✅ | ✅ | ✅ | 5 |
+| **cadvisor** | root | - | - | - | - | 5 |
+| **open-webui** | root** | - | - | - | - | 0 |
+| **pgadmin** | root** | - | - | - | - | 1 |
+
+*\*Requires data volume writes*
+*\*\*Entrypoint switches to non-root user*
+
+### 6.3 Rationale for Controls
+
+#### Capability Restrictions (cap_drop: ALL)
+
+Linux capabilities grant specific privileges to processes. Most observability services only need to:
+- Read configuration files
+- Listen on network ports (unprivileged)
+- Write to data volumes
+- Read from /proc and /sys (already world-readable)
+
+None require elevated capabilities, so `cap_drop: ALL` is applied.
+
+#### No-New-Privileges
+
+Prevents processes from gaining additional privileges through:
+- setuid/setgid binaries
+- file capabilities
+- exec calls
+
+#### Read-Only Root Filesystem
+
+Prevents runtime modifications to:
+- System binaries
+- Configuration files
+- Libraries
+
+Services with writable volumes (grafana-data, loki-data) cannot use read_only.
+
+### 6.4 Verification Commands
+
+Check container security settings:
+
+```bash
+# View container capabilities
+docker inspect <container> --format='{{.HostConfig.CapDrop}}'
+
+# Check security options
+docker inspect <container> --format='{{.HostConfig.SecurityOpt}}'
+
+# Verify read-only status
+docker inspect <container> --format='{{.HostConfig.ReadonlyRootfs}}'
+
+# View all Prometheus targets (should all be 'up')
+curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[].health'
+```
+
+### 6.5 Troubleshooting Restricted Containers
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Service fails to start | Missing write access | Add tmpfs mount or remove read_only |
+| Permission denied on config | Missing :ro mount | Add explicit read-only bind mount |
+| Cannot bind to port <1024 | Requires root | Use unprivileged ports (default) |
+| cAdvisor no metrics | cgroup access | Requires privileged (by design) |
+
+### 6.6 Related Issues
+
+- [#698](https://github.com/xencon/aixcl/issues/698) - Container Security Hardening Initiative
+- [#705](https://github.com/xencon/aixcl/issues/705) - Capability Restrictions Implementation
+- [#784](https://github.com/xencon/aixcl/issues/784) - Phase 1: Non-privileged services
+- [#786](https://github.com/xencon/aixcl/issues/786) - Phase 2: Post-migration services
+- [#788](https://github.com/xencon/aixcl/issues/788) - Phase 3: Security options


### PR DESCRIPTION
Fixes #790

Adds comprehensive documentation for container security hardening controls implemented in #705.

## Changes

New Section 6 covering:
- Security controls overview table
- Service security matrix with all 9 services
- Rationale for cap_drop, no-new-privileges, read_only
- Verification commands for container inspection
- Troubleshooting guide
- Related issues references

## Security Matrix

| Service | User | cap_drop | no-new-priv | read_only | Status |
|---------|------|----------|-------------|-----------|--------|
| prometheus | default | ALL | ✅ | ✅ | Hardened |
| grafana | default | ALL | ✅ | ❌ | Hardened |
| loki | default | ALL | ✅ | ❌ | Hardened |
| postgres-exporter | 65534 | ALL | ✅ | ✅ | Hardened |
| node-exporter | 65534 | ALL | ✅ | ✅ | Hardened |
| alloy | 12345 | ALL | ✅ | ✅ | Hardened |

## Verification

Documentation includes commands to verify:
- Container capabilities: docker inspect --format='{{.HostConfig.CapDrop}}'
- Security options: docker inspect --format='{{.HostConfig.SecurityOpt}}'
- Read-only status: docker inspect --format='{{.HostConfig.ReadonlyRootfs}}'

## Related

- Completes #705 Phase 4 (Documentation)
- Parent: #698 (Security Hardening Initiative)