### PR TITLE
Unify release templates and standardize all GitHub releases (#975)

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,77 +1,36 @@
-# Release vX.Y.Z
+---
+name: AIXCL Release Notes Template
+description: Template for creating GitHub releases
+version: 2.0
+---
 
-## Summary
+## AIXCL vX.Y.Z
 
-Brief description of this release - what it includes, key highlights, and why it matters.
+**One-line summary describing this release.**
 
-### Target Date
-YYYY-MM-DD
+### What's New in vX.Y.Z
 
-### Previous Release
-vX.Y.Z-(N-1) (or specify)
+#### Thematic Category
+- ✅ Description of change or feature (#issue-number)
+- ✅ Another change or feature (#issue-number)
+
+#### Another Category
+- ✅ Description (#issue-number)
+
+### Installation
+
+```bash
+git clone https://github.com/xencon/aixcl.git
+cd aixcl
+./aixcl utils check-env
+./aixcl stack start --profile usr
+```
+
+### Documentation
+- [Getting Started](README.md)
+- [Development Workflow](DEVELOPMENT.md)
+- [Changelog](CHANGELOG.md)
 
 ---
 
-## Security
-
-List security-related changes, CVE fixes, hardening improvements:
-- Security fix 1
-- Security fix 2
-
-## Added
-
-List new features, services, or capabilities:
-- New feature 1
-- New feature 2
-
-## Changed
-
-List modifications to existing functionality:
-- Change 1
-- Change 2
-
-## Deprecated
-
-List features marked for deprecation (will be removed in future):
-- Deprecated feature 1
-
-## Removed
-
-List removed features or services:
-- Removed feature 1
-
-## Fixed
-
-List bug fixes and issue resolutions:
-- Fix 1 (Fixes #<issue-number>)
-- Fix 2 (Fixes #<issue-number>)
-
-## Documentation
-
-List documentation updates:
-- Doc update 1
-- Doc update 2
-
----
-
-## Related Issues
-
-- Closes #<issue-number>
-- Closes #<issue-number>
-
-## Deployment Notes
-
-Any special instructions for deploying this release:
-- Migration steps
-- Configuration changes
-- Breaking changes requiring user action
-
-## Known Issues
-
-List any known issues not yet resolved:
-- Issue 1 (tracked in #<issue-number>)
-- Issue 2 (tracked in #<issue-number>)
-
----
-
-**Full Changelog**: https://github.com/xencon/aixcl/compare/vPREVIOUS...vX.Y.Z
+**Full Changelog**: [vPREVIOUS...vX.Y.Z](../../compare/vPREVIOUS...vX.Y.Z)

--- a/ai/actions/workflow/action-create-release.md
+++ b/ai/actions/workflow/action-create-release.md
@@ -99,35 +99,34 @@ echo "✅ Version $RELEASE_VERSION validated"
 ### Step 4: Generate Release Notes
 
 ```bash
-# Read template
-TEMPLATE=$(cat ai/templates/release/release_notes.md)
+# Read current and previous tag names
+LATEST_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "v0.0.0")
 
-# Extract from CHANGELOG
-UNRELEASED=$(sed -n '/^## \[Unreleased\]/,/^## \[v/p' CHANGELOG.md | head --1 | tail -n +2)
+# Extract Unreleased section from CHANGELOG — first line is the summary
+CHANGELOG_SUMMARY=$(sed -n '/^## \[Unreleased\]/,/^## \[v/p' CHANGELOG.md | grep -v "^## " | grep -v "^###" | grep "^$" | head -1)
 
-# Parse sections
-SECURITY=$(echo "$UNRELEASED" | sed -n '/### Security/,/### /p' | head --1 | tail -n +2)
-ADDED=$(echo "$UNRELEASED" | sed -n '/### Added/,/### /p' | head --1 | tail -n +2)
-CHANGED=$(echo "$UNRELEASED" | sed -n '/### Changed/,/### /p' | head --1 | tail -n +2)
-FIXED=$(echo "$UNRELEASED" | sed -n '/### Fixed/,/### /p' | head --1 | tail -n +2)
+# Generate release notes in unified format
+RELEASE_NOTES="## AIXCL $RELEASE_VERSION
 
-# Generate draft
-RELEASE_NOTES="# Release $RELEASE_VERSION
+**$CHANGELOG_SUMMARY**
 
-## Summary
-$(echo "$UNRELEASED" | grep -v "^###" | grep -v "^$" | head -1)
+### What's New in $RELEASE_VERSION
 
-## Security
-$SECURITY
+$(sed -n '/^## \[Unreleased\]/,/^## \[v/p' CHANGELOG.md | sed 's/^### /#### /' | grep -v "^## \[" | grep -v "^---$" | grep -v "^$(date +%Y-%m-%d)$" | sed 's/^- /- ✅ /')
 
-## Added
-$ADDED
+### Installation
 
-## Changed
-$CHANGED
+\`\`\`bash
+git clone https://github.com/xencon/aixcl.git
+cd aixcl
+./aixcl utils check-env
+./aixcl stack start --profile usr
+\`\`\`
 
-## Fixed
-$FIXED
+### Documentation
+- [Getting Started](README.md)
+- [Development Workflow](DEVELOPMENT.md)
+- [Changelog](CHANGELOG.md)
 
 ---
 

--- a/ai/templates/release/release_notes.md
+++ b/ai/templates/release/release_notes.md
@@ -1,104 +1,35 @@
 ---
 name: "Release Notes"
-about: "Template for creating a new release"
-title: "[RELEASE] vX.Y.Z"
-labels: ["release"]
-assignees: ["<assignee>"]
+about: "Template for creating a new GitHub release"
 ---
 
-# Release vX.Y.Z
+## AIXCL vX.Y.Z
 
-## Summary
+**One-line summary describing this release.**
 
-Brief description of this release - what it includes, key highlights, and why it matters.
+### What's New in vX.Y.Z
 
-### Target Date
-YYYY-MM-DD
+#### Thematic Category
+- ✅ Description of change or feature (#issue-number)
+- ✅ Another change or feature (#issue-number)
 
-### Previous Release
-vX.Y.Z-(N-1) (or specify)
+#### Another Category
+- ✅ Description (#issue-number)
 
----
+### Installation
 
-## Security
+```bash
+git clone https://github.com/xencon/aixcl.git
+cd aixcl
+./aixcl utils check-env
+./aixcl stack start --profile usr
+```
 
-List security-related changes, CVE fixes, hardening improvements:
-- [ ] Security fix 1
-- [ ] Security fix 2
-
-## Added
-
-List new features, services, or capabilities:
-- [ ] New feature 1
-- [ ] New feature 2
-
-## Changed
-
-List modifications to existing functionality:
-- [ ] Change 1
-- [ ] Change 2
-
-## Deprecated
-
-List features marked for deprecation (will be removed in future):
-- [ ] Deprecated feature 1
-
-## Removed
-
-List removed features or services:
-- [ ] Removed feature 1
-
-## Fixed
-
-List bug fixes and issue resolutions:
-- [ ] Fix 1 (Fixes #<issue-number>)
-- [ ] Fix 2 (Fixes #<issue-number>)
-
-## Documentation
-
-List documentation updates:
-- [ ] Doc update 1
-- [ ] Doc update 2
+### Documentation
+- [Getting Started](README.md)
+- [Development Workflow](DEVELOPMENT.md)
+- [Changelog](CHANGELOG.md)
 
 ---
 
-## Related Issues
-
-- Closes #<issue-number>
-- Closes #<issue-number>
-
-## Verification Checklist
-
-- [ ] All CI checks passing
-- [ ] Security scan completed
-- [ ] Performance benchmarks run
-- [ ] Breaking changes documented
-- [ ] Migration guide provided (if applicable)
-- [ ] CHANGELOG.md updated
-- [ ] Version bumped in relevant files
-- [ ] Git tag created: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
-- [ ] Release notes published to GitHub
-
-## Deployment Notes
-
-Any special instructions for deploying this release:
-- Migration steps
-- Configuration changes
-- Breaking changes requiring user action
-
-## Known Issues
-
-List any known issues not yet resolved:
-- Issue 1 (tracked in #<issue-number>)
-- Issue 2 (tracked in #<issue-number>)
-
----
-
-## Template Usage Notes
-
-1. Replace X.Y.Z with actual version number
-2. Remove unused sections (if no items in Deprecated, remove that section)
-3. Follow [Keep a Changelog](https://keepachangelog.com/) format
-4. Reference all related issues
-5. Update CHANGELOG.md with same content after release
-6. Create GitHub Release with these notes
+**Full Changelog**: [vPREVIOUS...vX.Y.Z](../../compare/vPREVIOUS...vX.Y.Z)


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #975

### Description of Changes
Unify release templates and standardize all GitHub releases (v1.0.0 through v1.1.2) to a single consistent format.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: At least one assignee is set
- [x] **Component Label**: At least one `component:*` label
- [x] **Title Format**: `<description> (#<number>)` with NO colons

### Testing Notes
- Verified all 4 user-facing releases (v1.0.0-v1.1.2) now share consistent formatting
- Verified release templates match the v1.0.0 reference standard

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #975
