### PR TITLE
Add .security/ to gitignore and use CHANGEME placeholders in .env.example (#979)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ context/
 *.sqlite
 *.sqlite3
 export/
+
+# Generated SSL/certificates
+.security/

--- a/config/.env.example
+++ b/config/.env.example
@@ -10,20 +10,20 @@
 
 # PostgreSQL Configuration
 POSTGRES_USER=admin
-POSTGRES_PASSWORD=admin
+POSTGRES_PASSWORD=CHANGEME
 POSTGRES_DATABASE=webui
 
 # pgAdmin Configuration
 PGADMIN_EMAIL=admin@example.com
-PGADMIN_PASSWORD=admin
+PGADMIN_PASSWORD=CHANGEME
 
 # Open WebUI Configuration
 OPENWEBUI_EMAIL=admin@example.com
-OPENWEBUI_PASSWORD=admin
+OPENWEBUI_PASSWORD=CHANGEME
 
 # Grafana Configuration (optional, defaults shown)
 # GRAFANA_ADMIN_USER=admin
-# GRAFANA_ADMIN_PASSWORD=admin
+# GRAFANA_ADMIN_PASSWORD=CHANGEME
 
 # Default profile for stack commands
 # Options: usr (minimal), dev (UI+DB), ops (Observability), sys (Full)


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #979

### Description of Changes
- Add `.security/` to `.gitignore` to prevent generated SSL certificates from being tracked
- Change default passwords in `config/.env.example` from `admin` to `CHANGEME`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: At least one assignee is set
- [x] **Component Label**: At least one `component:*` label
- [x] **Title Format**: No colons in description

### Testing Notes
- Verified `.gitignore` contains `.security/` entry
- Verified `.env.example` passwords are now `CHANGEME`

### Verification
- [x] No regressions observed

### Related Issues
- Closes #979

## Additional Notes

Fixes #979
