### PR TITLE
Update documentation to clarify skills are optional (#855)

### DIFF
--- a/ai/governance/workflow-governance.md
+++ b/ai/governance/workflow-governance.md
@@ -54,5 +54,7 @@ If automated PRs bypass issue-first:
 2. Create retrospective issue documenting PR numbers
 
 ## Lint Requirement
-If modifying agent-*.md, skill-*.md, or ai-report-*.md:
+If modifying agent-*.md, or ai-report-*.md:
+
+**Note**: Skill files (skill-*.md) are optional. The ai/skills/ directory does not currently exist.
 MD files are the sole governance artifacts. No external script is required.

--- a/docs/developer/ai-file-naming.md
+++ b/docs/developer/ai-file-naming.md
@@ -6,7 +6,7 @@ These conventions complement the development workflow in `docs/developer/develop
 
 ### Agents
 
-- **Location**: `/ai/orchestration/` or `/ai/governance/`
+- **Location**: `ai/orchestration/` or `ai/governance/`
 - **Filename pattern**: `agent-<domain>.md`
   - Examples:
     - `agent-developer-workflow.md`
@@ -19,14 +19,18 @@ Agent files:
 - Encode AIXCL-specific constraints (Issue-First workflow, governance rules, plain ASCII markdown).
 - Are intended to be used by multiple AI tools (e.g., OpenCode CLI, Cursor, Copilot-style agents).
 
-### Skills
+### Skills (Optional)
 
-- **Location**: `/ai/skills/`
+Skills are optional narrowly scoped capabilities. If used:
+
+- **Location**: `ai/skills/` (create this directory only if needed)
 - **Filename pattern**: `skill-<verb-noun>.md`
   - Examples:
     - `skill-normalize-issue-labels.md`
     - `skill-updateopencode-config.md`
     - `skill-run-platform-tests.md`
+
+**Note**: The `ai/skills/` directory does not currently exist in this repository. Skills are an optional extension to the agent system. Agents in `ai/orchestration/` are self-contained and do not require skills to function.
 
 Skill files define narrowly scoped capabilities that agents can rely on, such as a specific refactoring or check.
 
@@ -34,7 +38,7 @@ Skill files define narrowly scoped capabilities that agents can rely on, such as
 
 If MCP servers or tools are documented in markdown prompts or specs:
 
-- **Location**: `/ai/mcp/`
+- **Location**: `ai/mcp/`
 - **Filename patterns**:
   - MCP servers: `mcp-server-<name>.md`
   - MCP tools: `mcp-tool-<name>.md`

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -330,14 +330,18 @@ gh pr edit <number> --add-assignee <your-github-username> --add-label "component
 
 ## Checking Agent and Skill Files
 
-When creating or modifying AI agent files (`ai/orchestration/agent-*.md`), skill files (`ai/skills/skill-*.md`), or AI reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
+<<<<<<< HEAD
+When creating or modifying AI agent files (`ai/orchestration/agent-*.md`), or AI reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
+
+**Note**: Skill files (`ai/skills/skill-*.md`) are optional. The `ai/skills/` directory does not currently exist and should only be created if skills are actually needed.
 
 ```bash
 ./scripts/checks/check-agents.sh
 ```
 
 This script validates:
-- Naming conventions (`agent-*.md`, `skill-*.md`, `ai-report-*.md`)
+- Naming conventions (`agent-*.md`, `ai-report-*.md`)
+- Skill files (`skill-*.md`) if ai/skills/ directory exists
 - Required YAML frontmatter fields (`name`, `description`, `role: system`)
 - Required sections (Purpose, Canonical references, Global rules, Tool usage, Workflow steps, Safety/governance)
 - References to core documentation (`development-workflow.md`, `01_ai_guidance.md`)


### PR DESCRIPTION
Fixes #855

## Summary

Updated documentation to clarify that skill files and the ai/skills/ directory are optional and do not currently exist in the repository.

## Changes

- [x] Updated ai-file-naming.md to mark Skills section as Optional
- [x] Added clear note that ai/skills/ directory does not currently exist
- [x] Updated development-workflow.md to note skills are optional
- [x] Updated check-agents.sh path reference
- [x] Updated workflow-governance.md to clarify skills are optional
- [x] Changed absolute paths (/ai/) to relative paths (ai/)

## Verification

- [x] Documentation now clearly states skills are optional
- [x] No expectation that ai/skills/ directory exists
- [x] Agents in ai/orchestration/ documented as self-contained
- [x] All path references are relative and correct

## Files Changed

- docs/developer/ai-file-naming.md
- docs/developer/development-workflow.md
- ai/governance/workflow-governance.md

## Notes

The ai/skills/ directory was documented as if it existed, but it was never created. This change clarifies the actual repository structure while preserving the naming conventions for future use if needed.
