### PR TITLE
Add /platform, /status, /report to agent-context available commands (#816)

### DIFF
--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -22,6 +22,9 @@ When interacting with users, you can execute these slash commands:
 - `/verify` - Check CI status
 - `/actions` - List all actions
 - `/lint` - Validate agents/actions
+- `/platform` - Live platform health report
+- `/status` - Quick triage command (inference, postgres, webui, docker)
+- `/report` - Workflow progress report
 - `/mode [planning|building|reviewing]` - Switch modes
 
 **Quick Start:** Users can run `/workflow "your task description"` to begin.


### PR DESCRIPTION
## Summary

Fixes #816

### Description of Changes

The agent-context.md prompt lists available slash commands but was missing three created recently: /platform (PR #807), /status (PR #811), /report (updated PR #813).

This caused the agent not to recognize them as executable commands. When users typed `/platform`, the agent treated it as a file reference and quoted the content instead of running the live health queries.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-816/update-agent-commands-list`)
- [x] Commit messages follow conventional style (`fix: ...`)
- [x] All tests run and pass

### Testing Notes

- Ran `./scripts/checks/check-agents.sh` — all checks passed
- Verified command descriptions match their file headers
- Verified zero Unicode characters

### Verification

- [x] Behavior works as expected
- [x] No regressions observed
- [x] File passes validation and has zero Unicode

### Related Issues

- Closes #816