### PR TITLE
Vault-managed credentials for all services (#999)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ pgadmin-servers.json
 # Open WebUI secret keys
 .webui_secret_key
 *.key
+.aixcl.initialized
 
 # Database backups (user-generated)
 pg-backup/*

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -447,6 +447,7 @@ services:
       - aixcl-grafana:/var/lib/grafana
       - ../grafana/provisioning:/etc/grafana/provisioning:ro
       - aixcl-vault-secrets:/run/secrets:ro
+      - ../scripts/runtime/grafana-entrypoint.sh:/usr/local/bin/grafana-entrypoint.sh:ro
     entrypoint: ["/usr/local/bin/grafana-entrypoint.sh"]
     environment:
       - GF_SECURITY_ADMIN_USER=${AIXCL_ADMIN_USER:-admin}


### PR DESCRIPTION
Fixes #999 Fixes #1005

## Summary
This PR implements Vault as the single source of truth for ALL service credentials (PostgreSQL, Open WebUI, pgAdmin, Grafana) and introduces `./aixcl stack init` for first-run setup.

## Changes
- lib/aixcl/commands/stack.sh: Add init_stack() for first-run prompts (username/email).
- lib/aixcl/commands/vault-init.sh: Generate random passwords for all services, store in KV with email/username.
- lib/aixcl/commands/vault.sh: Add generic cmd_vault_passwords() that reads ALL /bootstrap/* KV paths dynamically.
- config/.env.example: Strip ALL password fields. Only admin identity and non-credential config remain.
- scripts/runtime/: Add Vault-aware entrypoints for postgres, grafana.
- scripts/vault/: Add bootstrap agents for grafana.
- services/docker-compose.yml: Fix missing grafana-entrypoint.sh volume mount (Bug #1005).
- .gitignore: Add .aixcl.initialized marker file.

## Verification
- [x] Clean clone: ./aixcl stack init prompts for username/email.
- [x] ./aixcl stack start --profile sys starts all services.
- [x] ./aixcl vault passwords shows all generated credentials.
