### PR TITLE
Fix orphaned links and broken references in documentation (#850)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ git clone https://github.com/xencon/aixcl.git && cd aixcl
 > 3. Enable "Direct Connections" toggle
 > 4. Save and refresh the page
 >
-> See [Open WebUI Configuration Guide](docs/user/openwebui-setup.md) for detailed instructions.
+> The basic configuration is shown above. For additional Open WebUI settings, refer to the Settings page in the Open WebUI interface.
 
 ---
 

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -266,10 +266,10 @@ The CI workflow automatically checks for CRLF line endings and will fail the bui
 A single agent runs this workflow end-to-end (issue, branch, commit, PR, assign and label). Use it from the repo root with OpenCode CLI and approve `gh`/`git` tool calls when prompted:
 
 ```bash
-cn --config "$(pwd)/opencode/cli-ollama.yaml" --agent /ai/orchestration/agent-developer-workflow.md
+opencode --agent ai/orchestration/agent-developer-workflow.md
 ```
 
-See opencode-cli-setup.md](.opencode-cli-setup.md) for install and config.
+See [opencode-setup.md](./opencode-setup.md) for installation and configuration instructions.
 
 ## AI Assistant Instructions
 


### PR DESCRIPTION
Fixes #850

## Summary

This PR fixes orphaned/broken links in documentation that were causing 404 errors or user confusion.

## Changes

- [x] Removed broken link to non-existent docs/user/openwebui-setup.md in README.md
 - Configuration instructions already provided inline above the link
 - Updated text to direct users to Open WebUI Settings page
  
- [x] Fixed malformed markdown link in development-workflow.md
 - Changed See opencode-cli-setup.md](.opencode-cli-setup.md) to proper markdown syntax
 - Link now points to correct file: opencode-setup.md
  
- [x] Updated OpenCode CLI command syntax
 - Removed non-existent config file reference (opencode/cli-ollama.yaml)
 - Changed from cn to opencode command
 - Updated path from absolute (/ai/orchestration/) to relative (ai/orchestration/)

## Verification

- [x] All modified links resolve to existing files
- [x] Markdown syntax is valid
- [x] No functional code changes (documentation only)

## Testing

- Verified README.md renders correctly without broken link
- Verified development-workflow.md link syntax is correct
- Confirmed opencode-setup.md exists at referenced path
