### PR TITLE
Fix workflow documentation branch base and inconsistencies (#877)

### DIFF
--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -88,7 +88,7 @@ When conflicts arise, follow this order:
 2. **Create Branch**
    - Format: `issue-<number>/<short-description>`
    - Example: `issue-217/fix-encoding-problem`
-   - Always branch from `main`
+    - Always branch from `dev`
 
 3. **Make Changes**
    - Small, reversible steps

--- a/.opencode/commands/branch.md
+++ b/.opencode/commands/branch.md
@@ -41,9 +41,9 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 | State | Action |
 |-------|--------|
-| **On `main`** | Proceed as normal: prompt user for issue number and description |
+| **On `dev`** | Proceed as normal: prompt user for issue number and description |
 | **On `issue-<n>/*` branch** | Warn user: `Already on feature branch issue-<n>. Run /commit or /pr instead.` Confirm before proceeding |
-| **On any other branch** | Warn user: `Not on main. Create an issue first with /issue`, then return to main before running /branch again |
+| **On any other branch** | Warn user: `Not on dev. Create an issue first with /issue`, then return to dev before running /branch again |
 
 ### Deriving Description from Issue
 
@@ -59,8 +59,8 @@ DESCRIPTION=$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | cu
 ## What It Does
 
 1. Verifies issue exists (if number provided)
-2. Checks out main branch
-3. Pulls latest changes from origin/main
+2. Checks out dev branch
+3. Pulls latest changes from origin/dev
 4. Creates branch with format: `issue-<number>/<description>`
 5. Confirms branch creation
 6. Ready to make changes
@@ -89,8 +89,8 @@ Examples:
 ```
 
 This will:
-- Checkout main
-- Pull origin/main
+- Checkout dev
+- Pull origin/dev
 - Create `issue-217/<inferred-description>` branch
 - Switch to new branch
 

--- a/.opencode/commands/report.md
+++ b/.opencode/commands/report.md
@@ -35,8 +35,8 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # Uncommitted changes (empty = clean)
 UNSTAGED=$(git status --short)
 
-# Commits not on main (empty = no commits)
-COMMITS=$(git log --oneline main..HEAD)
+# Commits not on dev (empty = no commits)
+COMMITS=$(git log --oneline dev..HEAD)
 
 # Open PR for this branch
 PR_JSON=$(gh pr list --head "$BRANCH" --json state,number --jq '.[0]')
@@ -60,14 +60,14 @@ fi
 
 | Branch Pattern | Unstaged Changes | Commits on Branch | PR State | Current Phase | Next Action |
 |---------------|-------------------|-------------------|----------|---------------|-------------|
-| `main` | any | — | none | No active workflow | Start with `/workflow` or `/issue` |
-| `main` | yes | — | none | Working on main (blocked) | Create issue first, then switch to `/branch` |
+| `dev` | any | — | none | No active workflow | Start with `/workflow` or `/issue` |
+| `dev` | yes | — | none | Working on dev (blocked) | Create issue first, then switch to `/branch` |
 | `issue-<n>` branch | yes | none or old | none | **Phase 3: Work in progress** | `Add .` then `/commit` to stage and commit |
 | `issue-<n>` branch | no | none | none | **Phase 3: Work pending** | Begin implementation or `/commit` |
 | `issue-<n>` branch | no | 1+ commits | none | **Phase 5: PR needed** | `/pr` to create pull request |
 | `issue-<n>` branch | no | 1+ commits | OPEN | **Phase 6: CI pending** | `/verify` to check or continue monitoring |
 | `issue-<n>` branch | no | 1+ commits | OPEN + CI green | Ready to merge | `/merge` or `gh pr merge` |
-| `issue-<n>` branch | no | 1+ commits | MERGED | Completed | `git checkout main` |
+| `issue-<n>` branch | no | 1+ commits | MERGED | Completed | `git checkout dev` |
 
 ### Report Format
 

--- a/.opencode/commands/workflow.md
+++ b/.opencode/commands/workflow.md
@@ -78,7 +78,7 @@ This command orchestrates the entire Issue-First workflow:
 5. Notes issue number
 
 ### Phase 2: Branch Creation
-6. Checks out main branch
+6. Checks out dev branch
 7. Pulls latest changes
 8. Creates feature branch: `issue-<number>/<description>`
 9. Switches to new branch
@@ -129,7 +129,7 @@ Creates a [FEATURE] issue, branches, implements, commits, and creates PR.
 ```
 /workflow Fix memory leak in connection pooling
 ```
-Creates a [BUG] issue with Fix label, branches from main, implements fix.
+Creates a [BUG] issue with Fix label, branches from dev, implements fix.
 
 ### Refactoring Task
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -248,7 +248,7 @@ Consult these before making architectural or structural decisions:
 When working via the OpenCode CLI:
 
 - This file is loaded automatically via the `instructions` field in `opencode.json`
-- The AIXCL local provider is configured in `opencode.json` — use `./opencode` to start a session
+- The AIXCL local provider is configured in `opencode.json` — use `opencode` to start a session
 - Custom slash commands can be added under `.opencode/commands/`
 - Custom agents can be added under `.opencode/agents/`
 - Permissions for `bash`, `edit`, and `webfetch` tools are configured in `opencode.json`

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clone https://github.com/xencon/aixcl.git && cd aixcl
 **5. Launch OpenCode**
 
 ```bash
-./opencode
+opencode
 ```
 
 > **Note for Open WebUI Users (vLLM/llama.cpp):** When using vLLM or llama.cpp engines, models must be manually configured in Open WebUI:

--- a/ai/actions/workflow/action-create-branch.md
+++ b/ai/actions/workflow/action-create-branch.md
@@ -1,6 +1,6 @@
 ---
 name: Create Branch
-description: Creates a feature branch from main following the branch naming convention
+description: Creates a feature branch from dev following the branch naming convention
 category: workflow
 tool: git
 requires:
@@ -11,14 +11,14 @@ requires:
 
 # Action: Create Branch
 
-Creates a feature branch from `main` following AIXCL branch naming conventions.
+Creates a feature branch from `dev` following AIXCL branch naming conventions.
 
 ## Commands
 
 ```bash
-# Checkout main and pull latest
-git checkout main
-git pull origin main
+# Checkout dev and pull latest
+git checkout dev
+git pull origin dev
 
 # Create branch
 git checkout -b issue-<number>/<short-description>
@@ -43,7 +43,7 @@ issue-<number>/<short-description>
 ## Process
 
 1. Verify issue exists and is assigned
-2. Ensure you're on main and it's up to date
+2. Ensure you're on dev and it's up to date
 3. Create branch with correct naming format
 4. Confirm branch creation
 5. Ready to make changes
@@ -53,7 +53,7 @@ issue-<number>/<short-description>
 After creation:
 - [ ] Branch name includes issue number
 - [ ] Branch name is lowercase with hyphens
-- [ ] Branch is based on latest main
+- [ ] Branch is based on latest dev
 - [ ] Issue number matches exactly
 
 ## Alternative Patterns

--- a/ai/actions/workflow/action-detect-workflow-state.md
+++ b/ai/actions/workflow/action-detect-workflow-state.md
@@ -73,7 +73,7 @@ gh pr list --state=open --head="$(git branch --show-current)" 2>/dev/null
 | Current State | Detected | Suggested Next Step |
 |--------------|----------|---------------------|
 | No issue | `gh issue list` empty | `/issue` - Create issue |
-| Issue exists, no branch | On `main` | `/branch <number>` - Create branch |
+| Issue exists, no branch | On `dev` | `/branch <number>` - Create branch |
 | On feature branch, no changes | Clean git status | Ready to work or `/commit` |
 | On feature branch, has changes | Modified files | `/commit` - Commit changes |
 | Branch pushed, no PR | `gh pr list` empty | `/pr` - Create PR |
@@ -133,7 +133,7 @@ When running `/workflow`, the agent should:
    ```
    Current state detected:
    - Open issues: #217, #218
-   - Current branch: main
+   - Current branch: dev
    - Working directory: clean
    - No existing PR for this branch
    
@@ -172,7 +172,7 @@ Agent:
 
 Found:
 ✓ 2 open issues by you: #220, #221
-✓ Currently on branch: main
+✓ Currently on branch: dev
 ✓ Working directory: clean
 ✓ No PR exists yet
 

--- a/ai/orchestration/agent-developer-workflow.md
+++ b/ai/orchestration/agent-developer-workflow.md
@@ -21,7 +21,7 @@ You orchestrate the full AIXCL Issue-First development workflow from this reposi
 
 - Always use the Issue-First workflow:
   - Create an issue.
-  - Create a branch from `main`.
+  - Create a branch from `dev`.
   - Make changes and commit with conventional commit format.
   - Push and create a PR that references the issue.
   - Assign and label the PR to match the issue.
@@ -45,7 +45,7 @@ You orchestrate the full AIXCL Issue-First development workflow from this reposi
 ## Workflow steps
 
 1. **Create Issue**: When work is described, infer a good issue title, body, and labels. Propose the issue and create it using `gh issue create` upon approval.
-2. **Create Branch**: Create a feature branch from `main` using `git checkout -b`.
+2. **Create Branch**: Create a feature branch from `dev` using `git checkout -b`.
 3. **Make Changes**: Perform the requested code and documentation updates.
 4. **Commit**: Create one or more commits using conventional commit format.
 5. **Push and Create PR**: Push the branch and create a PR using `gh pr create` that references the issue.

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -38,11 +38,11 @@ gh issue create --title "Brief description" --body "Detailed description of the 
 
 ### 2. Create a Branch
 
-Create a branch from `main` with a descriptive name:
+Create a branch from `dev` with a descriptive name:
 
 ```bash
-git checkout main
-git pull origin main
+git checkout dev
+git pull origin dev
 git checkout -b issue-<number>/<short-description>
 ```
 
@@ -330,7 +330,6 @@ gh pr edit <number> --add-assignee <your-github-username> --add-label "component
 
 ## Checking Agent and Skill Files
 
-<<<<<<< HEAD
 When creating or modifying AI agent files (`ai/orchestration/agent-*.md`), or AI reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
 
 **Note**: Skill files (`ai/skills/skill-*.md`) are optional. The `ai/skills/` directory does not currently exist and should only be created if skills are actually needed.

--- a/docs/developer/opencode-setup.md
+++ b/docs/developer/opencode-setup.md
@@ -32,7 +32,7 @@ Ensure your AIXCL stack is running and your preferred inference engine is health
 From the repo root:
 
 ```bash
-./opencode
+opencode
 ```
 
 OpenCode will connect to the AIXCL local provider defined in `opencode.json` and load the


### PR DESCRIPTION
Fixes #877

## Summary

This PR consolidates and fixes workflow documentation inconsistencies, particularly around the git branch base (dev vs main) and OpenCode command references.

## Changes

- [x] Fixed branch base from `main` to `dev` in all workflow documentation:
 - `ai/actions/workflow/action-create-branch.md`
 - `ai/orchestration/agent-developer-workflow.md`
 - `.opencode/agents/agent-context.md`
 - `docs/developer/development-workflow.md`
 - `.opencode/commands/branch.md`
 - `.opencode/commands/workflow.md`
 - `ai/actions/workflow/action-detect-workflow-state.md`
 - `.opencode/commands/report.md`
- [x] Removed merge conflict marker from `docs/developer/development-workflow.md` (line 333)
- [x] Fixed OpenCode command from `./opencode` to `opencode` in:
 - `DEVELOPMENT.md`
 - `README.md`
 - `docs/developer/opencode-setup.md`

## Verification

- [x] All files now consistently reference branching from `dev`
- [x] All files now use correct `opencode` command (not `./opencode`)
- [x] No merge conflict markers remain in documentation
- [x] Files align with `WORKFLOW_POLICY.md` which correctly specifies dev as base branch
