### PR TITLE
Add logs subcommand to vault CLI (#947)

### DIFF
--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -25,6 +25,9 @@ function cmd_vault() {
         rotate)
             cmd_vault_rotate "$@"
             ;;
+        logs)
+            cmd_vault_logs "$@"
+            ;;
         *)
             echo "AIXCL Vault Management"
             echo ""
@@ -36,12 +39,15 @@ function cmd_vault() {
             echo "  credentials  View generated dynamic credentials"
             echo "  passwords    View static bootstrap passwords (from Vault KV)"
             echo "  rotate       Manually trigger credential rotation"
+            echo "  logs [n]     View Vault container logs (default: 50 lines)"
             echo ""
             echo "Examples:"
             echo "  ./aixcl vault init          # Initialize Vault on first run"
             echo "  ./aixcl vault status        # Check if Vault is ready"
             echo "  ./aixcl vault credentials   # View service credentials"
             echo "  ./aixcl vault passwords     # View bootstrap passwords"
+            echo "  ./aixcl vault logs          # View last 50 log lines"
+            echo "  ./aixcl vault logs 100      # View last 100 log lines"
             echo ""
             return 1
             ;;
@@ -207,6 +213,34 @@ function cmd_vault_passwords() {
     echo ""
 }
 
+function cmd_vault_logs() {
+    # Show Vault container logs, consistent with stack logs behavior
+    local tail_count="${1:-50}"
+    local container_name="vault"
+    
+    # Validate tail count
+    if [[ ! "$tail_count" =~ ^[0-9]+$ ]] || [[ "$tail_count" -lt 1 ]] || [[ "$tail_count" -gt 10000 ]]; then
+        echo "Error: Log line count must be a number between 1 and 10000"
+        return 1
+    fi
+    
+    # Check if container exists (running or stopped)
+    local actual_container
+    actual_container=$("${DOCKER_BIN:-docker}" ps -a --format "{{.Names}}" 2>/dev/null | grep -E "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$" | head -1)
+    
+    if [ -n "$actual_container" ]; then
+        echo "Fetching logs for Vault (last $tail_count lines)..."
+        echo ""
+        "${DOCKER_BIN:-docker}" logs --tail="$tail_count" "$actual_container" 2>/dev/null || echo "  (no logs available)"
+    else
+        echo "Error: Vault container not found"
+        echo ""
+        echo "Vault may not be running. Start the stack with:"
+        echo "  ./aixcl stack start --profile sys"
+        return 1
+    fi
+}
+
 # Export the main command
 export -f cmd_vault
 export -f cmd_vault_init
@@ -214,3 +248,4 @@ export -f cmd_vault_status
 export -f cmd_vault_credentials
 export -f cmd_vault_passwords
 export -f cmd_vault_rotate
+export -f cmd_vault_logs


### PR DESCRIPTION
## Summary
Fixes #947

### Description of Changes
Adds a `logs` subcommand to `./aixcl vault` for viewing Vault container logs, consistent with how `./aixcl stack logs <service>` works for other services.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### Testing Notes
Tested with running stack:
- `./aixcl vault logs` — shows last 50 lines (default)
- `./aixcl vault logs 10` — shows last 10 lines
- `./aixcl vault logs abc` — returns validation error

### Verification
- [x] `./aixcl vault logs` displays Vault container logs
- [x] `./aixcl vault logs 100` shows last 100 lines
- [x] Line count validation works (1-10000)
- [x] Help text lists `logs` subcommand
- [x] Graceful error when Vault container is not found

### Related Issues
- Closes #947