### PR TITLE
Harden postgres container security (no read_only, no cap_add needed) (#834)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -174,6 +174,11 @@ services:
       - ../scripts/db/init:/docker-entrypoint-initdb.d:ro
     network_mode: host
     restart: always
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    # Note: read_only cannot be applied - database requires write access
     command: >
       postgres
       -c listen_addresses=127.0.0.1


### PR DESCRIPTION
Fixes #834

## Summary
Apply security hardening to postgres container - simplest of the remaining services.

## Security Changes
- cap_drop: ALL (no cap_add required - runs directly as UID 999)
- security_opt: no-new-privileges:true
- **No read_only** - Database requires write access to data directory
- **No cap_add** - PostgreSQL starts directly as postgres user, no privilege dropping

## Why Simple
PostgreSQL is the only service that:
- Already runs as non-root (user: 999:999)
- Does NOT use su/entrypoint for privilege dropping
- Has no authentication mechanisms that conflict with security constraints

## Testing Required
- Container must start with new security constraints
- PostgreSQL must accept connections
- Database queries must work
- Open WebUI must be able to connect

## Risk Assessment
Low - PostgreSQL designed to run as non-root, no privilege escalation needed.

## Related
- Part of #821 (Container security hardening)