### PR TITLE
Prepare v1.1.0 release (#957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.0] - 2026-05-03
+
+### Summary
+
+Release v1.1.0 - Vault integration hardening and observability cleanup. This release includes 9 commits focusing on Vault secrets volume mounting, Alpine container compatibility, and removal of deprecated Alloy service.
+
+### Added
+
+- **Vault Secrets Volume Mounting**: Mount Vault secrets volume into open-webui and pgadmin containers (#953)
+  - Open WebUI and pgAdmin now read credentials from /run/secrets/ via aixcl-vault-secrets volume
+  - Entrypoint scripts persist passwords to /var/lib/pgadmin for non-root user (UID 5050)
+- **Vault CLI Logs Subcommand**: Add ./aixcl vault logs [n] for viewing Vault init/bootstrap output (#949)
+
+### Fixed
+
+- **POSIX/Alpine Compatibility**: Change vault bootstrap scripts from bash to sh (#950, #951)
+  - Alpine-based hashicorp/vault:1.18 image does not include bash
+  - Changed shebang from bash to sh, removed unsupported local variables
+- **Bootstrap Container Permissions**: Add DAC_OVERRIDE capability (#952)
+  - Allows bootstrap containers to write to aixcl-vault-secrets volume (owned by UID 999)
+
+### Changed
+
+- **Remove Deprecated Alloy Service**: Clean up alloy from docker-compose.yml (#955, #956)
+  - Removed alloy service definition (~38 lines) and aixcl-alloy-data volume
+  - Eliminates noisyy errors on stack stop/restart for non-existent container
+
+### Deprecated
+
+- Alloy service removed entirely. Use Loki+Promtail for log aggregation instead.
+
 ## [v1.0.0] - 2026-04-30
 
 ### Summary

--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -25,6 +25,9 @@ function cmd_vault() {
         rotate)
             cmd_vault_rotate "$@"
             ;;
+        logs)
+            cmd_vault_logs "$@"
+            ;;
         *)
             echo "AIXCL Vault Management"
             echo ""
@@ -36,12 +39,15 @@ function cmd_vault() {
             echo "  credentials  View generated dynamic credentials"
             echo "  passwords    View static bootstrap passwords (from Vault KV)"
             echo "  rotate       Manually trigger credential rotation"
+            echo "  logs [n]     View Vault container logs (default: 50 lines)"
             echo ""
             echo "Examples:"
             echo "  ./aixcl vault init          # Initialize Vault on first run"
             echo "  ./aixcl vault status        # Check if Vault is ready"
             echo "  ./aixcl vault credentials   # View service credentials"
             echo "  ./aixcl vault passwords     # View bootstrap passwords"
+            echo "  ./aixcl vault logs          # View last 50 log lines"
+            echo "  ./aixcl vault logs 100      # View last 100 log lines"
             echo ""
             return 1
             ;;
@@ -207,6 +213,34 @@ function cmd_vault_passwords() {
     echo ""
 }
 
+function cmd_vault_logs() {
+    # Show Vault container logs, consistent with stack logs behavior
+    local tail_count="${1:-50}"
+    local container_name="vault"
+    
+    # Validate tail count
+    if [[ ! "$tail_count" =~ ^[0-9]+$ ]] || [[ "$tail_count" -lt 1 ]] || [[ "$tail_count" -gt 10000 ]]; then
+        echo "Error: Log line count must be a number between 1 and 10000"
+        return 1
+    fi
+    
+    # Check if container exists (running or stopped)
+    local actual_container
+    actual_container=$("${DOCKER_BIN:-docker}" ps -a --format "{{.Names}}" 2>/dev/null | grep -E "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$" | head -1)
+    
+    if [ -n "$actual_container" ]; then
+        echo "Fetching logs for Vault (last $tail_count lines)..."
+        echo ""
+        "${DOCKER_BIN:-docker}" logs --tail="$tail_count" "$actual_container" 2>/dev/null || echo "  (no logs available)"
+    else
+        echo "Error: Vault container not found"
+        echo ""
+        echo "Vault may not be running. Start the stack with:"
+        echo "  ./aixcl stack start --profile sys"
+        return 1
+    fi
+}
+
 # Export the main command
 export -f cmd_vault
 export -f cmd_vault_init
@@ -214,3 +248,4 @@ export -f cmd_vault_status
 export -f cmd_vault_credentials
 export -f cmd_vault_passwords
 export -f cmd_vault_rotate
+export -f cmd_vault_logs

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -12,6 +12,22 @@ echo "=== Open WebUI Non-Root Entrypoint ==="
 echo "Target UID: $USER_ID"
 echo "Target GID: $GROUP_ID"
 
+# Read PostgreSQL password from Vault secrets volume if available
+# This overrides any stale .env password with the Vault-generated secret
+if [ -f /run/secrets/postgres-password ]; then
+    POSTGRES_PASSWORD=$(cat /run/secrets/postgres-password)
+    export POSTGRES_PASSWORD
+    echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
+fi
+
+# Build DATABASE_URL from env vars or defaults, using Vault password if available
+POSTGRES_USER="${POSTGRES_USER:-admin}"
+POSTGRES_DATABASE="${POSTGRES_DATABASE:-webui}"
+export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}"
+
+# Note: Open WebUI uses this DATABASE_URL for its database connection.
+# We reconstruct it here to ensure POSTGRES_PASSWORD reflects the Vault secret.
+
 # Wait for PostgreSQL to be ready before starting Open WebUI
 # This prevents Open WebUI from falling back to SQLite
 if [ -n "${DATABASE_URL:-}" ]; then

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -6,8 +6,22 @@ set -e
 
 echo "=== pgAdmin Non-Root Entrypoint ==="
 
+# Read Vault secrets if available
+if [ -f /run/secrets/pgadmin-password ]; then
+    PGADMIN_DEFAULT_PASSWORD=$(cat /run/secrets/pgadmin-password)
+    export PGADMIN_DEFAULT_PASSWORD
+    echo "[Vault] pgAdmin root password loaded from /run/secrets/pgadmin-password"
+fi
+
+# Read PostgreSQL password for connection in servers.json
+PG_CONNECT_PASSWORD="admin"
+if [ -f /run/secrets/postgres-password ]; then
+    PG_CONNECT_PASSWORD=$(cat /run/secrets/postgres-password)
+    echo "[Vault] PostgreSQL connection password loaded from /run/secrets/postgres-password"
+fi
+
 # Create the servers.json file with proper permissions (required for pgAdmin to connect to PostgreSQL)
-cat > /pgadmin4/servers.json << 'EOF'
+cat > /pgadmin4/servers.json << EOF
 {
   "Servers": {
     "1": {
@@ -17,7 +31,7 @@ cat > /pgadmin4/servers.json << 'EOF'
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "admin",
-      "Password": "admin",
+      "Password": "${PG_CONNECT_PASSWORD}",
       "SSLMode": "prefer",
       "Favorite": true
     }

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -6,40 +6,38 @@ set -e
 
 echo "=== pgAdmin Non-Root Entrypoint ==="
 
-# Read Vault secrets if available
-if [ -f /run/secrets/pgadmin-password ]; then
-    PGADMIN_DEFAULT_PASSWORD=$(cat /run/secrets/pgadmin-password)
-    export PGADMIN_DEFAULT_PASSWORD
-    echo "[Vault] pgAdmin root password loaded from /run/secrets/pgadmin-password"
+# Read Vault secrets if available (only root can read /run/secrets)
+if [ "$(id -u)" = "0" ]; then
+    if [ -f /run/secrets/pgadmin-password ]; then
+        PGADMIN_DEFAULT_PASSWORD=$(cat /run/secrets/pgadmin-password)
+        export PGADMIN_DEFAULT_PASSWORD
+        echo "[Vault] pgAdmin root password loaded from /run/secrets/pgadmin-password"
+    fi
+
+    # Read PostgreSQL password for connection in servers.json
+    PG_CONNECT_PASSWORD="admin"
+    if [ -f /run/secrets/postgres-password ]; then
+        PG_CONNECT_PASSWORD=$(cat /run/secrets/postgres-password)
+        echo "[Vault] PostgreSQL connection password loaded from /run/secrets/postgres-password"
+    fi
+
+    # Persist passwords to /var/lib/pgadmin so the pgadmin user can read them after su
+    mkdir -p /var/lib/pgadmin
+    echo "$PGADMIN_DEFAULT_PASSWORD" > /var/lib/pgadmin/.pgadmin-passwd
+    echo "$PG_CONNECT_PASSWORD" > /var/lib/pgadmin/.pg-connect-passwd
+    chmod 600 /var/lib/pgadmin/.pgadmin-passwd /var/lib/pgadmin/.pg-connect-passwd
+else
+    echo "Running as non-root — skipping /run/secrets/ read (already set by root)"
+    if [ -f /var/lib/pgadmin/.pgadmin-passwd ]; then
+        PGADMIN_DEFAULT_PASSWORD=$(cat /var/lib/pgadmin/.pgadmin-passwd)
+        export PGADMIN_DEFAULT_PASSWORD
+    fi
+    if [ -f /var/lib/pgadmin/.pg-connect-passwd ]; then
+        PG_CONNECT_PASSWORD=$(cat /var/lib/pgadmin/.pg-connect-passwd)
+    fi
 fi
 
-# Read PostgreSQL password for connection in servers.json
-PG_CONNECT_PASSWORD="admin"
-if [ -f /run/secrets/postgres-password ]; then
-    PG_CONNECT_PASSWORD=$(cat /run/secrets/postgres-password)
-    echo "[Vault] PostgreSQL connection password loaded from /run/secrets/postgres-password"
-fi
-
-# Create the servers.json file with proper permissions (required for pgAdmin to connect to PostgreSQL)
-cat > /pgadmin4/servers.json << EOF
-{
-  "Servers": {
-    "1": {
-      "Group": "Servers",
-      "Name": "AIXCL",
-      "Host": "localhost",
-      "Port": 5432,
-      "MaintenanceDB": "postgres",
-      "Username": "admin",
-      "Password": "${PG_CONNECT_PASSWORD}",
-      "SSLMode": "prefer",
-      "Favorite": true
-    }
-  }
-}
-EOF
-
-chmod 644 /pgadmin4/servers.json 2>/dev/null || true
+# servers.json was created inside the root block above
 
 # pgAdmin runs as pgadmin user (UID 5050) in official image
 USER_ID="${PGADMIN_USER_ID:-5050}"
@@ -82,6 +80,32 @@ if [ "$(id -u)" = "0" ]; then
         pkill -f "postfix/master" 2>/dev/null || true
     fi
     
+    # Persist passwords to /var/lib/pgadmin so the pgadmin user can read them after su
+    mkdir -p /var/lib/pgadmin
+    echo "$PGADMIN_DEFAULT_PASSWORD" > /var/lib/pgadmin/.pgadmin-passwd
+    echo "$PG_CONNECT_PASSWORD" > /var/lib/pgadmin/.pg-connect-passwd
+    chmod 600 /var/lib/pgadmin/.pgadmin-passwd /var/lib/pgadmin/.pg-connect-passwd
+
+    # Create servers.json as root (pgadmin user can't write to /pgadmin4)
+    cat > /pgadmin4/servers.json << EOF
+{
+  "Servers": {
+    "1": {
+      "Group": "Servers",
+      "Name": "AIXCL",
+      "Host": "localhost",
+      "Port": 5432,
+      "MaintenanceDB": "postgres",
+      "Username": "admin",
+      "Password": "${PG_CONNECT_PASSWORD}",
+      "SSLMode": "prefer",
+      "Favorite": true
+    }
+  }
+}
+EOF
+    chmod 644 /pgadmin4/servers.json
+
     echo "Switching to pgadmin user (UID: $USER_ID)..."
     
     # Export environment variables for the pgadmin user

--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching Open WebUI bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/openwebui" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,9 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/openwebui-password
-    chmod 600 /run/secrets/openwebui-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/openwebui-password; then
+        log "ERROR: Cannot write /run/secrets/openwebui-password"
+        return 1
+    fi
+    if ! chmod 600 /run/secrets/openwebui-password; then
+        log "ERROR: Cannot chmod /run/secrets/openwebui-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/openwebui-password"
 }

--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -15,7 +15,7 @@ fetch_bootstrap_password() {
     log "Fetching Open WebUI bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-    local response
+response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/openwebui" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
     
@@ -26,7 +26,7 @@ fetch_bootstrap_password() {
     
     # Extract password using basic shell (no jq needed)
     # Handle both "password": "value" and "password":"value" formats
-    local password
+password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then

--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for Open WebUI bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for pgAdmin bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -15,7 +15,7 @@ fetch_bootstrap_password() {
     log "Fetching pgAdmin bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-    local response
+response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/pgadmin" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
     
@@ -26,7 +26,7 @@ fetch_bootstrap_password() {
     
     # Extract password using basic shell (no jq needed)
     # Handle both "password": "value" and "password":"value" formats
-    local password
+password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching pgAdmin bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/pgadmin" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,9 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/pgadmin-password
-    chmod 600 /run/secrets/pgadmin-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/pgadmin-password; then
+        log "ERROR: Cannot write /run/secrets/pgadmin-password"
+        return 1
+    fi
+    if ! chmod 600 /run/secrets/pgadmin-password; then
+        log "ERROR: Cannot chmod /run/secrets/pgadmin-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/pgadmin-password"
 }

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -15,7 +15,7 @@ fetch_bootstrap_password() {
     log "Fetching PostgreSQL bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-    local response
+response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
     
@@ -26,7 +26,7 @@ fetch_bootstrap_password() {
     
     # Extract password using basic shell (no jq needed)
     # Handle both "password": "value" and "password":"value" formats
-    local password
+password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -15,18 +15,16 @@ fetch_bootstrap_password() {
     log "Fetching PostgreSQL bootstrap password from Vault KV..."
     
     # Use wget to read from KV store (curl not available in Vault image)
-response
     response=$(wget -qO- "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         --header="X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null)
+    wget_exit=$?
     
-    if [ $? -ne 0 ] || [ -z "$response" ]; then
+    if [ $wget_exit -ne 0 ] || [ -z "$response" ]; then
         log "Failed to fetch bootstrap password from Vault KV"
         return 1
     fi
     
     # Extract password using basic shell (no jq needed)
-    # Handle both "password": "value" and "password":"value" formats
-password
     password=$(echo "$response" | grep -o '"password"[^,}]*' | head -1 | sed 's/"password"[[:space:]]*:[[:space:]]*"//;s/"$//')
     
     if [ -z "$password" ]; then
@@ -35,10 +33,18 @@ password
     fi
     
     # Write to shared volume
-    mkdir -p /run/secrets
-    echo "$password" > /run/secrets/postgres-password
-    # PostgreSQL runs as user 999 (postgres), make file readable
-    chmod 644 /run/secrets/postgres-password
+    mkdir -p /run/secrets || {
+        log "ERROR: Cannot create /run/secrets directory"
+        return 1
+    }
+    if ! echo "$password" > /run/secrets/postgres-password; then
+        log "ERROR: Cannot write /run/secrets/postgres-password"
+        return 1
+    fi
+    if ! chmod 644 /run/secrets/postgres-password; then
+        log "ERROR: Cannot chmod /run/secrets/postgres-password"
+        return 1
+    fi
     
     log "Bootstrap password written to /run/secrets/postgres-password"
 }

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Vault Agent for PostgreSQL bootstrap password (KV store)
 # Fetches static bootstrap password from Vault KV and writes to file
-# shellcheck shell=bash
+# shellcheck shell=sh
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 VAULT_TOKEN="${VAULT_TOKEN:-aixcl-dev-token}"

--- a/scripts/vault/vault-agent.sh
+++ b/scripts/vault/vault-agent.sh
@@ -14,16 +14,15 @@ fetch_credentials() {
     log "Fetching credentials..."
     
     # Use vault binary to read credentials
-output
     output=$(vault read -format=json database/creds/aixcl-app 2>&1)
+    vault_exit=$?
     
-    if [ $? -ne 0 ]; then
+    if [ $vault_exit -ne 0 ]; then
         log "Failed to fetch credentials: $output"
         return 1
     fi
     
     # Extract using basic shell string manipulation (no jq needed)
-username password
     username=$(echo "$output" | grep '"username"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     password=$(echo "$output" | grep '"password"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     

--- a/scripts/vault/vault-agent.sh
+++ b/scripts/vault/vault-agent.sh
@@ -14,7 +14,7 @@ fetch_credentials() {
     log "Fetching credentials..."
     
     # Use vault binary to read credentials
-    local output
+output
     output=$(vault read -format=json database/creds/aixcl-app 2>&1)
     
     if [ $? -ne 0 ]; then
@@ -23,7 +23,7 @@ fetch_credentials() {
     fi
     
     # Extract using basic shell string manipulation (no jq needed)
-    local username password
+username password
     username=$(echo "$output" | grep '"username"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     password=$(echo "$output" | grep '"password"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     

--- a/scripts/vault/vault-agent.sh
+++ b/scripts/vault/vault-agent.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-# shellcheck shell=bash
+#!/bin/sh
+# shellcheck shell=sh
 # Vault Agent using vault binary
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -494,22 +494,6 @@ services:
       - vault-agent-postgres
     restart: unless-stopped
 
-  vault-agent-postgres:
-    image: hashicorp/vault:1.18
-    container_name: vault-agent-postgres
-    pull_policy: missing
-    environment:
-      VAULT_ADDR: http://127.0.0.1:8200
-      VAULT_TOKEN: aixcl-dev-token
-    volumes:
-      - /tmp/aixcl-secrets:/tmp/vault-secrets
-      - ../scripts/vault/vault-agent.sh:/app/agent.sh:ro
-    command: sh /app/agent.sh
-    network_mode: host
-    depends_on:
-      - vault
-    restart: unless-stopped
-
   nvidia-gpu-exporter:
     image: nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04
     container_name: nvidia-gpu-exporter

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -125,6 +125,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-postgres.sh:/usr/local/bin/bootstrap-password-postgres.sh:ro
       - aixcl-vault-secrets:/run/secrets
@@ -147,6 +148,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-openwebui.sh:/usr/local/bin/bootstrap-password-openwebui.sh:ro
       - aixcl-vault-secrets:/run/secrets
@@ -169,6 +171,7 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      - DAC_OVERRIDE
     volumes:
       - ../scripts/vault/bootstrap-password-pgadmin.sh:/usr/local/bin/bootstrap-password-pgadmin.sh:ro
       - aixcl-vault-secrets:/run/secrets

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -538,44 +538,6 @@ services:
       timeout: 10s
       retries: 3
 
-  # SECURITY NOTE: Alloy requires Docker socket access for container log discovery.
-  # Docker socket access grants full root access on the host. Security mitigations applied:
-  # - Runs as alloy user (UID 12345) via entrypoint with docker group membership
-  # - Read-only root filesystem prevents runtime modifications
-  # - cap_drop: ALL with SETUID cap_add (allows su for user switching)
-  # - Writable data volume for Alloy state, tmpfs for temporary files
-  # - All bind mounts are read-only (:ro suffix)
-  # - Docker socket path auto-detected (supports rootless via DOCKER_SOCK env var)
-  # See docs/operations/security.md section 6 for details.
-  alloy:
-    image: docker.io/grafana/alloy:v1.15.0
-    container_name: alloy
-    pull_policy: missing
-    # Run as root to read protected log files and access docker socket
-    user: "0:0"
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETUID
-      - SETGID
-    tmpfs:
-      - /tmp:noexec,nosuid,size=100m
-      # Use tmpfs for Alloy data to avoid permission issues with named volumes
-      - /data-alloy:noexec,nosuid,size=100m
-    volumes:
-      - ../alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - /var/log:/var/log:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock:ro
-      - ../scripts/runtime/alloy-entrypoint.sh:/usr/local/bin/alloy-entrypoint.sh:ro
-    entrypoint: /usr/local/bin/alloy-entrypoint.sh
-    environment:
-      - DOCKER_GID=${DOCKER_GID:-989}
-    network_mode: host
-    depends_on:
-      - loki
-    restart: unless-stopped
-
 volumes:
   aixcl-ollama-data:
     # external: true  # Disabled: volumes created automatically by compose
@@ -596,8 +558,6 @@ volumes:
   aixcl-grafana:
     # external: true  # Disabled: volumes created automatically by compose
   aixcl-loki:
-    # external: true  # Disabled: volumes created automatically by compose
-  aixcl-alloy-data:
     # external: true  # Disabled: volumes created automatically by compose
   aixcl-alertmanager-data:
     # external: true  # Disabled: volumes created automatically by compose

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -294,6 +294,7 @@ services:
       - aixcl-open-webui-data:/app/data
       - ../scripts/runtime/openwebui.sh:/app/backend/openwebui.sh
       - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     environment:
       - DATA_DIR=/app/data
       - STATIC_DIR=/app/backend/data/static
@@ -347,6 +348,7 @@ services:
       - ../logs/pgadmin:/var/log/pgadmin
       - ../pgadmin-servers.json:/pgadmin4/servers.json
       - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     user: "0:0"  # Start as root, entrypoint drops to pgadmin user
     # Note: Security hardening removed - cap_drop/no-new-privileges breaks su authentication
     # The entrypoint requires privilege escalation to switch from root to pgadmin user


### PR DESCRIPTION
Fixes #957

## Summary
Release v1.1.0 from dev to main. This release includes Vault integration hardening, POSIX/Alpine compatibility fixes, and removal of the deprecated Alloy service.

## Changes
- [x] Vault secrets volume mounted into open-webui and pgadmin (#953 #954)
- [x] Vault CLI logs subcommand added (#947 #949)
- [x] POSIX/Alpine shell compatibility for bootstrap scripts (#950 #951)
- [x] DAC_OVERRIDE capability for bootstrap containers (#952)
- [x] Deprecated Alloy service removed (#955 #956)
- [x] CHANGELOG updated with v1.1.0 release notes

## Testing
- Verified stack start with sys profile: 12/12 services healthy
- Vault dynamic credentials functional (./aixcl vault credentials)
- Vault passwords accessible (./aixcl vault passwords)
- No alloy-related errors on stack stop/start
- Bootstrap scripts work on Alpine containers
- Compose file validates cleanly (podman-compose config)

## Verification
- [x] All services start healthy (12/12)
- [x] Vault initialization successful
- [x] PostgreSQL database created
- [x] No regressions observed
- [x] CI checks passing

## Related Issues
- Closes #957