### PR TITLE
Refactor vault and stack commands to use shared lifecycle utilities (#968)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -20,6 +20,8 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 source "${SCRIPT_DIR}/lib/core/color.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/core/common.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/core/service_utils.sh"
 
 # Load environment variables from .env file (before docker_utils validates COMPOSE_FILE)
 if ! load_env_file ".env"; then

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -804,13 +804,7 @@ function start_service() {
     fi
     
     local service="$1"
-    local force_recreate="${2:-false}"  # Optional second parameter to force recreate
-
-    # Resolve 'engine' alias
-    local actual_service="$service"
-    if [[ "$service" == "engine" ]]; then
-        actual_service=$(get_container_name "engine")
-    fi
+    local force_recreate="${2:-false}"
     
     # Validate service name
     if ! is_valid_service "$service"; then
@@ -823,83 +817,8 @@ function start_service() {
         return 1
     fi
     
-    local container_name
-    container_name=$(get_container_name "$service")
-    
-    # Set up compose command with GPU detection
-    set_compose_cmd
-    
-    # Check if service is already running (handle both exact name and hash-prefixed names)
-    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
-        log_info "Service '$service' is already running."
-        return 0
-    fi
-    
-    # Remove any existing containers (running or stopped) to avoid ContainerConfig errors
-    # This is especially important after rebuilds when docker-compose tries to recreate containers
-    log_info "Cleaning up any existing containers for $actual_service..."
-    run_compose rm -f "$actual_service" 2>/dev/null || true
-    
-    # Also remove hash-prefixed containers directly via docker (handles edge cases)
-    local hash_prefixed
-    hash_prefixed=$("${DOCKER_BIN:-docker}" ps -a --format "{{.ID}} {{.Names}}" 2>/dev/null | grep -E "_${container_name}$|^[0-9a-f]+_${container_name}$" | awk '{print $1}') || true
-    if [ -n "$hash_prefixed" ]; then
-        echo "Removing hash-prefixed containers to avoid docker-compose issues..."
-        echo "$hash_prefixed" | while read -r container_id; do
-            "${DOCKER_BIN:-docker}" rm -f "$container_id" 2>/dev/null || true
-        done
-    fi
-    
-    # Remove container by exact name if it exists
-    "${DOCKER_BIN:-docker}" rm -f "$container_name" 2>/dev/null || true
-    
-    log_info "Starting service: $service..."
-    
-    # Check for .env file if needed (for services that require it)
-    if [ ! -f "${SCRIPT_DIR}/.env" ] && { [ "$service" = "open-webui" ] || [ "$service" = "postgres" ] || [ "$service" = "pgadmin" ]; }; then
-        if [ -f "${SCRIPT_DIR}/config/.env.example" ]; then
-            log_warning ".env file not found. Copying from config/.env.example..."
-            cp "${SCRIPT_DIR}/config/.env.example" "${SCRIPT_DIR}/.env"
-            load_env_file "${SCRIPT_DIR}/.env"
-        else
-            log_error ".env file required for service '$service'"
-            return 1
-        fi
-    fi
-    
-    # Generate pgAdmin configuration if starting pgadmin
-    if [ "$service" = "pgadmin" ]; then
-        generate_pgadmin_config
-    fi
-    
-    # Start the specific service
-    # Use --force-recreate if explicitly requested (e.g., after a rebuild)
-    if [ "$force_recreate" = "true" ]; then
-        if run_compose up -d --force-recreate --no-deps "$actual_service"; then
-            log_success "Successfully started service: $service (recreated)"
-        else
-            log_error "Failed to start service: $service"
-            return 1
-        fi
-    else
-        if run_compose up -d "$actual_service"; then
-            log_success "Successfully started service: $service"
-        else
-            log_error "Failed to start service: $service"
-            return 1
-        fi
-    fi
-    
-    # Wait a moment for the service to initialize
-    sleep 2
-    
-    # Check if the container is actually running (handle both exact name and hash-prefixed names)
-    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
-        log_info "Service '$service' is now running."
-    else
-        log_warning "Service '$service' may not have started correctly. Check logs with: $0 logs $service"
-    fi
-    return 0
+    # Delegate to shared utility
+    container_start "$service" "$force_recreate"
 }
 
 function stop_service() {
@@ -915,12 +834,6 @@ function stop_service() {
     fi
     
     local service="$1"
-
-    # Resolve 'engine' alias
-    local actual_service="$service"
-    if [[ "$service" == "engine" ]]; then
-        actual_service=$(get_container_name "engine")
-    fi
     
     # Validate service name
     if ! is_valid_service "$service"; then
@@ -933,34 +846,8 @@ function stop_service() {
         return 1
     fi
     
-    local container_name
-    container_name=$(get_container_name "$service")
-    
-    # Check if service is running
-    if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^${container_name}$"; then
-        log_info "Service '$service' is not running."
-        return 0
-    fi
-    
-    # Set up compose command with GPU detection
-    set_compose_cmd
-    
-    log_info "Stopping service: $service..."
-    
-    # Stop the specific service
-    if run_compose stop "$actual_service"; then
-        log_success "Successfully stopped service: $service"
-        
-        # Clean up pgAdmin configuration if stopping pgadmin
-        if [ "$service" = "pgadmin" ] && [ -f "pgadmin-servers.json" ]; then
-            rm -f pgadmin-servers.json
-            log_info "Cleaned up pgAdmin configuration file"
-        fi
-        return 0
-    else
-        log_error "Failed to stop service: $service"
-        return 1
-    fi
+    # Delegate to shared utility
+    container_stop "$service"
 }
 
 function service() {

--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -10,6 +10,15 @@ function cmd_vault() {
     shift || true
     
     case "$subcommand" in
+        start)
+            cmd_vault_start "$@"
+            ;;
+        stop)
+            cmd_vault_stop "$@"
+            ;;
+        restart)
+            cmd_vault_restart "$@"
+            ;;
         init)
             cmd_vault_init "$@"
             ;;
@@ -33,7 +42,12 @@ function cmd_vault() {
             echo ""
             echo "Usage: ./aixcl vault <command> [options]"
             echo ""
-            echo "Commands:"
+            echo "Lifecycle Commands:"
+            echo "  start        Start the Vault container"
+            echo "  stop         Stop the Vault container"
+            echo "  restart      Restart the Vault container"
+            echo ""
+            echo "Query Commands:"
             echo "  init         Initialize Vault (idempotent)"
             echo "  status       Check Vault health and initialization state"
             echo "  credentials  View generated dynamic credentials"
@@ -42,16 +56,30 @@ function cmd_vault() {
             echo "  logs [n]     View Vault container logs (default: 50 lines)"
             echo ""
             echo "Examples:"
+            echo "  ./aixcl vault start         # Start Vault container"
+            echo "  ./aixcl vault stop          # Stop Vault container"
+            echo "  ./aixcl vault restart       # Restart Vault container"
             echo "  ./aixcl vault init          # Initialize Vault on first run"
             echo "  ./aixcl vault status        # Check if Vault is ready"
             echo "  ./aixcl vault credentials   # View service credentials"
             echo "  ./aixcl vault passwords     # View bootstrap passwords"
             echo "  ./aixcl vault logs          # View last 50 log lines"
-            echo "  ./aixcl vault logs 100      # View last 100 log lines"
             echo ""
             return 1
             ;;
     esac
+}
+
+function cmd_vault_start() {
+    container_start "vault"
+}
+
+function cmd_vault_stop() {
+    container_stop "vault"
+}
+
+function cmd_vault_restart() {
+    container_restart "vault"
 }
 
 function cmd_vault_init() {
@@ -300,6 +328,9 @@ vault_is_enabled_in_profile() {
 
 # Export the main command
 export -f cmd_vault
+export -f cmd_vault_start
+export -f cmd_vault_stop
+export -f cmd_vault_restart
 export -f cmd_vault_init
 export -f cmd_vault_status
 export -f cmd_vault_credentials

--- a/lib/core/service_utils.sh
+++ b/lib/core/service_utils.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Shared container lifecycle utilities
+# Used by: stack, service, vault commands
+# Provides: container_start, container_stop, container_restart
+# Dependencies: common.sh, docker_utils.sh (must be sourced first)
+
+# Start a single container by service name
+# Usage: container_start <service> [force_recreate]
+container_start() {
+    local service="$1"
+    local force_recreate="${2:-false}"
+    
+    # Resolve 'engine' alias
+    local actual_service="$service"
+    if [[ "$service" == "engine" ]]; then
+        actual_service=$(get_container_name "engine")
+    fi
+    
+    local container_name
+    container_name=$(get_container_name "$service")
+    
+    # Set up compose command with GPU detection
+    set_compose_cmd
+    
+    # Check if already running
+    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
+        log_info "Service '$service' is already running."
+        return 0
+    fi
+    
+    # Remove existing containers (running or stopped)
+    log_info "Cleaning up existing containers for $actual_service..."
+    run_compose rm -f "$actual_service" 2>/dev/null || true
+    
+    # Remove hash-prefixed containers directly
+    local hash_prefixed
+    hash_prefixed=$("${DOCKER_BIN:-docker}" ps -a --format "{{.ID}} {{.Names}}" 2>/dev/null | grep -E "_${container_name}$|^[0-9a-f]+_${container_name}$" | awk '{print $1}') || true
+    if [ -n "$hash_prefixed" ]; then
+        echo "$hash_prefixed" | while read -r container_id; do
+            "${DOCKER_BIN:-docker}" rm -f "$container_id" 2>/dev/null || true
+        done
+    fi
+    
+    # Remove exact match
+    "${DOCKER_BIN:-docker}" rm -f "$container_name" 2>/dev/null || true
+    
+    log_info "Starting service: $service..."
+    
+    # Ensure .env exists for services that need it
+    if [ ! -f "${SCRIPT_DIR}/.env" ] && { [ "$service" = "open-webui" ] || [ "$service" = "postgres" ] || [ "$service" = "pgadmin" ]; }; then
+        if [ -f "${SCRIPT_DIR}/config/.env.example" ]; then
+            log_warning ".env file not found. Copying from config/.env.example..."
+            cp "${SCRIPT_DIR}/config/.env.example" "${SCRIPT_DIR}/.env"
+            load_env_file "${SCRIPT_DIR}/.env"
+        else
+            log_error ".env file required for service '$service'"
+            return 1
+        fi
+    fi
+    
+    # Generate pgAdmin config if needed
+    if [ "$service" = "pgadmin" ]; then
+        generate_pgadmin_config
+    fi
+    
+    # Start the container
+    if [ "$force_recreate" = "true" ]; then
+        if run_compose up -d --force-recreate --no-deps "$actual_service"; then
+            log_success "Successfully started service: $service (recreated)"
+        else
+            log_error "Failed to start service: $service"
+            return 1
+        fi
+    else
+        if run_compose up -d "$actual_service"; then
+            log_success "Successfully started service: $service"
+        else
+            log_error "Failed to start service: $service"
+            return 1
+        fi
+    fi
+    
+    # Wait briefly for initialization
+    sleep 2
+    
+    # Verify it's running
+    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
+        log_info "Service '$service' is now running."
+    else
+        log_warning "Service '$service' may not have started correctly. Check logs with: $0 logs $service"
+    fi
+    return 0
+}
+
+# Stop a single container by service name
+# Usage: container_stop <service>
+container_stop() {
+    local service="$1"
+    
+    # Resolve 'engine' alias
+    local actual_service="$service"
+    if [[ "$service" == "engine" ]]; then
+        actual_service=$(get_container_name "engine")
+    fi
+    
+    local container_name
+    container_name=$(get_container_name "$service")
+    
+    # Check if running
+    if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^${container_name}$"; then
+        log_info "Service '$service' is not running."
+        return 0
+    fi
+    
+    set_compose_cmd
+    
+    log_info "Stopping service: $service..."
+    
+    if run_compose stop "$actual_service"; then
+        log_success "Successfully stopped service: $service"
+        
+        # Clean up pgAdmin config if stopping pgadmin
+        if [ "$service" = "pgadmin" ] && [ -f "pgadmin-servers.json" ]; then
+            rm -f pgadmin-servers.json
+            log_info "Cleaned up pgAdmin configuration file"
+        fi
+        return 0
+    else
+        log_error "Failed to stop service: $service"
+        return 1
+    fi
+}
+
+# Restart a single container by service name
+# Usage: container_restart <service> [force_recreate]
+container_restart() {
+    local service="$1"
+    local force_recreate="${2:-false}"
+    
+    log_info "Restarting service: $service..."
+    
+    if container_stop "$service"; then
+        if container_start "$service" "$force_recreate"; then
+            log_success "Successfully restarted service: $service"
+            return 0
+        else
+            log_error "Failed to start service during restart: $service"
+            return 1
+        fi
+    else
+        log_error "Failed to stop service during restart: $service"
+        return 1
+    fi
+}
+
+# Export functions for use in other modules
+export -f container_start container_stop container_restart


### PR DESCRIPTION
# Pull Request

## Summary
Refactors container lifecycle management into a shared utility module so both `vault` and `stack service` commands use the same code path for start/stop/restart operations.

Fixes #968

### Description of Changes
- Extract `container_start`, `container_stop`, `container_restart` into `lib/core/service_utils.sh`
- Refactor `start_service()` and `stop_service()` in `lib/aixcl/commands/stack.sh` to delegate to shared utilities
- Add `start`, `stop`, `restart` subcommands to `./aixcl vault` command in `lib/aixcl/commands/vault.sh`
- Source new shared module in `aixcl` main script
- Export new functions for dispatcher use
- Use "honest architecture": shared functions over thin aliases

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes
Tested all 4 profiles after refactor:
- `usr` profile (2 services): both healthy
- `dev` profile (4 services): all healthy
- `ops` profile (10 services): all healthy
- `sys` profile (12 services): all healthy

`./aixcl stack stop` correctly stops all services. `./aixcl vault start` and `./aixcl vault stop` use shared utility code.

### Verification
- [x] `./aixcl vault start` starts vault container
- [x] `./aixcl vault stop` stops vault container
- [x] `./aixcl vault restart` restarts vault container
- [x] `./aixcl stack service stop <name>` still works
- [x] All 4 profiles start healthy
- [x] No regressions in stack start/stop

### Related Issues
- Closes #968
