### PR TITLE
Upgrade Open WebUI to v0.9.1 (#838)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -102,7 +102,7 @@ services:
 
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.8.12
+    image: ghcr.io/open-webui/open-webui:v0.9.1
     container_name: open-webui
     pull_policy: if_not_present
     user: "0:0"  # Start as root for permission setup, entrypoint switches to non-root


### PR DESCRIPTION
Fixes #838

## Summary
Upgrade Open WebUI from v0.8.12 to v0.9.1 to incorporate latest features and security fixes.

## Changes
- [x] Update image tag in services/docker-compose.yml
- [x] Test Open WebUI starts successfully
- [x] Verify web UI accessible on port 8080

## Description of Changes
Update Open WebUI container image from:
- ghcr.io/open-webui/open-webui:v0.8.12
- ghcr.io/open-webui/open-webui:v0.9.1

## Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

## Testing Notes
- Container starts with new version
- Health endpoint responds
- No errors in logs

## Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

## Related Issues
- Closes #838
