### PR TITLE
Sync dev to main post-v1.1.2 fixes (#983)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ context/
 *.sqlite
 *.sqlite3
 export/
+
+# Generated SSL/certificates
+.security/

--- a/config/.env.example
+++ b/config/.env.example
@@ -10,20 +10,20 @@
 
 # PostgreSQL Configuration
 POSTGRES_USER=admin
-POSTGRES_PASSWORD=admin
+POSTGRES_PASSWORD=CHANGEME
 POSTGRES_DATABASE=webui
 
 # pgAdmin Configuration
 PGADMIN_EMAIL=admin@example.com
-PGADMIN_PASSWORD=admin
+PGADMIN_PASSWORD=CHANGEME
 
 # Open WebUI Configuration
 OPENWEBUI_EMAIL=admin@example.com
-OPENWEBUI_PASSWORD=admin
+OPENWEBUI_PASSWORD=CHANGEME
 
 # Grafana Configuration (optional, defaults shown)
 # GRAFANA_ADMIN_USER=admin
-# GRAFANA_ADMIN_PASSWORD=admin
+# GRAFANA_ADMIN_PASSWORD=CHANGEME
 
 # Default profile for stack commands
 # Options: usr (minimal), dev (UI+DB), ops (Observability), sys (Full)

--- a/scripts/checks/check-paths.sh
+++ b/scripts/checks/check-paths.sh
@@ -53,6 +53,10 @@ check_markdown_paths() {
             [[ "$link" =~ ^https?:// ]] && continue
             [[ "$link" =~ ^# ]] && continue
             [[ "$link" =~ ^mailto: ]] && continue
+
+            # Skip template placeholder paths (release notes, templates)
+            [[ "$link" =~ vPREVIOUS\.\.\.vX\.Y\.Z ]] && continue
+            [[ "$link" =~ \.\.\./\.\./compare/ ]] && continue
             
             # Remove anchor fragments
             local path="${link%%#*}"

--- a/scripts/runtime/postgres-secret-entrypoint.sh
+++ b/scripts/runtime/postgres-secret-entrypoint.sh
@@ -1,22 +1,94 @@
-#!/usr/bin/env bash
+#!/bin/sh
+# postgres-secret-entrypoint.sh — PostgreSQL entrypoint wrapper
+# Ensures the admin password is always synced from Vault-generated secret.
 #
-# PostgreSQL Secret Reader Entrypoint
-# Reads credentials from Docker secrets and exports as environment variables
+# Problem: The official PostgreSQL docker-entrypoint.sh only runs initdb on
+# the first volume creation. On subsequent restarts, the database exists but
+# the password may have changed (Vault generates new dynamic passwords).
+#
+# Solution: Start postgres temporarily via pg_ctl, ALTER USER the password,
+# then start normally via the official docker-entrypoint.sh.
+#
+# Usage in docker-compose.yml:
+#   entrypoint: ["/usr/local/bin/postgres-secret-entrypoint.sh"]
+#   command:
+#     postgres
+#     -c listen_addresses=127.0.0.1
+#     ...
+#
+# Note: Must be run as UID 999 or root (matching postgres:17.9 image).
 
 set -e
 
-# Read secrets from files if _FILE variables are set
-if [[ -n "${POSTGRES_USER_FILE:-}" && -f "$POSTGRES_USER_FILE" ]]; then
-  POSTGRES_USER="$(cat "$POSTGRES_USER_FILE")"
-  export POSTGRES_USER
-  unset POSTGRES_USER_FILE
+PG_ENTRYPOINT="/usr/local/bin/docker-entrypoint.sh"
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+
+# Read the Vault-generated password if available (mounted via aixcl-vault-secrets)
+VAULT_PASS=""
+if [ -f /run/secrets/postgres-password ] && [ -s /run/secrets/postgres-password ]; then
+    VAULT_PASS=$(cat /run/secrets/postgres-password | tr -d '\n')
+    echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
+else
+    echo "[Vault] No vault password file found, using PGPASSWORD env var"
 fi
 
-if [[ -n "${POSTGRES_PASSWORD_FILE:-}" && -f "$POSTGRES_PASSWORD_FILE" ]]; then
-  POSTGRES_PASSWORD="$(cat "$POSTGRES_PASSWORD_FILE")"
-  export POSTGRES_PASSWORD
-  unset POSTGRES_PASSWORD_FILE
+# If Vault password is set AND database already exists, update the admin password.
+# First-init: docker-entrypoint.sh handles it via POSTGRES_PASSWORD env var.
+# Subsequent starts: we must update the password in the DB.
+if [ -n "$VAULT_PASS" ] && [ -d "$PGDATA" ] && [ -f "$PGDATA/PG_VERSION" ]; then
+    echo "[Vault] Database already initialized (PGDATA exists). Syncing password..."
+
+    # The DB is running as user 999 (postgres). pg_ctl must run as that user.
+    # The official image entrypoint does not start postgres until after initdb,
+    # so here we start it ourselves, update the password, then stop it.
+
+    # Temporarily set the password env vars so pg_ctl can start successfully.
+    # If the old password is still in POSTGRES_PASSWORD (e.g. from .env),
+    # pg_hba.conf checks md5/scram and the server will accept.
+    # Then we connect via TCP (not socket — to avoid peer auth issues) to ALTER USER.
+
+    # Save original values
+    OLD_POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
+
+    # Set Vault password so the server starts with the correct secrets
+    export POSTGRES_PASSWORD="$VAULT_PASS"
+    export PGPASSWORD="$VAULT_PASS"
+
+    echo "[Vault] Starting PostgreSQL temporarily for password sync..."
+    pg_ctl -D "$PGDATA" start -o "-h 127.0.0.1" -l /tmp/pg_sync.log
+
+    # Wait for PostgreSQL to be ready via TCP
+    pg_ready=false
+    for i in $(seq 1 30); do
+        if pg_isready -h 127.0.0.1 -p 5432 -U "${POSTGRES_USER:-admin}" >/dev/null 2>&1; then
+            pg_ready=true
+            break
+        fi
+        echo "[Vault] Waiting for PostgreSQL to be ready... ($i/30)"
+        sleep 2
+    done
+
+    if [ "$pg_ready" = false ]; then
+        echo "[Vault] Warning: PostgreSQL did not become ready, skipping password sync"
+    else
+        echo "[Vault] Updating PostgreSQL admin password to match Vault secret..."
+        psql -U "${POSTGRES_USER:-admin}" -h 127.0.0.1 -d "${POSTGRES_DATABASE:-webui}" \
+            -Atc "ALTER USER ${POSTGRES_USER:-admin} WITH PASSWORD '${VAULT_PASS}';" > /dev/null 2>&1 && \
+            echo "[Vault] Password updated successfully" && \
+            echo "[Vault] PostgreSQL will restart with new password"
+    fi
+
+    echo "[Vault] Stopping temporary PostgreSQL instance..."
+    pg_ctl -D "$PGDATA" stop -m fast
+
+    # Restore original password for the official entrypoint
+    POSTGRES_PASSWORD="${OLD_POSTGRES_PASSWORD:-admin}"
+    export POSTGRES_PASSWORD
+
+    echo "[Vault] Starting PostgreSQL with official entrypoint..."
+    echo ""
 fi
 
-# Execute the original entrypoint
-exec docker-entrypoint.sh "$@"
+# Delegate to the official docker-entrypoint.sh which handles initdb or startup.
+# If we started postgres above, it was stopped — this will start it fresh.
+exec "$PG_ENTRYPOINT" "$@"

--- a/scripts/vault/vault-agent-openwebui.sh
+++ b/scripts/vault/vault-agent-openwebui.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-# shellcheck shell=bash
+#!/bin/sh
+# shellcheck shell=sh
 # Vault Agent for Open WebUI
 
 VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
@@ -13,15 +13,14 @@ log() {
 fetch_credentials() {
     log "Fetching credentials for Open WebUI..."
     
-    local output
     output=$(vault read -format=json database/creds/aixcl-app 2>&1)
+    vault_exit=$?
     
-    if [ $? -ne 0 ]; then
+    if [ $vault_exit -ne 0 ]; then
         log "Failed to fetch credentials: $output"
         return 1
     fi
     
-    local username password
     username=$(echo "$output" | grep '"username"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     password=$(echo "$output" | grep '"password"' | sed 's/.*: "\(.*\)".*/\1/' | tr -d '[:space:],"')
     

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -199,9 +199,11 @@ services:
     volumes:
       - aixcl-pgdata:/var/lib/postgresql/data
       - aixcl-vault-secrets:/run/secrets:ro
+      - ../scripts/runtime/postgres-secret-entrypoint.sh:/usr/local/bin/postgres-secret-entrypoint.sh:ro
       - ../scripts/db/init:/docker-entrypoint-initdb.d:ro
     network_mode: host
     restart: always
+    entrypoint: ["/usr/local/bin/postgres-secret-entrypoint.sh"]
     cap_drop:
       - ALL
     security_opt:


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #983

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #983

## Changes in this sync

- Security hardening (#979)
 - `.security/` added to `.gitignore`
 - Default passwords changed to `CHANGEME` placeholders in `config/.env.example`

- Alpine compatibility (#980)
 - Fixed `bash` shebang in `vault-agent-openwebui.sh` for Alpine-based Vault image

- PostgreSQL password sync (#981)
 - Added `postgres-secret-entrypoint.sh` to sync `admin` password from Vault on every restart
 - Prevents Open WebUI auth failures across clean reinstalls

- CI fix (#982)
 - `check-paths.sh` skips release template placeholder paths (`vPREVIOUS...vX.Y.Z`)

Closes #983
