### PR TITLE
Update agents.md to reflect opencode.json configuration (#854)

### DIFF
--- a/docs/developer/agents.md
+++ b/docs/developer/agents.md
@@ -1,4 +1,4 @@
-## Agents and initialization
+# Agents and Initialization
 
 This document explains how AI agents are registered and initialized in this repository. It builds on:
 
@@ -7,48 +7,103 @@ This document explains how AI agents are registered and initialized in this repo
 - `docs/developer/ai-file-naming.md`
 - `docs/developer/agent-template.md`
 
-### Agent registry
+## Agent Configuration
 
-Agents are declared in a registry file so tools and scripts can discover them in a consistent way:
+Agents are configured in `opencode.json` at the repository root. This file defines:
 
-- **Registry file**: `/ai/orchestration/registry.yaml`
+- Default agent to use
+- Agent definitions and their configuration
+- Permissions for each agent
+- Initial context documentation
 
-Example entry:
+Example from `opencode.json`:
 
-```yaml
-agents:
-  - id: developer-workflow
-    file: /ai/orchestration/agent-developer-workflow.md
-    description: Runs the AIXCL issue-first developer workflow end-to-end.
-    default_model: Deepseek Coder
-    init_docs:
-      - docs/developer/development-workflow.md
-      - docs/architecture/governance/01_ai_guidance.md
-      - docs/developer/ai-file-naming.md
-      - docs/developer/agent-template.md
+```json
+{
+  "default_agent": "agent-context",
+  "agent": {
+    "agent-context": {
+      "mode": "primary",
+      "description": "AIXCL primary agent with full project context",
+      "prompt": "{file:.opencode/agents/agent-context.md}",
+      "permission": {
+        "read": "allow",
+        "edit": "ask",
+        "bash": {
+          "*": "ask"
+        }
+      }
+    }
+  }
+}
 ```
 
-- **id**: Stable identifier used by tools (for example `developer-workflow`).
-- **file**: Path to the agent markdown file.
-- **description**: Short description of what the agent does.
-- **default_model**: Optional hint about which model to use.
-- **init_docs**: List of core documentation files that should be available to the agent as context when it runs.
+### Configuration Fields
 
-### Initialization expectations
+- **default_agent**: The agent ID to use when no specific agent is requested
+- **agent.{id}**: Agent definition where `{id}` is the agent identifier
+  - **mode**: Agent mode (`primary`, `secondary`, etc.)
+  - **description**: Short description of agent purpose
+  - **prompt**: Path to the agent markdown file (can use `{file:}` syntax)
+  - **permission**: Tool permissions for this agent
 
-When running an agent, tools should:
+## Agent File Locations
 
-1. Look up the agent by `id` in `/ai/orchestration/registry.yaml`.
-2. Load the agent markdown file from the `file` field.
-3. Include the `init_docs` files as high-priority context (for example via a docs provider or equivalent mechanism).
+Agent markdown files are stored in two locations:
+
+1. **`.opencode/agents/`**: Primary agents for OpenCode integration
+   - Example: `agent-context.md`
+
+2. **`ai/orchestration/`**: Workflow orchestration agents
+   - Example: `agent-developer-workflow.md`
+
+## Initialization Process
+
+When running an agent:
+
+1. OpenCode reads `opencode.json` to find the default agent or requested agent
+2. Loads the agent markdown file from the `prompt` field
+3. Loads all files listed in the `instructions` array as context
+4. Applies permission settings from the agent configuration
+
+### Initial Context
+
+The `instructions` array in `opencode.json` lists files that provide initial context:
+
+```json
+{
+  "instructions": [
+    "AGENTS.md",
+    "DEVELOPMENT.md",
+    "ai/governance/workflow-governance.md",
+    "docs/architecture/governance/00_invariants.md",
+    "docs/architecture/governance/01_ai_guidance.md",
+    "docs/developer/development-workflow.md",
+    "ai/actions/*.md"
+  ]
+}
+```
 
 This ensures that all agents see the same workflow, governance, and naming guidance without each tool needing hard-coded paths.
 
-### Developer workflow agent
+## Developer Workflow Agent
 
-The developer workflow agent is registered with id `developer-workflow` and file `/ai/orchestration/agent-developer-workflow.md`. It:
+The developer workflow agent is defined in `ai/orchestration/agent-developer-workflow.md`. It:
 
-- Encodes the AIXCL Issue-First development workflow.
-- References the governance and workflow docs directly in its markdown.
-- Is suitable for use from tools such as OpenCode CLI, Cursor, or other orchestrators that can read the registry and agent file.
+- Encodes the AIXCL Issue-First development workflow
+- References the governance and workflow docs directly in its markdown
+- Can be invoked via OpenCode CLI: `opencode --agent ai/orchestration/agent-developer-workflow.md`
 
+## Custom Agents
+
+You can add custom agents by:
+
+1. Creating a new agent markdown file in `.opencode/agents/` or `ai/orchestration/`
+2. Adding the agent definition to `opencode.json` under the `agent` field
+3. Following the template in `docs/developer/agent-template.md`
+
+## See Also
+
+- `docs/developer/agent-template.md` - Template for creating new agents
+- `docs/developer/ai-file-naming.md` - Naming conventions for AI files
+- `docs/architecture/governance/01_ai_guidance.md` - AI behavioral guidance


### PR DESCRIPTION
Fixes #854

## Summary

Rewrote docs/developer/agents.md to reflect the actual agent configuration approach using opencode.json instead of the non-existent registry.yaml.

## Changes

- [x] Removed all references to non-existent ai/orchestration/registry.yaml
- [x] Documented actual configuration via opencode.json
- [x] Explained agent definition structure and fields
- [x] Documented agent file locations (.opencode/agents/ and ai/orchestration/)
- [x] Described initialization process and context loading
- [x] Added guidance for creating custom agents
- [x] Updated references to use existing files

## Verification

- [x] Documentation now matches actual repository structure
- [x] All referenced files exist (opencode.json, agent files)
- [x] No references to non-existent registry.yaml
- [x] Clear explanation of agent configuration for contributors

## Files Changed

- docs/developer/agents.md (complete rewrite)

## Related

- opencode.json exists and defines agents
- ai/orchestration/agent-developer-workflow.md exists
- .opencode/agents/agent-context.md exists
