### PR TITLE
Remove Alloy reference from Grafana log-alerts comment (#962)

### DIFF
--- a/grafana/provisioning/alerting/log-alerts.yml
+++ b/grafana/provisioning/alerting/log-alerts.yml
@@ -21,5 +21,5 @@
 
 # Note: Log-based alerts require Loki as a data source
 # These alerts can be created in Grafana UI using Loki queries
-# Prometheus-based log alerts can be created if using Alloy metrics
+# System-level log metrics (disk, network, CPU) are available via node-exporter and cadvisor
 


### PR DESCRIPTION
Fixes #962

## Summary
Remove stale Alloy reference from Grafana log-alerts.yml comment. Alloy was removed from the stack in v1.1.0 via PR #956.

## Changes
- [x] Updated comment to reference node-exporter and cadvisor instead of Alloy

## Verification
- [x] grep -r alloy grafana/ returns no matches
- [x] CI checks pass

## Related Issues
- Closes #962