### PR TITLE
Remove duplicate vault-agent-postgres service definition (#945)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -494,22 +494,6 @@ services:
       - vault-agent-postgres
     restart: unless-stopped
 
-  vault-agent-postgres:
-    image: hashicorp/vault:1.18
-    container_name: vault-agent-postgres
-    pull_policy: missing
-    environment:
-      VAULT_ADDR: http://127.0.0.1:8200
-      VAULT_TOKEN: aixcl-dev-token
-    volumes:
-      - /tmp/aixcl-secrets:/tmp/vault-secrets
-      - ../scripts/vault/vault-agent.sh:/app/agent.sh:ro
-    command: sh /app/agent.sh
-    network_mode: host
-    depends_on:
-      - vault
-    restart: unless-stopped
-
   nvidia-gpu-exporter:
     image: nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04
     container_name: nvidia-gpu-exporter


### PR DESCRIPTION
## Summary
Fixes #945

### Description of Changes
Removes the duplicate `vault-agent-postgres` service definition from `services/docker-compose.yml` that was breaking YAML parsing and preventing PostgreSQL and Open WebUI from starting properly.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### Testing Notes
Validated with `docker compose -f services/docker-compose.yml config` after fix — parses cleanly.

### Verification
- [x] `docker compose config` validates successfully
- [x] No regressions in vault-agent functionality (correct definition at line 77 preserved)

### Related Issues
- Closes #945