### PR TITLE
Make /report state detection explicit with exact git/gh commands (#812)

### DIFF
--- a/.opencode/commands/report.md
+++ b/.opencode/commands/report.md
@@ -21,51 +21,97 @@ Or with specific issue/PR:
 
 ## What It Does
 
-1. Detects current workflow state (issue, branch, PR, CI status)
-2. Generates visual report with tables
-3. Displays workflow steps completed
-4. Shows CI check status
-5. Provides summary with links and status
+Runs explicit state detection commands against the current repository, then generates a visual report showing exactly where the user is in the Issue-First workflow.
 
-## Report Format
+### State Detection Commands
+
+These commands are run in sequence to detect the repository state:
+
+```bash
+# Current branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Uncommitted changes (empty = clean)
+UNSTAGED=$(git status --short)
+
+# Commits not on main (empty = no commits)
+COMMITS=$(git log --oneline main..HEAD)
+
+# Open PR for this branch
+PR_JSON=$(gh pr list --head "$BRANCH" --json state,number --jq '.[0]')
+PR_STATE=$(echo "$PR_JSON" | jq -r '.state // "none"')
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // "none"')
+
+# Issue number extracted from branch name
+if [[ "$BRANCH" =~ ^issue-([0-9]+)/ ]]; then
+    ISSUE="${BASH_REMATCH[1]}"
+    # Fetch issue existence
+    ISSUE_STATE=$(gh issue view "$ISSUE" --json state --jq '.state // "none"')
+fi
+
+# CI status (if PR exists)
+if [[ "$PR_STATE" == "OPEN" ]]; then
+    CI_STATUS=$(gh pr checks "$PR_NUMBER" --json state)
+fi
+```
+
+### Decision Tree
+
+| Branch Pattern | Unstaged Changes | Commits on Branch | PR State | Current Phase | Next Action |
+|---------------|-------------------|-------------------|----------|---------------|-------------|
+| `main` | any | — | none | No active workflow | Start with `/workflow` or `/issue` |
+| `main` | yes | — | none | Working on main (blocked) | Create issue first, then switch to `/branch` |
+| `issue-<n>` branch | yes | none or old | none | **Phase 3: Work in progress** | `Add .` then `/commit` to stage and commit |
+| `issue-<n>` branch | no | none | none | **Phase 3: Work pending** | Begin implementation or `/commit` |
+| `issue-<n>` branch | no | 1+ commits | none | **Phase 5: PR needed** | `/pr` to create pull request |
+| `issue-<n>` branch | no | 1+ commits | OPEN | **Phase 6: CI pending** | `/verify` to check or continue monitoring |
+| `issue-<n>` branch | no | 1+ commits | OPEN + CI green | Ready to merge | `/merge` or `gh pr merge` |
+| `issue-<n>` branch | no | 1+ commits | MERGED | Completed | `git checkout main` |
+
+### Report Format
 
 ```
-════════════════════════════════════════════════════════════════
+================================================================
   Issue-First Workflow Report
-════════════════════════════════════════════════════════════════
+================================================================
 
 Workflow Steps
 | Step | Action | Result |
 |------|--------|--------|
-| 1. Create Issue | gh issue create | pass #661 |
-| 2. Create Branch | git checkout -b | pass issue-661/... |
-| 3. Make Changes | Implementation | pass Complete |
-| 4. Commit | git commit | pass abc1234 |
-| 5. Create PR | gh pr create | pass #662 |
-| 6. Verify CI | gh pr checks | pass Passing |
+| 1. Create Issue  | gh issue create | pass issue #661 (state: open)   |
+| 2. Create Branch | git checkout -b | pass issue-661/fix-encoding     |
+| 3. Make Changes  | Implementation  | pass 2 commits ahead of main    |
+| 4. Commit        | git commit      | pass abc1234                    |
+| 5. Create PR     | gh pr create    | pass PR #662 (state: open)      |
+| 6. Verify CI     | gh pr checks    | pass all checks green           |
 
 CI Status
 | Check | Status |
 |-------|--------|
-| Dependency Review | pass pass |
-| Validate Shell Scripts | pass pass |
-| ... | ... |
+| Dependency Review     | pass |
+| Validate Shell Scripts| pass |
+| ...                   | ...  |
 
-Summary
-- Issue: #661
-- Branch: issue-661/...
-- PR: #662
-- Status: pass Ready to merge
+Workflow Summary
+- Branch:         issue-661/fix-encoding
+- Issue:          #661 (open)
+- Pull Request:   #662 (open)
+- Commits on branch: 2
+- CI status:      pass (all green)
+- Current phase:  Phase 6 (CI verified)
+- Next action:    Ready to merge (use gh pr merge 662)
 ```
 
 ## When to Use
 
-- After completing workflow steps
-- To check current state
-- Before merging
-- To share status with team
+- After completing any workflow step to verify progress
+- Before asking the user what to do next (run `/report` first)
+- Before merging to confirm CI is green
+- After interruption to resume at the correct phase
+- To share status with team members
 
 ## Related
 
-- `/workflow` - Run full workflow
+- `/workflow` - Run full Issue-First workflow
 - `/verify` - Check CI only
+- `/status` - Quick stack triage


### PR DESCRIPTION
## Summary

Fixes #812

### Description of Changes

The /report command described "detects current workflow state" but never specified which commands to run. The agent had to guess. Updated it with exact state detection commands, a decision tree, and enhanced report format.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-812/explicit-report-state-detection`)
- [x] Commit messages follow conventional style (`refactor: ...`)
- [x] All tests run and pass

### Testing Notes

- Ran `./scripts/checks/check-agents.sh` — all checks passed
- Ran `grep` for Unicode characters on modified file — zero found
- Verified all git and gh commands are valid syntax
- Verified decision tree covers all workflow states from /workflow update

### Verification

- [x] Behavior works as expected
- [x] No regressions observed
- [x] State detection commands are exact and validated
- [x] Decision tree maps correctly to /workflow phases
- [x] Report format example shows issue state, PR state, commits, CI status
- [x] File passes validation and has zero Unicode

### Related Issues

- Closes #812