### PR TITLE
Fix vault bootstrap scripts for Alpine containers (#950)

### DIFF
--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for Open WebUI bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for pgAdmin bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for PostgreSQL bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/vault-agent.sh
+++ b/scripts/vault/vault-agent.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-# shellcheck shell=bash
+#!/bin/sh
+# shellcheck shell=sh
 # Vault Agent using vault binary
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"


### PR DESCRIPTION
## Summary
Fixes #950

### Description of Changes
Changes shebang in all Vault bootstrap scripts from `#!/usr/bin/env bash` to `#!/bin/sh` because the `hashicorp/vault:1.18` image is Alpine-based and does not include `bash`.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### Testing Notes
Scripts are already POSIX-compatible in logic (use `local`, `wget`, basic shell constructs). The only change is the interpreter directive.

### Verification
- [x] All four vault scripts updated: postgres, openwebui, pgadmin, vault-agent
- [x] Scripts use `#!/bin/sh` shebang
- [x] shellcheck directives updated to `shell=sh`

### Related Issues
- Closes #950