### PR TITLE
Fix stack start silent failure on clean build due to missing PROFILE and pipefail (#1008)

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -24,6 +24,10 @@ AIXCL_ADMIN_EMAIL=
 #AIXCL_ADMIN_USER=admin
 #AIXCL_ADMIN_EMAIL=admin@example.com
 
+# Default profile for stack commands
+# Options: usr (minimal), dev (UI+DB), ops (Observability), sys (Full)
+PROFILE=usr
+
 # PostgreSQL Configuration
 POSTGRES_USER=admin
 POSTGRES_DATABASE=webui

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -170,7 +170,7 @@ function start() {
         if [ -f "$env_file" ]; then
             # Read PROFILE from .env file
             local env_profile
-            env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
             
             if [ -n "$env_profile" ]; then
                 profile="$env_profile"
@@ -227,7 +227,7 @@ function start() {
         local env_file="${SCRIPT_DIR}/.env"
         if [ -f "$env_file" ]; then
             local current_env_profile
-            current_env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            current_env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
             if [ "$current_env_profile" != "$profile" ]; then
                 # Update or add PROFILE in .env file
                 if grep -qE "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null; then
@@ -560,7 +560,7 @@ function stop() {
     local profile=""
     local env_file="${SCRIPT_DIR}/.env"
     if [ -f "$env_file" ]; then
-        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     fi
     [ -z "$profile" ] && profile="sys"
     
@@ -761,7 +761,7 @@ function restart() {
         if [ -f "$env_file" ]; then
             # Read PROFILE from .env file
             local env_profile
-            env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
             
             if [ -n "$env_profile" ]; then
                 profile="$env_profile"
@@ -814,7 +814,7 @@ function restart() {
         local env_file="${SCRIPT_DIR}/.env"
         if [ -f "$env_file" ]; then
             local current_env_profile
-            current_env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            current_env_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
             if [ "$current_env_profile" != "$profile" ]; then
                 # Update or add PROFILE in .env file
                 if grep -qE "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null; then
@@ -1097,7 +1097,7 @@ function export_quadlet() {
     local profile=""
     # Load profile from .env if not specified
     if [ -f "${SCRIPT_DIR}/.env" ]; then
-        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "${SCRIPT_DIR}/.env" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "${SCRIPT_DIR}/.env" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     fi
     
     if [ -z "$profile" ]; then
@@ -1180,7 +1180,7 @@ function status() {
     local current_profile=""
     local env_file="${SCRIPT_DIR}/.env"
     if [ -f "$env_file" ]; then
-        current_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        current_profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     fi
     
     # Determine overall status (Running/Stopped)

--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -344,7 +344,7 @@ vault_is_enabled_in_profile() {
     local profile=""
     local env_file="${SCRIPT_DIR}/.env"
     if [ -f "$env_file" ]; then
-        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     fi
     [ -z "$profile" ] && profile="sys"
     

--- a/lib/core/env_check.sh
+++ b/lib/core/env_check.sh
@@ -222,7 +222,8 @@ check_env() {
     if [ -f "${SCRIPT_DIR}/.env" ]; then
         local env_errors=0
         # Check for required variables
-        for var in POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DATABASE; do
+        # NOTE: Passwords are managed by Vault. Do not require them in .env.
+        for var in POSTGRES_USER POSTGRES_DATABASE; do
             if ! grep -q "^[[:space:]]*${var}=" "${SCRIPT_DIR}/.env"; then
                 print_error "Missing required environment variable in .env: $var"
                 env_errors=1


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1008

### Description of Changes
This PR fixes the silent failure of `./aixcl stack start` on clean builds. The root cause was twofold:
1. `config/.env.example` was missing the `PROFILE=` line (removed during Vault migration), so `.env` generated from it had no profile.
2. `grep | head | cut | sed` pipelines in `stack.sh` and `vault.sh` fail under `set -e` + `set -o pipefail` when `PROFILE` is absent, causing immediate silent termination.

Changes made:
- Added `PROFILE=usr` back to `config/.env.example`
- Appended `|| true` to 7 grep pipelines in `lib/aixcl/commands/stack.sh`
- Appended `|| true` to 1 grep pipeline in `lib/aixcl/commands/vault.sh`
- Removed `POSTGRES_PASSWORD` from the hard-required env check list in `lib/core/env_check.sh` (Vault-managed)

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee set
- [x] Component label added
- [x] Title format correct (no colons)

### Testing Notes
Tested on Ubuntu 24.04 WSL with Podman:
- `rm -f .aixcl.initialized; cp config/.env.example .env`
- `./aixcl stack init` (admin/admin@example.com)
- `./aixcl stack start --profile sys` — proceeds past profile selection, pulls images
- `./aixcl utils check-env` — passes (green checkmark), no POSTGRES_PASSWORD missing error

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1008
