### PR TITLE
Fix missing grafana entrypoint volume mount (#1005)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ pgadmin-servers.json
 # Open WebUI secret keys
 .webui_secret_key
 *.key
+.aixcl.initialized
 
 # Database backups (user-generated)
 pg-backup/*

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -447,6 +447,7 @@ services:
       - aixcl-grafana:/var/lib/grafana
       - ../grafana/provisioning:/etc/grafana/provisioning:ro
       - aixcl-vault-secrets:/run/secrets:ro
+      - ../scripts/runtime/grafana-entrypoint.sh:/usr/local/bin/grafana-entrypoint.sh:ro
     entrypoint: ["/usr/local/bin/grafana-entrypoint.sh"]
     environment:
       - GF_SECURITY_ADMIN_USER=${AIXCL_ADMIN_USER:-admin}


### PR DESCRIPTION
Fixes #1005

## Summary
Add missing volume mount for Grafana entrypoint script so the container can start successfully with the Vault-managed password entrypoint.

## Changes
- services/docker-compose.yml: Mount `../scripts/runtime/grafana-entrypoint.sh` into `/usr/local/bin/grafana-entrypoint.sh` (read-only).
- .gitignore: Add `.aixcl.initialized` to prevent committing the first-run initialization marker.

## Verification
- [x] Grafana container starts successfully with profile sys
- [x] Grafana login works with Vault-managed credentials

## Testing Notes
Discovered during end-to-end clean-install testing of Vault credential flow. Grafana container failed with: `exec: "/usr/local/bin/grafana-entrypoint.sh": stat: no such file or directory`

## Related Issues
- Closes #1005
