### PR TITLE
Revert open-webui security hardening - su authentication failure (#831)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -148,14 +148,6 @@ services:
       - postgres
     network_mode: host
     restart: always
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETUID
-      - SETGID
-    security_opt:
-      - no-new-privileges:true
-    # Note: read_only cannot be applied - entrypoint chowns/chmods container files
     entrypoint: ["/usr/local/bin/openwebui-entrypoint.sh"]
     command: []
     healthcheck:


### PR DESCRIPTION
Reverts changes for #831

## Summary
Remove security hardening from open-webui container due to su authentication failure.

## Problem
With cap_drop: ALL + no-new-privileges:true, the entrypoint cannot use to switch to the webui user. Results in:
- 
- Container restart loop
- Service unavailable

## Changes
- Removed cap_drop: ALL
- Removed cap_add: SETUID, SETGID
- Removed security_opt: no-new-privileges:true

## Reason
Open WebUI entrypoint requires privilege escalation to switch users. The current implementation is incompatible with no-new-privileges constraint.

## Future Work
Consider alternative approaches:
- Use gosu instead of su for privilege dropping
- Run container directly as non-root user (bypassing entrypoint)
- Accept that Open WebUI cannot be hardened to this level

## Verification After Revert
- [x] Container starts successfully
- [x] Web UI accessible on port 8080
- [x] No authentication errors in logs

Fixes #831 (by reverting)
