### PR TITLE
Update Grafana docker-containers dashboard with all 13 containers (#840)

### DIFF
--- a/grafana/provisioning/dashboards/AIXCL/docker-containers.json
+++ b/grafana/provisioning/dashboards/AIXCL/docker-containers.json
@@ -84,7 +84,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}[5m]) * 100",
+          "expr": "rate(container_cpu_usage_seconds_total{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}[5m]) * 100",
           "refId": "A",
           "legendFormat": "{{name}}"
         }
@@ -158,7 +158,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}",
+          "expr": "container_memory_usage_bytes{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}",
           "refId": "A",
           "legendFormat": "{{name}}"
         }
@@ -298,7 +298,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "container_last_seen{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"} > bool (time() - 60)",
+          "expr": "container_last_seen{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"} > bool (time() - 60)",
           "refId": "A",
           "legendFormat": "{{name}}"
         }
@@ -368,12 +368,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(container_fs_reads_bytes_total{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}[5m])",
+          "expr": "rate(container_fs_reads_bytes_total{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}[5m])",
           "refId": "A",
           "legendFormat": "{{name}} - Read"
         },
         {
-          "expr": "rate(container_fs_writes_bytes_total{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}[5m])",
+          "expr": "rate(container_fs_writes_bytes_total{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}[5m])",
           "refId": "B",
           "legendFormat": "{{name}} - Write"
         }
@@ -443,7 +443,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "(container_memory_usage_bytes{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"} / container_spec_memory_limit_bytes{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}) * 100",
+          "expr": "(container_memory_usage_bytes{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"} / container_spec_memory_limit_bytes{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}) * 100",
           "refId": "A",
           "legendFormat": "{{name}} Memory %"
         }
@@ -501,7 +501,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "sum(container_start_time_seconds{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"} > 0) by (name)",
+          "expr": "sum(container_start_time_seconds{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"} > 0) by (name)",
           "refId": "A",
           "legendFormat": "{{name}} Restarts"
         }
@@ -571,7 +571,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "time() - container_start_time_seconds{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}",
+          "expr": "time() - container_start_time_seconds{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}",
           "refId": "A",
           "legendFormat": "{{name}} Uptime"
         }
@@ -641,12 +641,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(container_fs_reads_total{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}[5m])",
+          "expr": "rate(container_fs_reads_total{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}[5m])",
           "refId": "A",
           "legendFormat": "{{name}} - Reads"
         },
         {
-          "expr": "rate(container_fs_writes_total{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}[5m])",
+          "expr": "rate(container_fs_writes_total{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}[5m])",
           "refId": "B",
           "legendFormat": "{{name}} - Writes"
         }
@@ -716,7 +716,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "container_processes{name=~\"ollama|open-webui|postgres|pgadmin|prometheus|grafana\"}",
+          "expr": "container_processes{name=~\"vllm|open-webui|postgres|pgadmin|prometheus|alertmanager|grafana|loki|alloy|cadvisor|node-exporter|postgres-exporter|nvidia-gpu-exporter\"}",
           "refId": "A",
           "legendFormat": "{{name}} Processes"
         }


### PR DESCRIPTION
Fixes #840

## Summary
Update Grafana docker-containers.json dashboard to include all 13 containers currently running in the sys profile.

## Problem
The dashboard was missing 8 containers that are actively running:
- vllm (active inference engine)
- alertmanager (newly added to sys profile)
- nvidia-gpu-exporter
- alloy
- loki
- cadvisor
- node-exporter
- postgres-exporter

And included ollama which is not currently in the profile.

## Changes
Updated container name regex patterns in 5 panels:
- Container CPU Usage
- Container Memory Usage
- Container Uptime
- Container Disk Read I/O
- Container Disk Write I/O

## Verification
- [x] All 13 containers appear in CPU panel
- [x] All 13 containers appear in Memory panel
- [x] Grafana loads without errors

## Related
- Issue #840
