### PR TITLE
Fix check-agents.sh path and update directory references (#852 #853)

### DIFF
--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -266,10 +266,10 @@ The CI workflow automatically checks for CRLF line endings and will fail the bui
 A single agent runs this workflow end-to-end (issue, branch, commit, PR, assign and label). Use it from the repo root with OpenCode CLI and approve `gh`/`git` tool calls when prompted:
 
 ```bash
-cn --config "$(pwd)/opencode/cli-ollama.yaml" --agent /ai/orchestration/agent-developer-workflow.md
+opencode --agent ai/orchestration/agent-developer-workflow.md
 ```
 
-See opencode-cli-setup.md](.opencode-cli-setup.md) for install and config.
+See [opencode-setup.md](./opencode-setup.md) for installation and configuration instructions.
 
 ## AI Assistant Instructions
 
@@ -330,10 +330,10 @@ gh pr edit <number> --add-assignee <your-github-username> --add-label "component
 
 ## Checking Agent and Skill Files
 
-When creating or modifying AI agent files (`/ai/orchestration/agent-*.md`), skill files (`/ai/skills/skill-*.md`), or AI reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
+When creating or modifying AI agent files (`ai/orchestration/agent-*.md`), skill files (`ai/skills/skill-*.md`), or AI reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
 
 ```bash
-./scripts/check-agents.sh
+./scripts/checks/check-agents.sh
 ```
 
 This script validates:


### PR DESCRIPTION
Fixes #852 Fixes #853

## Summary

This PR fixes incorrect paths in documentation that were pointing to non-existent files or using incorrect directory structures.

## Changes

### Issue #852: Fix check-agents.sh path
- [x] Fixed incorrect path: ./scripts/check-agents.sh → ./scripts/checks/check-agents.sh
- [x] Changed absolute paths (/ai/orchestration/, /ai/skills/) to relative paths

### Issue #853: Fix OpenCode CLI references
- [x] Updated OpenCode CLI command syntax:
 - Removed non-existent config file reference (opencode/cli-ollama.yaml)
 - Changed from cn to opencode command
 - Updated path from absolute (/ai/orchestration/) to relative (ai/orchestration/)
- [x] Fixed malformed markdown link to opencode-setup.md

## Verification

- [x] Script exists at correct path: ./scripts/checks/check-agents.sh
- [x] All paths now use relative format from repository root
- [x] OpenCode setup documentation exists at referenced path
- [x] No references to non-existent configuration files

## Files Changed

- docs/developer/development-workflow.md

## Testing

- Verified check-agents.sh exists at corrected path
- Confirmed all directory references are relative and correct
- Tested OpenCode command syntax matches current installation
