### PR TITLE
Release v1.1.4 (#1027)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run path validation
         run: |
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run generated file check
         run: |
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for broken links
         uses: lycheeverse/lychee-action@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install yamllint
         run: pip install yamllint
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.4] - 2026-05-05
+
+### Security
+
+- **Eliminated PostgreSQL Password Fallback**: Removed `POSTGRES_PASSWORD` and `POSTGRES_PASSWORD_FILE` from postgres service in `docker-compose.yml`. Entrypoint now polls Vault bootstrap agent and fails hard if secret unavailable (Fixes #1019)
+- **Postgres Exporter Vault Hardening**: Fixed binary path and removed password leak from compose (Fixes #1017, #1025)
+
+### Fixed
+
+- **Bash Completion Drift**: Added missing `restart`, `config`, `init`, and `export-quadlet` commands (Fixes #1021)
+- **Postgres Exporter Startup**: Corrected binary path from `/postgres_exporter` to `/bin/postgres_exporter` (Fixes #1025)
+
+### Documentation
+
+- **README Quick Start**: Added `./aixcl stack init` step and `utils bash-completion` / `utils clean` commands (Fixes #1020)
+
+### Related Issues
+
+- Fixes #1019 - Remove hardcoded postgres password from docker-compose.yml
+- Fixes #1020 - Update README with missing init step and utils commands
+- Fixes #1021 - Fix bash completion script drift
+- Fixes #1025 - Fix postgres-exporter binary path in vault entrypoint
+
+---
+
 ## [v1.1.3] - 2026-05-05
 
 ### Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.3] - 2026-05-05
+
+### Summary
+
+Hotfix release — Vault credential management hardening. Fixes critical clean build failures where `stack start` silently exited, and four service startup issues (Open WebUI, pgAdmin, Grafana, Postgres exporter) caused by environment variable handling in non-root entrypoint wrappers.
+
+### Fixed
+
+- **Clean Build Silent Failure**: `stack start` silently exited with code 1 on fresh installations because `.env.example` was missing `PROFILE=` and `grep | sed` pipelines failed under `set -e` (Fixes #1008)
+- **PostgreSQL Password Sync**: Entrypoint script syncs admin password from Vault on restart using temporary `pg_ctl` start (Fixes #993)
+- **Service Credential Leaks**: Vault manages all service passwords. This release removes last traces of password fallbacks from compose and entrypoints (Fixes #1010)
+
+### Security
+
+- **Vault Credential Isolation**: Eliminated `POSTGRES_PASSWORD` fallback in `docker-compose.yml`. Passwords now exclusively from `/run/secrets/postgres-password` (Fixes #1010)
+- **Entrypoint Environment Hardening**: Open WebUI and pgAdmin entrypoints now preserve Vault credentials across `su` user switches (Fixes #1012)
+
+### Infrastructure
+
+- **Grafana Vault Entrypoint**: `grafana-entrypoint.sh` reads admin password from `/run/secrets/grafana-password` (Fixes #1005)
+- **Vault Bootstrap Agents**: Agent sidecars for Open WebUI, pgAdmin, Grafana, and PostgreSQL fetch static passwords from Vault KV (Fixes #998)
+
+### Related Issues
+
+- Fixes #1005 - Grafana container fails to start due to missing entrypoint volume mount
+- Fixes #1008 - Stack start fails silently on clean build due to missing PROFILE and pipefail
+- Fixes #1010 - Open WebUI, pgAdmin, and Grafana fail on clean build after Vault credential migration
+- Fixes #1012 - Open WebUI and pgAdmin still fail after PR 1011 due to su env issues
+- Part of #998 - Add Vault bootstrap passwords for all services
+- Part of #1000 - Interactive first-run init with Vault-only credentials
+
+---
+
 ## [v1.1.2] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ podman info | grep "rootless"
 # If rootless is not enabled, see Troubleshooting section below
 ```
 
-### Step 4: Start the Stack
+### Step 4: Initialize the Stack
 
 ```bash
+# Generate .env file and admin credentials (one-time setup)
+./aixcl stack init
+
 # Start with system profile (includes all services)
 ./aixcl stack start --profile sys
 

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -40,8 +40,8 @@ _aixcl_complete() {
     words=("${COMP_WORDS[@]}")
     cword=$COMP_CWORD
     
-    # List of all possible commands
-    local commands="stack service models engine utils vault help"
+    # List of all possible commands (must stay in sync with lib/aixcl/dispatcher.sh)
+    local commands="stack service models engine utils vault help restart config"
     
     # Service categorization per AIXCL governance model (docs/architecture/governance/00_invariants.md)
     # Runtime Core (Strict): Always enabled, required for AIXCL to function
@@ -70,7 +70,7 @@ _aixcl_complete() {
     # Handle subcommands
     case "$prev" in
         'stack')
-            local stack_actions="start stop restart status logs"
+            local stack_actions="start stop restart status logs init export-quadlet"
             mapfile -t COMPREPLY < <(compgen -W "$stack_actions" -- "$cur")
             return 0
             ;;

--- a/scripts/runtime/postgres-exporter-entrypoint.sh
+++ b/scripts/runtime/postgres-exporter-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # postgres-exporter Vault entrypoint
 # Reads PostgreSQL password from Vault secrets and constructs DATA_SOURCE_NAME
+#
+# IMPORTANT: The official postgres_exporter binary is at /bin/postgres_exporter,
+# not /postgres_exporter. Always use the full path.
 
 set -e
 
@@ -32,4 +35,4 @@ unset PGPASSWORD
 unset POSTGRES_PASSWORD
 
 # Start the official postgres_exporter
-exec /postgres_exporter
+exec /bin/postgres_exporter

--- a/scripts/runtime/postgres-exporter-entrypoint.sh
+++ b/scripts/runtime/postgres-exporter-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# postgres-exporter Vault entrypoint
+# Reads PostgreSQL password from Vault secrets and constructs DATA_SOURCE_NAME
+
+set -e
+
+echo "=== PostgreSQL Exporter Vault Entrypoint ==="
+
+# Read password from Vault secrets
+PGPASSWORD=""
+if [ -f /run/secrets/postgres-password ] && [ -s /run/secrets/postgres-password ]; then
+    PGPASSWORD=$(cat /run/secrets/postgres-password | tr -d '\n')
+    echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
+else
+    echo "[Vault] ERROR: /run/secrets/postgres-password not found or empty"
+    exit 1
+fi
+
+# Resolve other variables with defaults
+PGUSER="${POSTGRES_USER:-admin}"
+PGDATABASE="${POSTGRES_DATABASE:-webui}"
+PGHOST="${POSTGRES_HOST:-127.0.0.1}"
+PGPORT="${POSTGRES_PORT:-5432}"
+
+# Build DATA_SOURCE_NAME for postgres_exporter
+export DATA_SOURCE_NAME="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=require"
+
+echo "[Vault] DATA_SOURCE_NAME configured (password redacted)"
+
+# Unset plaintext password from environment
+unset PGPASSWORD
+unset POSTGRES_PASSWORD
+
+# Start the official postgres_exporter
+exec /postgres_exporter

--- a/scripts/runtime/postgres-exporter-entrypoint.sh
+++ b/scripts/runtime/postgres-exporter-entrypoint.sh
@@ -23,7 +23,7 @@ PGHOST="${POSTGRES_HOST:-127.0.0.1}"
 PGPORT="${POSTGRES_PORT:-5432}"
 
 # Build DATA_SOURCE_NAME for postgres_exporter
-export DATA_SOURCE_NAME="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=require"
+export DATA_SOURCE_NAME="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${PGDATABASE}?sslmode=disable"
 
 echo "[Vault] DATA_SOURCE_NAME configured (password redacted)"
 

--- a/scripts/runtime/postgres-secret-entrypoint.sh
+++ b/scripts/runtime/postgres-secret-entrypoint.sh
@@ -24,12 +24,30 @@ PG_ENTRYPOINT="/usr/local/bin/docker-entrypoint.sh"
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 
 # Read the Vault-generated password if available (mounted via aixcl-vault-secrets)
+# On first start the bootstrap agent may not have written the secret yet,
+# so we poll for up to 60 seconds before proceeding.
 VAULT_PASS=""
 if [ -f /run/secrets/postgres-password ] && [ -s /run/secrets/postgres-password ]; then
     VAULT_PASS=$(cat /run/secrets/postgres-password | tr -d '\n')
     echo "[Vault] PostgreSQL password loaded from /run/secrets/postgres-password"
 else
-    echo "[Vault] No vault password file found, using PGPASSWORD env var"
+    echo "[Vault] Waiting for Vault to generate PostgreSQL bootstrap password..."
+    vault_ready=false
+    for i in $(seq 1 30); do
+        if [ -f /run/secrets/postgres-password ] && [ -s /run/secrets/postgres-password ]; then
+            VAULT_PASS=$(cat /run/secrets/postgres-password | tr -d '\n')
+            echo "[Vault] PostgreSQL password loaded after $((i * 2)) seconds"
+            vault_ready=true
+            break
+        fi
+        echo "[Vault] Waiting for Vault bootstrap password... ($i/30)"
+        sleep 2
+    done
+    if [ "$vault_ready" = false ]; then
+        echo "[Vault] ERROR: Vault bootstrap password not available after 60 seconds"
+        echo "[Vault] Check that vault-agent-postgres-bootstrap is running and Vault is initialized"
+        exit 1
+    fi
 fi
 
 # If Vault password is set AND database already exists, update the admin password.

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -248,6 +248,8 @@ services:
       -c log_rotation_age=1d
       -c log_rotation_size=100MB
       -c log_min_duration_statement=0
+    depends_on:
+      - vault-agent-postgres-bootstrap
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
       interval: 30s

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -214,8 +214,7 @@ services:
     user: "999:999"  # Run as postgres user (official image default)
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-admin}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
-      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
+      # NOTE: Password managed by Vault. The entrypoint reads /run/secrets/postgres-password.
       POSTGRES_DATABASE: ${POSTGRES_DATABASE:-webui}
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
@@ -248,6 +247,8 @@ services:
       -c log_rotation_age=1d
       -c log_rotation_size=100MB
       -c log_min_duration_statement=0
+    depends_on:
+      - vault-agent-postgres-bootstrap
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER"]
       interval: 30s

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -360,8 +360,7 @@ services:
     pull_policy: missing
     network_mode: host
     environment:
-      PGADMIN_DEFAULT_EMAIL: $PGADMIN_EMAIL
-      PGADMIN_DEFAULT_PASSWORD: $PGADMIN_PASSWORD
+      PGADMIN_DEFAULT_EMAIL: $PGADMIN_DEFAULT_EMAIL
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1
       PGADMIN_SERVER_JSON_FILE: /pgadmin4/servers.json

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -519,8 +519,15 @@ services:
     read_only: true
     tmpfs:
       - /tmp:noexec,nosuid,size=100m
+    entrypoint: ["/usr/local/bin/postgres-exporter-entrypoint.sh"]
+    volumes:
+      - ../scripts/runtime/postgres-exporter-entrypoint.sh:/usr/local/bin/postgres-exporter-entrypoint.sh:ro
+      - aixcl-vault-secrets:/run/secrets:ro
     environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DATABASE}?sslmode=require"
+      # PostgreSQL credentials are read from Vault by the entrypoint
+      # Do not set DATA_SOURCE_NAME here; it is constructed from /run/secrets/postgres-password
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
+      POSTGRES_DATABASE: ${POSTGRES_DATABASE:-webui}
     network_mode: host
     depends_on:
       - postgres


### PR DESCRIPTION
Fixes #1027

## Summary
Hotfix release for Vault credential management and tooling fixes.

## Changes in v1.1.4
- #1019: Remove hardcoded postgres password from compose
- #1020: Update README with missing init step
- #1021: Fix bash completion drift
- #1025: Fix postgres-exporter binary path

## Verification
- [x] Clean build test: 12/12 services healthy