### PR TITLE
Mount Vault secrets volume into open-webui and pgadmin (#953)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -12,6 +12,22 @@ echo "=== Open WebUI Non-Root Entrypoint ==="
 echo "Target UID: $USER_ID"
 echo "Target GID: $GROUP_ID"
 
+# Read PostgreSQL password from Vault secrets volume if available
+# This overrides any stale .env password with the Vault-generated secret
+if [ -f /run/secrets/postgres-password ]; then
+    POSTGRES_PASSWORD=$(cat /run/secrets/postgres-password)
+    export POSTGRES_PASSWORD
+    echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
+fi
+
+# Build DATABASE_URL from env vars or defaults, using Vault password if available
+POSTGRES_USER="${POSTGRES_USER:-admin}"
+POSTGRES_DATABASE="${POSTGRES_DATABASE:-webui}"
+export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}"
+
+# Note: Open WebUI uses this DATABASE_URL for its database connection.
+# We reconstruct it here to ensure POSTGRES_PASSWORD reflects the Vault secret.
+
 # Wait for PostgreSQL to be ready before starting Open WebUI
 # This prevents Open WebUI from falling back to SQLite
 if [ -n "${DATABASE_URL:-}" ]; then

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -6,8 +6,22 @@ set -e
 
 echo "=== pgAdmin Non-Root Entrypoint ==="
 
+# Read Vault secrets if available
+if [ -f /run/secrets/pgadmin-password ]; then
+    PGADMIN_DEFAULT_PASSWORD=$(cat /run/secrets/pgadmin-password)
+    export PGADMIN_DEFAULT_PASSWORD
+    echo "[Vault] pgAdmin root password loaded from /run/secrets/pgadmin-password"
+fi
+
+# Read PostgreSQL password for connection in servers.json
+PG_CONNECT_PASSWORD="admin"
+if [ -f /run/secrets/postgres-password ]; then
+    PG_CONNECT_PASSWORD=$(cat /run/secrets/postgres-password)
+    echo "[Vault] PostgreSQL connection password loaded from /run/secrets/postgres-password"
+fi
+
 # Create the servers.json file with proper permissions (required for pgAdmin to connect to PostgreSQL)
-cat > /pgadmin4/servers.json << 'EOF'
+cat > /pgadmin4/servers.json << EOF
 {
   "Servers": {
     "1": {
@@ -17,7 +31,7 @@ cat > /pgadmin4/servers.json << 'EOF'
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "admin",
-      "Password": "admin",
+      "Password": "${PG_CONNECT_PASSWORD}",
       "SSLMode": "prefer",
       "Favorite": true
     }

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -294,6 +294,7 @@ services:
       - aixcl-open-webui-data:/app/data
       - ../scripts/runtime/openwebui.sh:/app/backend/openwebui.sh
       - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     environment:
       - DATA_DIR=/app/data
       - STATIC_DIR=/app/backend/data/static
@@ -347,6 +348,7 @@ services:
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
       - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     user: "0:0"  # Start as root, entrypoint drops to pgadmin user
     # Note: Security hardening removed - cap_drop/no-new-privileges breaks su authentication
     # The entrypoint requires privilege escalation to switch from root to pgadmin user


### PR DESCRIPTION
## Summary
Fixes #953

### Description of Changes
Mounts the `aixcl-vault-secrets` Docker volume into `open-webui` and `pgadmin` containers at `/run/secrets:ro`, allowing them to read Vault-generated passwords just like PostgreSQL does.

### Problem Solved
Previously, Open WebUI used the stale `POSTGRES_PASSWORD=admin` from `.env`, while PostgreSQL was initialized with a Vault-generated random password. This caused authentication failures and prevented Open WebUI from connecting to PostgreSQL.

### Changes
- `services/docker-compose.yml`:
 - Add `aixcl-vault-secrets:/run/secrets:ro` mount to `open-webui`
 - Add `aixcl-vault-secrets:/run/secrets:ro` mount to `pgadmin`
- `scripts/runtime/openwebui-entrypoint.sh`:
 - Read `/run/secrets/postgres-password` if available
 - Rebuild `DATABASE_URL` with the Vault password
- `scripts/runtime/pgadmin-entrypoint.sh`:
 - Read `/run/secrets/pgadmin-password` for root login
 - Read `/run/secrets/postgres-password` for PostgreSQL server connection
 - Generate `servers.json` with actual Vault passwords

### Verification
- [x] Stack starts with 12/12 services healthy
- [x] Open WebUI connects to PostgreSQL successfully
- [x] pgAdmin connects to PostgreSQL successfully
- [x] No password failures in service logs
- [x] `./aixcl vault passwords` shows the same passwords services are using

### Related Issues
- Closes #953
