### PR TITLE
Remove read_only from vllm - entrypoint needs useradd (#836)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -55,9 +55,7 @@ services:
       - SETGID
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp:noexec,nosuid,size=100m
+    # Note: read_only cannot be applied - entrypoint creates vllm user with useradd
     # vLLM startup command with configurable model and memory settings
     command:
       - "--model"


### PR DESCRIPTION
Fixes #836

## Problem
vLLM entrypoint uses useradd to create the vllm user (UID 1000), which requires write access to /etc/passwd. With read_only: true, the container fails with:
- useradd: cannot lock /etc/passwd; try again later

## Fix
Remove read_only: true from vllm service, keeping other security hardening:
- cap_drop: ALL
- cap_add: SETUID, SETGID
- security_opt: no-new-privileges:true

## Changes
- Removed read_only: true
- Removed tmpfs mount for /tmp (no longer needed without read_only)
- Added comment explaining why read_only cannot be applied

## Verification
- Container must start successfully after fix
- vLLM must respond to inference API on port 11434
- No useradd errors in logs

## Related
- Same issue pattern as pgadmin (see PR #828)
- Part of Issue #821 container hardening