### PR TITLE
Fix Open WebUI pgAdmin and Grafana startup failures on Vault-managed credentials (#1010)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -116,6 +116,8 @@ function init_stack() {
     # Update .env with values
     sed -i "s/^AIXCL_ADMIN_USER=.*/AIXCL_ADMIN_USER=$AIXCL_ADMIN_USER/" "$env_file"
     sed -i "s/^AIXCL_ADMIN_EMAIL=.*/AIXCL_ADMIN_EMAIL=$AIXCL_ADMIN_EMAIL/" "$env_file"
+    sed -i "s/^PGADMIN_DEFAULT_EMAIL=.*/PGADMIN_DEFAULT_EMAIL=$AIXCL_ADMIN_EMAIL/" "$env_file"
+    sed -i "s/^OPENWEBUI_EMAIL=.*/OPENWEBUI_EMAIL=$AIXCL_ADMIN_EMAIL/" "$env_file"
 
     echo ""
     echo "Initialisation complete:"

--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -9,16 +9,11 @@ echo "=== Grafana Vault-Secure Entrypoint ==="
 # Read admin password from Vault secret
 if [ -f /run/secrets/grafana-password ]; then
     GRAFANA_ADMIN_PASSWORD=$(cat /run/secrets/grafana-password | tr -d '\n')
-    export GRAFANA_ADMIN_PASSWORD
     echo "[Vault] Grafana admin password loaded from /run/secrets/grafana-password"
 else
     echo "[Vault] Warning: /run/secrets/grafana-password not found, using fallback"
     GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD:-admin}"
-    export GRAFANA_ADMIN_PASSWORD
 fi
-
-# Export to Grafana's expected env var
-export GF_SECURITY_ADMIN_PASSWORD="$GRAFANA_ADMIN_PASSWORD"
 
 echo "[Vault] Starting Grafana with Vault-managed credentials..."
 
@@ -26,9 +21,12 @@ echo "$GRAFANA_ADMIN_PASSWORD" > /tmp/grafana-admin-password
 chown 472:472 /tmp/grafana-admin-password 2>/dev/null || true
 chmod 600 /tmp/grafana-admin-password
 
-# Pass env var to Grafana so it reads the password file
+# Pass password via file (avoids leaking in env and avoids conflict with direct var)
 export GF_SECURITY_ADMIN_PASSWORD__FILE=/tmp/grafana-admin-password
 unset GRAFANA_ADMIN_PASSWORD
+
+# Ensure GF_SECURITY_ADMIN_PASSWORD is not set (Grafana rejects both)
+unset GF_SECURITY_ADMIN_PASSWORD
 
 # Start Grafana official entrypoint
 exec /run.sh

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -107,7 +107,7 @@ if [ "$(id -u)" = "0" ]; then
     # Preserve environment variables needed by OpenWebUI (DATABASE_URL, etc.)
     # Using 'su' (not 'su -') preserves the environment
     export -n USER_ID GROUP_ID  # Don't export these to avoid confusion
-    exec su webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
+    exec su -m webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
 fi
 
 # At this point, we should be running as non-root


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1010

### Description of Changes
This PR fixes three service startup failures that occur after a clean build with Vault-managed credentials.

1. **Open WebUI**: `su webui -c` drops environment variables by default, causing `POSTGRES_PASSWORD` and `DATABASE_URL` to be lost. Changed to `su -m webui -c` to preserve the environment across the user switch.

2. **pgAdmin**: `init_stack()` only updated `AIXCL_ADMIN_USER` and `AIXCL_ADMIN_EMAIL`, leaving `PGADMIN_DEFAULT_EMAIL` and `OPENWEBUI_EMAIL` empty. Added sed commands to populate these from `AIXCL_ADMIN_EMAIL`.

3. **Grafana**: `grafana-entrypoint.sh` set both `GF_SECURITY_ADMIN_PASSWORD` and `GF_SECURITY_ADMIN_PASSWORD__FILE`. Grafana rejects this and exits. Removed the direct `GF_SECURITY_ADMIN_PASSWORD` export and rely solely on the `__FILE` mechanism.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### PR Validation Requirements
- [x] Assignee set
- [x] Component label added
- [x] Title format correct (no colons)

### Testing Notes
These fixes address three independent root causes identified from container logs:

- Open WebUI: `peewee.OperationalError: connection to server at "127.0.0.1", port 5432 failed: fe_sendauth: no password supplied`
- pgAdmin: `You need to define the PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD or PGADMIN_DEFAULT_PASSWORD_FILE environment variables.`
- Grafana: `ERROR: Both GF_SECURITY_ADMIN_PASSWORD and GF_SECURITY_ADMIN_PASSWORD__FILE are set (but are exclusive)`

Verification was done via `podman inspect` (confirmed `DATABASE_URL` had no password), `podman logs` (confirmed error messages), and manual `su -m` test inside the container (confirmed env preservation).

### Verification
- [x] Behavior works as expected (root causes identified and fixed)
- [x] No regressions observed (changes are additive or remove conflicting exports)
- [x] Full clean build test pending (requires `./aixcl stack restart` after merge)

### Related Issues
- Closes #1010
- Follows #1008 (clean build profile fix)
