### PR TITLE
Standardize volume names across contexts (#883)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -37,19 +37,22 @@ sudo systemctl restart docker
 # 1. Navigate to repository
 cd ~/src/github.com/xencon/aixcl
 
-# 2. Build and start the dev container
+# 2. Initialize external volumes (first time only)
+./scripts/utils/init-volumes.sh
+
+# 3. Build and start the dev container
 docker compose -f .devcontainer/docker-compose.dev.yml up -d
 
-# 3. Enter the container
+# 4. Enter the container
 docker exec -it devcontainer-devcontainer-1 /bin/bash
 
-# 4. Switch to vscode user (recommended)
+# 5. Switch to vscode user (recommended)
 su vscode
 
-# 5. Start AIXCL
+# 6. Start AIXCL
 ./aixcl stack start --profile usr
 
-# 6. Verify services
+# 7. Verify services
 ./aixcl stack status
 ```
 
@@ -220,6 +223,19 @@ The following data persists across container restarts:
 | `aixcl-hf-cache` | `/home/vscode/.cache/huggingface` | HF models |
 | `aixcl-llamacpp-data` | `/models` | llama.cpp models |
 | `aixcl-pgdata` | `/var/lib/postgresql/data` | PostgreSQL data |
+
+> **Note:** These volumes are shared with standard Docker workflows. Models downloaded via devcontainer are available in local Docker and vice versa.
+
+### First-Time Setup
+
+Before starting AIXCL for the first time (in devcontainer or locally), initialize the external volumes:
+
+```bash
+# Initialize volumes (creates them if they don't exist)
+./scripts/utils/init-volumes.sh
+```
+
+This ensures volumes are created as external named volumes, enabling data sharing across contexts.
 
 ---
 

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -22,7 +22,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       # Entrypoint scripts - mount entire scripts directory to avoid DinD file mount issue
       - ../scripts/runtime:/scripts/runtime:ro
-      # Persistence volumes
+      # Persistence volumes - using external named volumes for consistency across contexts
+      # These volumes are shared between local Docker, devcontainer, and GitHub Codespaces
       - aixcl-ollama-data:/home/vscode/.ollama
       - aixcl-hf-cache:/home/vscode/.cache/huggingface
       - aixcl-llamacpp-data:/models
@@ -53,21 +54,23 @@ services:
       start_period: 10s
 
 volumes:
+  # External named volumes for persistence across contexts (local, devcontainer, Codespaces)
+  # These volumes are created once and reused, ensuring data consistency
   aixcl-ollama-data:
-    driver: local
+    external: true
   aixcl-hf-cache:
-    driver: local
+    external: true
   aixcl-llamacpp-data:
-    driver: local
+    external: true
   aixcl-pgdata:
-    driver: local
+    external: true
   aixcl-pgadmin:
-    driver: local
+    external: true
   aixcl-grafana:
-    driver: local
+    external: true
   aixcl-prometheus:
-    driver: local
+    external: true
   aixcl-loki:
-    driver: local
+    external: true
   aixcl-alloy-data:
-    driver: local
+    external: true

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -383,6 +383,18 @@ function start() {
     echo "Pulling latest images..."
     run_compose pull
     
+    # Initialize external volumes if they don't exist
+    # This ensures volumes are created before services try to use them
+    if [ -f "${SCRIPT_DIR}/scripts/utils/init-volumes.sh" ]; then
+        echo "Checking external volumes..."
+        # Run the volume init script but suppress most output for clean UX
+        if bash "${SCRIPT_DIR}/scripts/utils/init-volumes.sh" 2>&1 | grep -E "(Created:|Error:|Summary)"; then
+            :  # Already showing the relevant lines
+        else
+            echo "[x] All external volumes ready"
+        fi
+    fi
+    
     if [ "$profile" = "usr" ]; then
         echo "Note: Usr profile includes PostgreSQL for database persistence (minimal footprint)"
     fi

--- a/scripts/utils/init-volumes.sh
+++ b/scripts/utils/init-volumes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Initialize external volumes for AIXCL
+# This script creates external named volumes that are shared across contexts
+# (local Docker, devcontainer, GitHub Codespaces)
+
+set -e
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# List of AIXCL external volumes
+VOLUMES=(
+  "aixcl-ollama-data"
+  "aixcl-hf-cache"
+  "aixcl-vllm-data"
+  "aixcl-llamacpp-data"
+  "aixcl-open-webui"
+  "aixcl-open-webui-data"
+  "aixcl-pgdata"
+  "aixcl-prometheus"
+  "aixcl-grafana"
+  "aixcl-loki"
+  "aixcl-alloy-data"
+  "aixcl-alertmanager-data"
+  "aixcl-pgadmin-storage"
+  "aixcl-pgadmin"
+  "aixcl-pgadmin-config"
+)
+
+echo "AIXCL Volume Initialization"
+echo "============================"
+echo ""
+echo "This script creates external Docker volumes for AIXCL."
+echo "These volumes are shared across:"
+echo "  - Local Docker (./aixcl stack start)"
+echo "  - Devcontainer (docker compose -f .devcontainer/docker-compose.dev.yml)"
+echo "  - GitHub Codespaces"
+echo ""
+
+# Detect Docker/Podman
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+if command -v podman &> /dev/null && ! command -v docker &> /dev/null; then
+  DOCKER_BIN="podman"
+fi
+
+echo "Using container engine: $DOCKER_BIN"
+echo ""
+
+# Check if Docker/Podman is available
+if ! command -v "$DOCKER_BIN" &> /dev/null; then
+  echo -e "${RED}Error: $DOCKER_BIN not found${NC}"
+  echo "Please install Docker or Podman"
+  exit 1
+fi
+
+# Check if Docker daemon is running
+if ! $DOCKER_BIN info &> /dev/null; then
+  echo -e "${RED}Error: $DOCKER_BIN daemon is not running${NC}"
+  echo "Please start the Docker/Podman daemon"
+  exit 1
+fi
+
+# Create volumes
+CREATED_COUNT=0
+EXISTING_COUNT=0
+
+for volume in "${VOLUMES[@]}"; do
+  if $DOCKER_BIN volume inspect "$volume" &> /dev/null; then
+    echo -e "${GREEN}[✓]${NC} Volume exists: $volume"
+    ((EXISTING_COUNT++))
+  else
+    echo -e "${YELLOW}[ ]${NC} Creating volume: $volume"
+    if $DOCKER_BIN volume create "$volume" &> /dev/null; then
+      echo -e "${GREEN}[✓]${NC} Created volume: $volume"
+      ((CREATED_COUNT++))
+    else
+      echo -e "${RED}[✗]${NC} Failed to create volume: $volume"
+      exit 1
+    fi
+  fi
+done
+
+echo ""
+echo "Summary"
+echo "======="
+echo -e "Created: ${GREEN}$CREATED_COUNT${NC} new volumes"
+echo -e "Existing: ${GREEN}$EXISTING_COUNT${NC} volumes"
+echo ""
+echo "All AIXCL volumes are ready!"
+echo ""
+echo "You can now run:"
+echo "  ./aixcl stack start --profile <profile>"
+echo ""
+echo "Or for devcontainer:"
+echo "  docker compose -f .devcontainer/docker-compose.dev.yml up -d"
+echo ""

--- a/scripts/utils/init-volumes.sh
+++ b/scripts/utils/init-volumes.sh
@@ -70,12 +70,12 @@ EXISTING_COUNT=0
 for volume in "${VOLUMES[@]}"; do
   if $DOCKER_BIN volume inspect "$volume" &> /dev/null; then
     echo -e "${GREEN}[✓]${NC} Volume exists: $volume"
-    ((EXISTING_COUNT++))
+    EXISTING_COUNT=$((EXISTING_COUNT + 1))
   else
     echo -e "${YELLOW}[ ]${NC} Creating volume: $volume"
     if $DOCKER_BIN volume create "$volume" &> /dev/null; then
       echo -e "${GREEN}[✓]${NC} Created volume: $volume"
-      ((CREATED_COUNT++))
+      CREATED_COUNT=$((CREATED_COUNT + 1))
     else
       echo -e "${RED}[✗]${NC} Failed to create volume: $volume"
       exit 1

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     pull_policy: if_not_present
     user: "0:0"  # Start as root to set permissions, entrypoint switches to ubuntu user
     volumes:
-      - ollama:/home/ubuntu/.ollama
+      - aixcl-ollama-data:/home/ubuntu/.ollama
       - ../scripts/runtime/ollama-entrypoint.sh:/ollama-entrypoint.sh:ro
     entrypoint: ["/ollama-entrypoint.sh"]
     environment:
@@ -35,7 +35,7 @@ services:
     network_mode: host
     restart: unless-stopped
     volumes:
-      - huggingface-cache:/home/vllm/.cache/huggingface
+      - aixcl-hf-cache:/home/vllm/.cache/huggingface
       - ../scripts/runtime/vllm-entrypoint.sh:/vllm-entrypoint.sh:ro
     environment:
       # vLLM runtime configuration (configured via .env)
@@ -83,7 +83,7 @@ services:
     pull_policy: if_not_present
     user: "1000:1000"  # Run as non-root user for security
     volumes:
-      - llamacpp-data:/models
+      - aixcl-llamacpp-data:/models
       - ../scripts/runtime/llamacpp-entrypoint.sh:/usr/local/bin/llamacpp-entrypoint.sh:ro
     tty: true
     network_mode: host
@@ -107,8 +107,8 @@ services:
     pull_policy: if_not_present
     user: "0:0"  # Start as root for permission setup, entrypoint switches to non-root
     volumes:
-      - open-webui:/app/backend/data
-      - open-webui-data:/app/data
+      - aixcl-open-webui:/app/backend/data
+      - aixcl-open-webui-data:/app/data
       - ../scripts/runtime/openwebui.sh:/app/backend/openwebui.sh
       - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
     environment:
@@ -168,7 +168,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - aixcl-pgdata:/var/lib/postgresql/data
       - ../scripts/db/init:/docker-entrypoint-initdb.d:ro
     network_mode: host
     restart: always
@@ -209,8 +209,8 @@ services:
       PGADMIN_USER_ID: "5050"
       PGADMIN_GROUP_ID: "5050"
     volumes:
-      - pgadmin-storage:/var/lib/pgadmin/storage
-      - pgadmin-data:/var/lib/pgadmin
+      - aixcl-pgadmin-storage:/var/lib/pgadmin/storage
+      - aixcl-pgadmin:/var/lib/pgadmin
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
       - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
@@ -233,7 +233,7 @@ services:
     volumes:
       - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
-      - prometheus-data:/prometheus
+      - aixcl-prometheus:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -261,7 +261,7 @@ services:
       - /tmp:noexec,nosuid,size=100m
     volumes:
       - ../prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
-      - alertmanager-data:/alertmanager
+      - aixcl-alertmanager-data:/alertmanager
     command:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--storage.path=/alertmanager'
@@ -283,7 +283,7 @@ services:
     security_opt:
       - no-new-privileges:true
     volumes:
-      - grafana-data:/var/lib/grafana
+      - aixcl-grafana:/var/lib/grafana
       - ../grafana/provisioning:/etc/grafana/provisioning:ro
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
@@ -392,7 +392,7 @@ services:
       - no-new-privileges:true
     volumes:
       - ../loki/loki-config.yml:/etc/loki/loki-config.yml:ro
-      - loki-data:/loki
+      - aixcl-loki:/loki
     command: -config.file=/etc/loki/loki-config.yml
     network_mode: host
     restart: unless-stopped
@@ -440,19 +440,37 @@ services:
       - loki
     restart: unless-stopped
 
+# External named volumes for persistence across contexts
+# These volumes are shared between local Docker, devcontainer, and GitHub Codespaces
+# Using external: true ensures volumes are created once and reused
 volumes:
-  ollama:
-  huggingface-cache:
-  vllm-data:
-  llamacpp-data:
-  open-webui:
-  open-webui-data:
-  postgres-data:
-  prometheus-data:
-  grafana-data:
-  loki-data:
-  alloy-data:
-  alertmanager-data:
-  pgadmin-storage:
-  pgadmin-data:
-  pgadmin-config:
+  aixcl-ollama-data:
+    external: true
+  aixcl-hf-cache:
+    external: true
+  aixcl-vllm-data:
+    external: true
+  aixcl-llamacpp-data:
+    external: true
+  aixcl-open-webui:
+    external: true
+  aixcl-open-webui-data:
+    external: true
+  aixcl-pgdata:
+    external: true
+  aixcl-prometheus:
+    external: true
+  aixcl-grafana:
+    external: true
+  aixcl-loki:
+    external: true
+  aixcl-alloy-data:
+    external: true
+  aixcl-alertmanager-data:
+    external: true
+  aixcl-pgadmin-storage:
+    external: true
+  aixcl-pgadmin:
+    external: true
+  aixcl-pgadmin-config:
+    external: true


### PR DESCRIPTION
Closes #883

## Summary
Standardized Docker volume naming across local Docker, devcontainer, and GitHub Codespaces to ensure data persistence and sharing across all contexts.

## Changes
- [x] Rename all volumes to use 'aixcl-' prefix (aixcl-ollama-data, aixcl-pgdata, etc.)
- [x] Update docker-compose.yml volumes to use `external: true`
- [x] Update devcontainer docker-compose.dev.yml to use same volume names
- [x] Create scripts/utils/init-volumes.sh for volume initialization
- [x] Update stack.sh to automatically check/init volumes on start
- [x] Update devcontainer README with new workflow instructions

## Problem Solved
Previously, different contexts used isolated volumes:
- Local Docker: `services_llamacpp-data`
- Devcontainer: `devcontainer_aixcl-llamacpp-data`
- Result: Models downloaded in one context not visible in another

## Solution
Now all contexts share the same external named volumes:
- `aixcl-ollama-data`, `aixcl-llamacpp-data`, `aixcl-pgdata`, etc.
- Models persist across local Docker, devcontainer, and Codespaces
- No data loss when switching contexts

## Developer Experience
- Run `./scripts/utils/init-volumes.sh` once (or it's auto-run on stack start)
- Volumes are created as external and reused across contexts
- Seamless data sharing between workflows

## Testing
- [x] Volume initialization script works
- [x] Stack start creates volumes automatically
- [x] Model downloaded in devcontainer visible locally
- [x] Model downloaded locally visible in devcontainer
- [x] PostgreSQL data persists across contexts
- [x] Clean start with no existing volumes
- [x] Existing volumes are preserved

## Breaking Changes
Users with existing volumes will need to:
1. Backup data if needed: `docker volume ls | grep -E "(ollama|llamacpp|postgres)"`
2. Delete old volumes (optional - they will be orphaned)
3. Run `./scripts/utils/init-volumes.sh` to create new volumes
4. Re-download models (or copy from old volumes)

## Related Issues
- Closes #883
- Enables #882 (CI devcontainer tests)
- Complements #880 (llamacpp model format fix)
