### PR TITLE
Correct Podman support claims to reflect experimental status (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,9 +198,9 @@ Release Candidate 3 for v1.0.0. This release includes 35+ commits since RC2 focu
 
 ### Added
 
-- **Rootless & Podman Support**: Full support for running AIXCL in rootless environments with both Docker and Podman. Includes automated socket detection and permission handling for volumes (Fixes #498).
+- **Rootless & Podman Support**: Code support for running AIXCL in rootless environments with both Docker and Podman. Docker rootless is verified; Podman support is implemented but experimental. Includes automated socket detection and permission handling for volumes (Fixes #498).
 - **Native Multi-Registry Pulls**: Support for `hf.co/` and `huggingface.co/` URIs in the `models add` command, enabling direct pulls from Hugging Face for all supported engines (Fixes #497).
-- **Podman Quadlet Generation**: New `stack export-quadlet` command to generate native Systemd unit files for robust, headless deployments (Fixes #499).
+- **Podman Quadlet Generation**: New `stack export-quadlet` command to generate native Systemd unit files for robust, headless deployments. Note: Quadlet generation is functional but not fully tested with Podman (Fixes #499).
 - **Integrated Model Inference Testing**: Merged prompt/response verification into the main `platform-tests.sh` suite for end-to-end reliability.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Agent workflow rules and permissions are configured automatically via `opencode.
 
 * [User Guide](https://github.com/xencon/aixcl/blob/main/docs/user/usage.md) - Detailed workflows and tips.
 * [Architecture](https://github.com/xencon/aixcl/blob/main/docs/architecture/governance) - Profiles and service contracts.
-* [Security](https://github.com/xencon/aixcl/blob/main/docs/operations/security.md) - Rootless Podman/Docker operations.
+* [Security](https://github.com/xencon/aixcl/blob/main/docs/operations/security.md) - Rootless Docker operations (Podman support: experimental).
 * [OpenCode Setup](https://github.com/xencon/aixcl/blob/main/docs/developer/opencode-setup.md) - CLI configuration and agent workflow.
 * [Contributing](https://github.com/xencon/aixcl/blob/main/DEVELOPMENT.md) - Issue-first workflow, templates, and PR requirements.
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -1,6 +1,9 @@
 # Rootless Container Operations
 
-AIXCL supports running on rootless container engines (Podman or Docker) to provide enhanced security isolation. This document outlines the operational considerations, benefits, and configuration details for rootless deployments.
+> **Podman Support Status**: Experimental/Beta
+> Podman support is implemented in code but has not been fully tested. Docker rootless mode is verified and recommended. See [#864](https://github.com/xencon/aixcl/issues/864) for current status.
+
+AIXCL supports running on rootless container engines (Docker fully verified, Podman experimental) to provide enhanced security isolation. This document outlines the operational considerations, benefits, and configuration details for rootless deployments.
 
 ## 1. Overview
 
@@ -24,9 +27,10 @@ If rootless mode is detected, the CLI will prioritize appropriate configurations
 ## 3. Operational Considerations
 
 ### 3.1 Socket Paths
-In rootless mode, the Docker/Podman socket is located in a user-writable directory rather than `/var/run/docker.sock`. AIXCL automatically detects these paths:
-- **Podman**: `${XDG_RUNTIME_DIR}/podman/podman.sock`
-- **Docker**: `${XDG_RUNTIME_DIR}/docker.sock`
+
+In rootless mode, the Docker socket is located in a user-writable directory rather than `/var/run/docker.sock`. AIXCL automatically detects these paths:
+- **Docker** (verified): `${XDG_RUNTIME_DIR}/docker.sock`
+- **Podman** (experimental): `${XDG_RUNTIME_DIR}/podman/podman.sock`
 
 The CLI exports this as `DOCKER_SOCK` for use within the container stack.
 
@@ -50,12 +54,17 @@ These services are configured to run as `user: root` within their containers. In
 
 ## 4. Migration Guide
 
-### 4.1 From Rootful Docker to Rootless Podman
+> **Podman Migration**: The following guide is theoretical and has not been tested end-to-end. Use with caution and report issues to [#864](https://github.com/xencon/aixcl/issues/864).
+
+### 4.1 From Rootful Docker to Rootless Podman (Experimental)
+
 1. Stop the existing stack: `./aixcl stack stop`
-2. Install Podman and `podman-compose`.
-3. Ensure your user is configured for rootless (check `/etc/subuid`).
-4. Run `./aixcl utils check-env` to verify detection.
+2. Install Podman and `podman-compose` (see [Podman installation guide](https://podman.io/getting-started/installation))
+3. Ensure your user is configured for rootless (check `/etc/subuid`)
+4. Run `./aixcl utils check-env` to verify detection
 5. Start the stack: `./aixcl stack start`
+
+**Note**: Podman support is experimental. Some features may not work as expected.
 
 **Note**: Volumes created in rootful Docker are owned by host root and will not be accessible to rootless Podman without manual `chown`. It is recommended to start with a clean stack or manually adjust permissions:
 ```bash

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -231,7 +231,9 @@ Note: Runtime core services (Inference Engine) health is critical. Operational s
 
 ### Exporting for Systemd (Headless)
 
-For production or headless environments running Podman, you can export your AIXCL stack as native Systemd Quadlet files:
+> **Note**: Podman Quadlet support is experimental. The `export-quadlet` command generates files but has not been fully tested with Podman. See [#864](https://github.com/xencon/aixcl/issues/864) for current status.
+
+For production or headless environments, you can export your AIXCL stack as native Systemd Quadlet files:
 
 ```bash
 ./aixcl stack export-quadlet


### PR DESCRIPTION
Fixes #864

## Summary

Updated documentation to accurately reflect that Podman support is implemented in code but not fully tested, while Docker rootless mode is verified and recommended.

## Changes Made

### docs/operations/security.md
- [x] Added warning banner at top: "Podman Support Status: Experimental/Beta"
- [x] Updated introduction to clarify Docker verified, Podman experimental
- [x] Updated socket paths section with (verified) and (experimental) labels
- [x] Marked migration guide as theoretical and untested
- [x] Added warning note about Podman support being experimental
- [x] Added reference to tracking issue #864

### README.md
- [x] Updated Security link description: "Rootless Docker operations (Podman support: experimental)"

### CHANGELOG.md
- [x] Updated Rootless & Podman Support: clarified Docker verified, Podman experimental code
- [x] Updated Podman Quadlet Generation: noted it's functional but not fully tested

### docs/user/usage.md
- [x] Added experimental warning to Quadlet export section
- [x] Added reference to tracking issue #864

## Verification

- [x] All changes are documentation only (no functional code changes)
- [x] Experimental warnings clearly visible to users
- [x] Tracking issue #864 referenced for updates
- [x] Claims now match actual implementation status

## Impact

Users will now understand that:
- Docker rootless mode is fully supported and verified
- Podman support exists in code but needs testing
- Quadlet generation is available but experimental

This prevents confusion and sets proper expectations for Podman users.
