### PR TITLE
Fix Open WebUI HOME and pgAdmin env preservation across su (#1012)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -105,8 +105,10 @@ if [ "$(id -u)" = "0" ]; then
     echo "Switching to webui user (UID: $USER_ID)..."
     # Re-run this script as the non-root user using su
     # Preserve environment variables needed by OpenWebUI (DATABASE_URL, etc.)
-    # Using 'su' (not 'su -') preserves the environment
+    # Using 'su -m' preserves the environment but keeps HOME=/root which causes
+    # asyncpg to look for /root/.postgresql/sslkey. Set HOME to webui's home.
     export -n USER_ID GROUP_ID  # Don't export these to avoid confusion
+    export HOME=/home/webui
     exec su -m webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
 fi
 

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -117,7 +117,8 @@ EOF
     export PGADMIN_REPLACE_SERVERS_ON_STARTUP
     
     # Re-run this script as the non-root user
-    exec su -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'
+    # Use su -m to preserve environment variables (email and password)
+    exec su -m -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'
 fi
 
 # At this point, we should be running as non-root


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1012

### Description of Changes
Open WebUI and pgAdmin still failed after PR #1011 due to remaining `su` environment issues:

- Open WebUI: `su -m webui -c` preserved env but kept `HOME=/root`, causing asyncpg to try reading `/root/.postgresql/postgresql.key` and fail with `PermissionError`
- pgAdmin: `su -s /bin/bash pgadmin -c` did not preserve env, dropping `PGADMIN_DEFAULT_EMAIL` and `PGADMIN_DEFAULT_PASSWORD`

Changes:
- Set `HOME=/home/webui` before `su -m` in `openwebui-entrypoint.sh`
- Add `-m` flag to `su` in `pgadmin-entrypoint.sh`

### Verification
- [x] Restart stack and confirm all services healthy

### Related Issues
- Closes #1012
