### PR TITLE
Add missing CLI commands to README.md documentation (#862)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,15 @@ Agent workflow rules and permissions are configured automatically via `opencode.
 | Command | Description |
 | --- | --- |
 | `./aixcl utils check-env` | Validate environment and dependencies |
+| `./aixcl stack start --profile sys` | Start all services with sys profile |
 | `./aixcl stack status` | Check service health and OpenCode connectivity |
 | `./aixcl stack logs engine` | View real-time inference logs |
 | `./aixcl stack stop` | Stop all services gracefully |
+| `./aixcl restart` | Restart services (shorthand for stack restart) |
+| `./aixcl service restart engine` | Restart a specific service |
+| `./aixcl models add <model>` | Add a model (e.g., `qwen2.5-coder:0.5b`) |
+| `./aixcl models remove <model>` | Remove a model |
+| `./aixcl models list` | List installed models |
 | `./aixcl utils clean` | Wipe unused containers and volumes (Fresh start) |
 
 ---


### PR DESCRIPTION
Fixes #862

## Summary

Expanded the Common Commands table in README.md to include additional CLI commands that were documented in manpage.txt but missing from the README.

## Changes

- [x] Added `./aixcl stack start --profile sys` command
- [x] Added `./aixcl restart` shorthand command
- [x] Added `./aixcl service restart engine` example
- [x] Added `./aixcl models add` command
- [x] Added `./aixcl models remove` command
- [x] Added `./aixcl models list` command

## Verification

- [x] All commands tested and working
- [x] Formatting matches existing table style
- [x] Commands are documented in manpage.txt
- [x] No functional code changes

## Before/After

**Before:** 5 commands in Common Commands table **After:** 11 commands in Common Commands table

All additions are frequently used commands that improve user onboarding.
