### PR TITLE
Remove deprecated alloy service from docker-compose.yml (#955)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -538,44 +538,6 @@ services:
       timeout: 10s
       retries: 3
 
-  # SECURITY NOTE: Alloy requires Docker socket access for container log discovery.
-  # Docker socket access grants full root access on the host. Security mitigations applied:
-  # - Runs as alloy user (UID 12345) via entrypoint with docker group membership
-  # - Read-only root filesystem prevents runtime modifications
-  # - cap_drop: ALL with SETUID cap_add (allows su for user switching)
-  # - Writable data volume for Alloy state, tmpfs for temporary files
-  # - All bind mounts are read-only (:ro suffix)
-  # - Docker socket path auto-detected (supports rootless via DOCKER_SOCK env var)
-  # See docs/operations/security.md section 6 for details.
-  alloy:
-    image: docker.io/grafana/alloy:v1.15.0
-    container_name: alloy
-    pull_policy: missing
-    # Run as root to read protected log files and access docker socket
-    user: "0:0"
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETUID
-      - SETGID
-    tmpfs:
-      - /tmp:noexec,nosuid,size=100m
-      # Use tmpfs for Alloy data to avoid permission issues with named volumes
-      - /data-alloy:noexec,nosuid,size=100m
-    volumes:
-      - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - /var/log:/var/log:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:ro
-      - ../scripts/runtime/alloy-entrypoint.sh:/usr/local/bin/alloy-entrypoint.sh:ro
-    entrypoint: /usr/local/bin/alloy-entrypoint.sh
-    environment:
-      - DOCKER_GID=${DOCKER_GID:-989}
-    network_mode: host
-    depends_on:
-      - loki
-    restart: unless-stopped
-
 volumes:
   aixcl-ollama-data:
     # external: true  # Disabled: volumes created automatically by compose
@@ -596,8 +558,6 @@ volumes:
   aixcl-grafana:
     # external: true  # Disabled: volumes created automatically by compose
   aixcl-loki:
-    # external: true  # Disabled: volumes created automatically by compose
-  aixcl-alloy-data:
     # external: true  # Disabled: volumes created automatically by compose
   aixcl-alertmanager-data:
     # external: true  # Disabled: volumes created automatically by compose


### PR DESCRIPTION
Fixes #955

## Summary
Remove the deprecated alloy service definition and associated volume from docker-compose.yml. The alloy container was causing errors on stack stop/restart because the service definition was retained after the service was removed from the active service list.

## Changes
- [x] Removed alloy service definition (~38 lines) from services/docker-compose.yml
- [x] Removed aixcl-alloy-data volume declaration from volumes section
- [x] Verified compose file validates cleanly with podman-compose config
- [x] No alloy references remain in functional compose files (only in docs/logs)

## Testing
- Validated compose syntax: podman-compose config returns successfully
- Verified no alloy references remain in docker-compose.yml
- Confirmed no alloy references in ALL_SERVICES array in lib/core/common.sh

## Verification
- [x] Stack stop/start works without alloy-related errors
- [x] No regressions to existing services
- [x] All tests pass (CI)

## Related Issues
- Closes #955