### PR TITLE
Harden open-webui container security (no read_only due to entrypoint) (#831)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -148,6 +148,14 @@ services:
       - postgres
     network_mode: host
     restart: always
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+    security_opt:
+      - no-new-privileges:true
+    # Note: read_only cannot be applied - entrypoint chowns/chmods container files
     entrypoint: ["/usr/local/bin/openwebui-entrypoint.sh"]
     command: []
     healthcheck:


### PR DESCRIPTION
Fixes #831

## Summary
Apply security hardening to open-webui container with capability-based privilege controls.

## Security Changes
- cap_drop: ALL (remove all Linux capabilities)
- cap_add: SETUID, SETGID (required for entrypoint su command)
- security_opt: no-new-privileges:true (prevent privilege escalation)
- **No read_only** - Entrypoint modifies container filesystem during startup

## Why No read_only
Open WebUI entrypoint performs chown/chmod operations on:
- /app/backend/open_webui (not a volume - part of image)
- /app/backend/openwebui.sh (not a volume - part of image)

This prevents read_only from being applied (same limitation as pgadmin).

## Testing Required
- Container must start with new security constraints
- Web UI must be accessible on port 8080
- Login must work
- No permission errors in logs

## Risk Assessment
High - Multiple write locations and complex startup sequence.

## Related
- Part of #821 (Container security hardening)