### PR TITLE
Fix postgres-exporter binary path (#1025)

### DIFF
--- a/scripts/runtime/postgres-exporter-entrypoint.sh
+++ b/scripts/runtime/postgres-exporter-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # postgres-exporter Vault entrypoint
 # Reads PostgreSQL password from Vault secrets and constructs DATA_SOURCE_NAME
+#
+# IMPORTANT: The official postgres_exporter binary is at /bin/postgres_exporter,
+# not /postgres_exporter. Always use the full path.
 
 set -e
 
@@ -32,4 +35,4 @@ unset PGPASSWORD
 unset POSTGRES_PASSWORD
 
 # Start the official postgres_exporter
-exec /postgres_exporter
+exec /bin/postgres_exporter


### PR DESCRIPTION
Fixes #1025

## Summary
- Corrected postgres_exporter binary path from `/postgres_exporter` to `/bin/postgres_exporter`
- Added comment in entrypoint noting the official image path

### Verification
- [x] `podman inspect` confirmed entrypoint is `/bin/postgres_exporter`
- [x] Clean build shows 12/12 services healthy
