### PR TITLE
Fix alloy entrypoint user switching from setpriv to su (#794)

### DIFF
--- a/scripts/runtime/alloy-entrypoint.sh
+++ b/scripts/runtime/alloy-entrypoint.sh
@@ -69,8 +69,8 @@ if [ "$(id -u)" = "0" ]; then
     fi
     
     echo "Switching to alloy user UID: $ACTUAL_UID..."
-    # Re-run this script as the non-root user using setpriv (works with no-new-privileges)
-    exec setpriv --reuid="$ACTUAL_UID" --regid="$ACTUAL_GID" --clear-groups --groups="$DOCKER_GID" /usr/local/bin/alloy-entrypoint.sh
+    # Re-run this script as the non-root user using su (works with SETUID/SETGID caps)
+    exec su -s /bin/bash alloy -c 'exec /usr/local/bin/alloy-entrypoint.sh'
 fi
 
 # At this point, we should be running as non-root


### PR DESCRIPTION
Fixes #794

Replaces setpriv with su in alloy entrypoint to fix container restart loops.

## Problem

setpriv command with --clear-groups and --groups arguments are mutually exclusive, causing:


## Solution

Use su command which works correctly with SETUID/SETGID capabilities:
- Replaces setpriv with su for user switching
- Maintains docker group membership via alloy user setup
- Works with cap_add SETUID/SETGID security controls

## Changes

- [x] Update entrypoint to use su instead of setpriv
- [x] Alloy user switches correctly to UID 473/12345
- [x] Docker socket group membership maintained

## Verification

- [x] Alloy container starts without errors
- [x] Prometheus target shows healthy (up=1)
- [x] All 7 observability targets healthy
- [x] Alloy metrics endpoint responding on port 12345

## Security

- Container still uses cap_drop: ALL
- Only SETUID/SETGID capabilities added (minimal required)
- Alloy runs as non-root user after switching

## Related

- Follows #792, #793 security hardening work
- Part of #698 Container Security Hardening Initiative