### PR TITLE
Make Vault profile-gated, not mandatory (#960)

### DIFF
--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -55,6 +55,11 @@ function cmd_vault() {
 }
 
 function cmd_vault_init() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile ops or --profile sys to enable Vault."
+        return 1
+    fi
     # Run the idempotent initialization
     local init_script="${SCRIPT_DIR}/lib/aixcl/commands/vault-init.sh"
     if [ -f "$init_script" ]; then
@@ -66,6 +71,11 @@ function cmd_vault_init() {
 }
 
 function cmd_vault_status() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile ops or --profile sys to enable Vault."
+        return 1
+    fi
     # Run the status check
     local status_script="${SCRIPT_DIR}/lib/aixcl/commands/vault-status.sh"
     if [ -f "$status_script" ]; then
@@ -77,6 +87,11 @@ function cmd_vault_status() {
 }
 
 function cmd_vault_credentials() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile ops or --profile sys to enable Vault."
+        return 1
+    fi
     # Source existing vault commands
     local vault_commands="${SCRIPT_DIR}/scripts/vault/vault-commands.sh"
     if [ -f "$vault_commands" ]; then
@@ -89,7 +104,30 @@ function cmd_vault_credentials() {
     fi
 }
 
+function cmd_vault_passwords() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile ops or --profile sys to enable Vault."
+        return 1
+    fi
+    # Source existing vault commands
+    local vault_commands="${SCRIPT_DIR}/scripts/vault/vault-commands.sh"
+    if [ -f "$vault_commands" ]; then
+        # shellcheck source=/dev/null
+        source "$vault_commands"
+        vault_passwords
+    else
+        echo "Error: vault-commands.sh not found"
+        return 1
+    fi
+}
+
 function cmd_vault_rotate() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile ops or --profile sys to enable Vault."
+        return 1
+    fi
     echo "Triggering manual credential rotation..."
     
     # Check if Vault is accessible
@@ -239,6 +277,25 @@ function cmd_vault_logs() {
         echo "  ./aixcl stack start --profile sys"
         return 1
     fi
+}
+
+# Check if Vault is enabled in the current profile
+# Reads PROFILE from .env file and checks if vault is in the service list
+vault_is_enabled_in_profile() {
+    local profile=""
+    local env_file="${SCRIPT_DIR}/.env"
+    if [ -f "$env_file" ]; then
+        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    fi
+    [ -z "$profile" ] && profile="sys"
+    
+    # Check if profile contains vault service
+    local profile_services
+    profile_services=$(get_profile_services_for_profile "$profile" 2>/dev/null)
+    if echo "$profile_services" | grep -qw "vault"; then
+        return 0
+    fi
+    return 1
 }
 
 # Export the main command

--- a/lib/cli/profile.sh
+++ b/lib/cli/profile.sh
@@ -37,6 +37,7 @@ declare -A PROFILE_DESCRIPTIONS=(
 # Profile service mappings (Docker-managed services only)
 # Each profile includes runtime core services plus profile-specific services.
 # NOTE: This is now a function to ensure INFERENCE_ENGINE is read after .env loading
+# Vault and bootstrap services are ONLY included in ops and sys profiles.
 get_profile_services_for_profile() {
     local profile="$1"
     # Use current INFERENCE_ENGINE value (may have been updated after .env loading)
@@ -44,10 +45,10 @@ get_profile_services_for_profile() {
     
     case "$profile" in
         usr)
-            echo "$engine vault postgres vault-agent-postgres-bootstrap"
+            echo "$engine postgres"
             ;;
         dev)
-            echo "$engine vault open-webui postgres pgadmin vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap"
+            echo "$engine open-webui postgres pgadmin"
             ;;
         ops)
             echo "$engine vault postgres prometheus grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter vault-agent-postgres vault-agent-postgres-bootstrap"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -191,7 +191,8 @@ services:
     user: "999:999"  # Run as postgres user (official image default)
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-admin}
-      POSTGRES_PASSWORD_FILE: /run/secrets/postgres-password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DATABASE: ${POSTGRES_DATABASE:-webui}
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"


### PR DESCRIPTION
Fixes #960

## Summary
Remove Vault and bootstrap containers from and profiles. Vault is now only enabled in and profiles where observability and audit requirements justify the operational overhead.

## Changes
- [x] usr profile: ollama postgres (no vault)
- [x] dev profile: ollama open-webui postgres pgadmin (no vault)
- [x] ops profile: includes vault + agents + bootstrap
- [x] sys profile: includes vault + agents + bootstrap (unchanged)
- [x] PostgreSQL accepts both env password and file password
- [x] Vault CLI commands show helpful message when Vault is not enabled
- [x] compose file validates cleanly

## Testing
- Verified get_profile_services for all 4 profiles
- podman-compose config returns successfully
- usr: 2 services, dev: 4 services, ops: 12 services, sys: 18 services

## Verification
- [x] No vault containers started for usr/dev
- [x] Vault containers start for ops/sys
- [x] ./aixcl vault status shows profile message when disabled
- [x] CI checks pass

## Related Issues
- Closes #960
