### PR TITLE
Harden pgadmin container security with capability restrictions (#826)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -202,6 +202,17 @@ services:
       - ../pgadmin-servers.json:/pgadmin4/servers.json
       - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
     user: "0:0"  # Start as root, entrypoint drops to pgadmin user
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=50m
+      - /var/lib/pgadmin/sessions:noexec,nosuid,size=50m
     entrypoint: ["/usr/local/bin/pgadmin-entrypoint.sh"]
 
   prometheus:


### PR DESCRIPTION
Fixes #826

## Summary
Apply security hardening to pgadmin container with capability-based privilege controls.

## Security Changes
- cap_drop: ALL (remove all Linux capabilities)
- cap_add: SETUID, SETGID (required for entrypoint su command)
- security_opt: no-new-privileges:true (prevent privilege escalation)
- read_only: true (read-only root filesystem)
- tmpfs mounts for /tmp and /var/lib/pgadmin/sessions (writable space)

## Rationale
pgAdmin entrypoint uses su to drop from root to pgadmin user (UID 5050). This requires SETUID/SETGID capabilities, similar to the alloy service which uses the same pattern successfully.

## Testing Required
- Container must start with new security constraints
- pgAdmin web UI must be accessible on port 5050
- Login must work with configured credentials
- PostgreSQL connections via pgAdmin must function
- No permission errors in container logs

## Risk Assessment
Medium - Entrypoint script modifications may be needed if pgAdmin writes to unexpected locations. tmpfs mounts provided for known writable paths.

## Verification Steps
1. ./aixcl stack restart pgadmin
2. curl -sf http://127.0.0.1:5050/misc/ping
3. docker inspect pgadmin (verify all security settings)
4. Test login and PostgreSQL connection

## Related
- Part of #821 (Container security hardening)