### PR TITLE
Add standardized release note templates (#842)

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,77 @@
+# Release vX.Y.Z
+
+## Summary
+
+Brief description of this release - what it includes, key highlights, and why it matters.
+
+### Target Date
+YYYY-MM-DD
+
+### Previous Release
+vX.Y.Z-(N-1) (or specify)
+
+---
+
+## Security
+
+List security-related changes, CVE fixes, hardening improvements:
+- Security fix 1
+- Security fix 2
+
+## Added
+
+List new features, services, or capabilities:
+- New feature 1
+- New feature 2
+
+## Changed
+
+List modifications to existing functionality:
+- Change 1
+- Change 2
+
+## Deprecated
+
+List features marked for deprecation (will be removed in future):
+- Deprecated feature 1
+
+## Removed
+
+List removed features or services:
+- Removed feature 1
+
+## Fixed
+
+List bug fixes and issue resolutions:
+- Fix 1 (Fixes #<issue-number>)
+- Fix 2 (Fixes #<issue-number>)
+
+## Documentation
+
+List documentation updates:
+- Doc update 1
+- Doc update 2
+
+---
+
+## Related Issues
+
+- Closes #<issue-number>
+- Closes #<issue-number>
+
+## Deployment Notes
+
+Any special instructions for deploying this release:
+- Migration steps
+- Configuration changes
+- Breaking changes requiring user action
+
+## Known Issues
+
+List any known issues not yet resolved:
+- Issue 1 (tracked in #<issue-number>)
+- Issue 2 (tracked in #<issue-number>)
+
+---
+
+**Full Changelog**: https://github.com/xencon/aixcl/compare/vPREVIOUS...vX.Y.Z

--- a/ai/templates/release/release_notes.md
+++ b/ai/templates/release/release_notes.md
@@ -1,0 +1,104 @@
+---
+name: "Release Notes"
+about: "Template for creating a new release"
+title: "[RELEASE] vX.Y.Z"
+labels: ["release"]
+assignees: ["<assignee>"]
+---
+
+# Release vX.Y.Z
+
+## Summary
+
+Brief description of this release - what it includes, key highlights, and why it matters.
+
+### Target Date
+YYYY-MM-DD
+
+### Previous Release
+vX.Y.Z-(N-1) (or specify)
+
+---
+
+## Security
+
+List security-related changes, CVE fixes, hardening improvements:
+- [ ] Security fix 1
+- [ ] Security fix 2
+
+## Added
+
+List new features, services, or capabilities:
+- [ ] New feature 1
+- [ ] New feature 2
+
+## Changed
+
+List modifications to existing functionality:
+- [ ] Change 1
+- [ ] Change 2
+
+## Deprecated
+
+List features marked for deprecation (will be removed in future):
+- [ ] Deprecated feature 1
+
+## Removed
+
+List removed features or services:
+- [ ] Removed feature 1
+
+## Fixed
+
+List bug fixes and issue resolutions:
+- [ ] Fix 1 (Fixes #<issue-number>)
+- [ ] Fix 2 (Fixes #<issue-number>)
+
+## Documentation
+
+List documentation updates:
+- [ ] Doc update 1
+- [ ] Doc update 2
+
+---
+
+## Related Issues
+
+- Closes #<issue-number>
+- Closes #<issue-number>
+
+## Verification Checklist
+
+- [ ] All CI checks passing
+- [ ] Security scan completed
+- [ ] Performance benchmarks run
+- [ ] Breaking changes documented
+- [ ] Migration guide provided (if applicable)
+- [ ] CHANGELOG.md updated
+- [ ] Version bumped in relevant files
+- [ ] Git tag created: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
+- [ ] Release notes published to GitHub
+
+## Deployment Notes
+
+Any special instructions for deploying this release:
+- Migration steps
+- Configuration changes
+- Breaking changes requiring user action
+
+## Known Issues
+
+List any known issues not yet resolved:
+- Issue 1 (tracked in #<issue-number>)
+- Issue 2 (tracked in #<issue-number>)
+
+---
+
+## Template Usage Notes
+
+1. Replace X.Y.Z with actual version number
+2. Remove unused sections (if no items in Deprecated, remove that section)
+3. Follow [Keep a Changelog](https://keepachangelog.com/) format
+4. Reference all related issues
+5. Update CHANGELOG.md with same content after release
+6. Create GitHub Release with these notes


### PR DESCRIPTION
Fixes #842

## Summary
Create standardized release templates to ensure consistency across all AIXCL releases, matching the existing issue and PR templates.

## Changes

### Templates Created

**1. AI Template** ()
- YAML frontmatter for agent/workflow compatibility
- Keep a Changelog format
- All standard sections (Security, Added, Changed, Deprecated, Removed, Fixed, Documentation)
- Verification checklist
- Deployment notes
- Known issues

**2. GitHub Template** ()
- Simplified format for GitHub Releases
- Same sections as AI template
- Comparison link for full changelog
- No YAML frontmatter (GitHub compatibility)

## Template Locations

| Template Type | Location |
|---------------|----------|
| Issues |  |
| Pull Requests |  |
| **Releases** |  ✨ NEW |
| **GitHub Releases** |  ✨ NEW |

## Verification
- [x] Templates follow existing conventions
- [x] YAML frontmatter compatible with AIXCL agent system
- [x] Sections align with CHANGELOG.md format
- [x] Templates are discoverable

## Related
- Closes #842
