### PR TITLE
Add DAC_OVERRIDE capability to bootstrap containers (#950)

### DIFF
--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching Open WebUI bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/openwebui" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,9 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/openwebui-password
-    chmod 600 /run/secrets/openwebui-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/openwebui-password; then
+        log "ERROR: Cannot write /run/secrets/openwebui-password"
+        return 1
+    fi
+    if ! chmod 600 /run/secrets/openwebui-password; then
+        log "ERROR: Cannot chmod /run/secrets/openwebui-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/openwebui-password"
 }

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching pgAdmin bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/pgadmin" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,9 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/pgadmin-password
-    chmod 600 /run/secrets/pgadmin-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/pgadmin-password; then
+        log "ERROR: Cannot write /run/secrets/pgadmin-password"
+        return 1
+    fi
+    if ! chmod 600 /run/secrets/pgadmin-password; then
+        log "ERROR: Cannot chmod /run/secrets/pgadmin-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/pgadmin-password"
 }

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching PostgreSQL bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,10 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/postgres-password
-    # PostgreSQL runs as user 999 (postgres), make file readable
-    chmod 644 /run/secrets/postgres-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/postgres-password; then
+        log "ERROR: Cannot write /run/secrets/postgres-password"
+        return 1
+    fi
+    if ! chmod 644 /run/secrets/postgres-password; then
+        log "ERROR: Cannot chmod /run/secrets/postgres-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/postgres-password"
 }

--- a/scripts/vault/vault-agent.sh
+++ b/scripts/vault/vault-agent.sh
@@ -14,16 +14,15 @@ fetch_credentials() {
     log "Fetching credentials..."
     
     # Use vault binary to read credentials
-output
     output=$(vault read -format=json database/creds/aixcl-app 2>&1)
+    vault_exit=$?
     
-    if [ $? -ne 0 ]; then
+    if [ $vault_exit -ne 0 ]; then
         log "Failed to fetch credentials: $output"
         return 1
     fi
     
     # Extract using basic shell string manipulation (no jq needed)
-username password
     username=$(echo "$output" | grep '"username"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     password=$(echo "$output" | grep '"password"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -125,6 +125,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-postgres.sh:/usr/local/bin/bootstrap-password-postgres.sh:ro
       - aixcl-vault-secrets:/run/secrets
@@ -147,6 +148,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-openwebui.sh:/usr/local/bin/bootstrap-password-openwebui.sh:ro
       - aixcl-vault-secrets:/run/secrets
@@ -169,6 +171,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-pgadmin.sh:/usr/local/bin/bootstrap-password-pgadmin.sh:ro
       - aixcl-vault-secrets:/run/secrets


### PR DESCRIPTION
## Summary
Fixes #950

### Description of Changes
Adds `CAP_DAC_OVERRIDE` capability to vault bootstrap containers so they can write secrets to shared volumes despite permission restrictions. Also improves POSIX sh compatibility and error handling in bootstrap scripts.

### Root Cause
The `hashicorp/vault:1.18` Alpine container drops all capabilities (`cap_drop: ALL`) including `DAC_OVERRIDE`. Without this, root cannot write to directories owned by other UIDs, leaving `aixcl-vault-secrets` volume empty and preventing PostgreSQL from starting.

### Changes
- `services/docker-compose.yml`: Add `DAC_OVERRIDE` to `vault-agent-{postgres,openwebui,pgadmin}-bootstrap`
- `scripts/vault/bootstrap-password-*.sh`: Remove unsupported `local` (SC3043), add error checking
- `scripts/vault/vault-agent.sh`: Fix stray variables, capture exit codes properly

### Verification
- [x] Bootstrap scripts write passwords successfully
- [x] PostgreSQL container starts and reads `/run/secrets/postgres-password`
- [x] All services healthy after `./aixcl stack restart --profile sys`

### Related Issues
- Closes #950
