### PR TITLE
Harden vllm container security with capability restrictions (#829)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -48,6 +48,16 @@ services:
       - HOME=/home/vllm
     # Use custom entrypoint to run as non-root user
     entrypoint: ["/vllm-entrypoint.sh"]
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:noexec,nosuid,size=100m
     # vLLM startup command with configurable model and memory settings
     command:
       - "--model"


### PR DESCRIPTION
Fixes #829

## Summary
Apply security hardening to vllm container with capability-based privilege controls.

## Security Changes
- cap_drop: ALL (remove all Linux capabilities)
- cap_add: SETUID, SETGID (required for entrypoint su command)
- security_opt: no-new-privileges:true (prevent privilege escalation)
- read_only: true (read-only root filesystem)
- tmpfs mount for /tmp (writable space for temporary files)

## Rationale
vLLM entrypoint uses su to drop from root to vllm user (UID 1000). Model cache writes to huggingface-cache volume remain writable even with read_only root filesystem.

## Testing Required
- Container must start with new security constraints
- Inference API must respond on port 11434
- Model inference must work
- No permission errors in logs

## Risk Assessment
Medium - Entrypoint script uses su. Hugging Face cache volume provides writable space for model downloads.

## Related
- Part of #821 (Container security hardening)