### PR TITLE
Fix postgres-exporter POSTGRES_PASSWORD leak with Vault-aware entrypoint (#1017)

### DIFF
--- a/scripts/runtime/postgres-exporter-entrypoint.sh
+++ b/scripts/runtime/postgres-exporter-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# postgres-exporter Vault entrypoint
+# Reads PostgreSQL password from Vault secrets and constructs DATA_SOURCE_NAME
+
+set -e
+
+echo "=== PostgreSQL Exporter Vault Entrypoint ==="
+
+# Read password from Vault secrets
+PGPASSWORD=""
+if [ -f /run/secrets/postgres-password ] && [ -s /run/secrets/postgres-password ]; then
+    PGPASSWORD=$(cat /run/secrets/postgres-password | tr -d '\n')
+    echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
+else
+    echo "[Vault] ERROR: /run/secrets/postgres-password not found or empty"
+    exit 1
+fi
+
+# Resolve other variables with defaults
+PGUSER="${POSTGRES_USER:-admin}"
+PGDATABASE="${POSTGRES_DATABASE:-webui}"
+PGHOST="${POSTGRES_HOST:-127.0.0.1}"
+PGPORT="${POSTGRES_PORT:-5432}"
+
+# Build DATA_SOURCE_NAME for postgres_exporter
+export DATA_SOURCE_NAME="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=require"
+
+echo "[Vault] DATA_SOURCE_NAME configured (password redacted)"
+
+# Unset plaintext password from environment
+unset PGPASSWORD
+unset POSTGRES_PASSWORD
+
+# Start the official postgres_exporter
+exec /postgres_exporter

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -519,8 +519,15 @@ services:
     read_only: true
     tmpfs:
       - /tmp:noexec,nosuid,size=100m
+    entrypoint: ["/usr/local/bin/postgres-exporter-entrypoint.sh"]
+    volumes:
+      - ../scripts/runtime/postgres-exporter-entrypoint.sh:/usr/local/bin/postgres-exporter-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}?sslmode=require"
+      # PostgreSQL credentials are read from Vault by the entrypoint
+      # Do not set DATA_SOURCE_NAME here; it is constructed from /run/secrets/postgres-password
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-webui}
     network_mode: host
     depends_on:
       - postgres


### PR DESCRIPTION
Fixes #1017

## Summary

Eliminates postgres-exporter password leak from docker-compose by introducing a Vault-aware entrypoint script.

### Description of Changes

- Created `scripts/runtime/postgres-exporter-entrypoint.sh` that reads from `/run/secrets/postgres-password`
- Removed `DATA_SOURCE_NAME` from `docker-compose.yml` — entrypoint constructs the connection string
- Mounted `aixcl-vault-secrets` and entrypoint into postgres-exporter container

### Change Checklist
- [x] Issue referenced in title and description
- [x] Commit messages follow conventional style

### Testing Notes
- Verified postgres-exporter metrics endpoint responds with PostgreSQL data
- Confirmed no `${POSTGRES_PASSWORD}` in compose file

### Verification
- [x] postgres-exporter metrics endpoint responds with PostgreSQL data
- [x] No `${POSTGRES_PASSWORD}` in compose file
- [x] Container starts successfully on clean build

### Related Issues
- Fixes #1017