### PR TITLE
Align existing release notes to standardized format (#846)

### DIFF
--- a/docs/reference/release-alignment-report.md
+++ b/docs/reference/release-alignment-report.md
@@ -1,0 +1,70 @@
+# Release Alignment Report
+
+## Summary
+
+Successfully aligned all existing GitHub releases to the standardized release notes format.
+
+## Actions Completed
+
+### Release Notes Updated
+
+| Release | Title Updated | Body Updated | Notes |
+|---------|---------------|--------------|-------|
+| v1.0.0-rc1 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc2 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc3 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc4 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc5 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc6 | Yes | Yes | Removed emoji, standardized sections |
+| v1.0.0-rc7 | Already compliant | Already compliant | Already used template format |
+
+### Formatting Changes Applied
+
+1. **Title Format**: Changed from "Release Candidate N - v1.0.0-rcN" to "Release v1.0.0-rcN"
+2. **Section Headers**: Standardized to Summary, Security, Added, Changed, Fixed, Documentation, Related Issues, Known Issues, Verification Checklist
+3. **Emoji Removal**: Replaced all Unicode emoji (🚀, ✨, 🔧, 🐛, etc.) with plain ASCII text
+4. **Full Changelog Links**: Added consistent "Full Changelog" links to all releases
+5. **Structured Tables**: Used markdown tables for security matrices and verification checklists
+6. **Consistent Dates**: Standardized date format to YYYY-MM-DD
+
+## Branch/Tag Analysis
+
+| Tag | Branch Status | Notes |
+|-----|---------------|-------|
+| v1.0.0-rc1 | On main | Correct |
+| v1.0.0-rc2 | On main | Correct |
+| v1.0.0-rc3 | On main | Correct |
+| v1.0.0-rc4 | On main | Correct |
+| v1.0.0-rc5 | On main | Correct |
+| v1.0.0-rc6 | Orphaned | Tag exists but not on any branch (alternate history) |
+| v1.0.0-rc7 | On main | Correct |
+
+### RC6 Tag Status
+
+**v1.0.0-rc6** exists as a tag but is not on the `main` branch. This is because:
+- The original rc6 was created on an alternate branch
+- The tag points to commit `8266aa3 docs: Update CHANGELOG for v1.0.0-rc6`
+- This commit was part of a separate history that was superseded by the current main branch
+- The release notes at https://github.com/xencon/aixcl/releases/tag/v1.0.0-rc6 have been updated
+
+**Impact**: None - the release is still accessible via GitHub, and the tag is preserved.
+
+## Compliance Checklist
+
+- [x] All releases use ASCII-only characters (no emoji)
+- [x] All releases have standard sections: Summary, Security (where applicable), Added, Changed, Fixed, Documentation
+- [x] All releases have Full Changelog link
+- [x] All releases follow consistent title format: "Release vX.Y.Z"
+- [x] RC1-RC5 confirmed on main branch
+- [x] RC6 branch location documented (orphaned but accessible)
+- [x] RC7 confirmed on main branch
+
+## Related Issues
+
+- Issue #846 - Align existing release notes to standardized format
+
+## References
+
+- Template: ai/templates/release/release_notes.md
+- Template: .github/RELEASE_TEMPLATE.md
+- Governance: AGENTS.md ASCII formatting requirements


### PR DESCRIPTION
Fixes #846

## Summary

Align all existing GitHub releases (v1.0.0-rc1 through v1.0.0-rc6) to use the standardized release notes format as prescribed by ai/templates/release/release_notes.md template.

## Changes Made

### Release Notes Standardization

| Release | Changes |
|---------|---------|
| v1.0.0-rc1 | Removed emoji, standardized sections, added Full Changelog link |
| v1.0.0-rc2 | Removed emoji, standardized sections, added Full Changelog link |
| v1.0.0-rc3 | Removed emoji, standardized sections, added Full Changelog link |
| v1.0.0-rc4 | Removed emoji, standardized sections, added Full Changelog link |
| v1.0.0-rc5 | Removed emoji, standardized sections, added Full Changelog link |
| v1.0.0-rc6 | Removed emoji, standardized sections, added Full Changelog link |

### Formatting Changes Applied

- Title format: Changed from "Release Candidate N - v1.0.0-rcN" to "Release v1.0.0-rcN"
- Section headers: Standardized to Summary, Security, Added, Changed, Fixed, Documentation, Related Issues, Known Issues, Verification Checklist
- Emoji removal: Replaced all Unicode emoji with plain ASCII text per AGENTS.md
- Full Changelog links: Added consistent links to all releases
- Structured tables: Used markdown tables for security matrices

## Documentation Added

- Created docs/reference/release-alignment-report.md documenting:
 - All standardization changes
 - Branch/tag analysis
 - RC6 orphaned status explanation
 - Compliance checklist

## Verification

- [x] All releases use ASCII-only characters (no emoji)
- [x] All releases have standard sections
- [x] All releases have Full Changelog link
- [x] All releases follow consistent title format
- [x] Documentation added to track changes

---

**Full Changelog**: See individual release pages for detailed changelogs
