### PR TITLE
Fix pgadmin read_only - remove due to startup file writes (#826)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -209,10 +209,8 @@ services:
       - SETGID
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp:noexec,nosuid,size=50m
-      - /var/lib/pgadmin/sessions:noexec,nosuid,size=50m
+    # Note: read_only cannot be applied to pgAdmin as it writes to multiple
+    # locations including /pgadmin4/servers.json during startup
     entrypoint: ["/usr/local/bin/pgadmin-entrypoint.sh"]
 
   prometheus:


### PR DESCRIPTION
Fixes #826

## Summary
Remove read_only from pgadmin container as it prevents startup due to entrypoint writing to /pgadmin4/servers.json.

## Changes
- Removed read_only: true
- Removed tmpfs mounts (no longer needed)
- Added comment explaining why read_only cannot be applied

## Reason
pgAdmin's entrypoint script generates /pgadmin4/servers.json during startup, which requires write access to the root filesystem. This is the same limitation that prevents Grafana from using read_only.

## Security Still Applied
- cap_drop: ALL
- cap_add: SETUID, SETGID
- security_opt: no-new-privileges:true

This matches Grafana's security level and is appropriate for a service with persistent data volumes.

## Verification
- [x] Container starts successfully
- [x] Ping endpoint responds (HTTP 200)
- [x] Security settings confirmed via docker inspect
- [x] No permission errors in logs

## Related
- Fixes issue introduced in PR #827
- Part of #821 (Container security hardening)