### PR TITLE
Refresh README with all sys profile access points (#1030)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,12 @@ curl http://localhost:11434/v1/chat/completions \
 | Service | URL | Login |
 |---------|-----|-------|
 | Open WebUI | http://localhost:8080 | First user = admin |
-| pgAdmin | http://localhost:5050 | Vault credentials (see below) |
-| Grafana | http://localhost:3000 | Vault credentials (see below) |
+| pgAdmin | http://localhost:5050 | Vault credentials |
+| Grafana | http://localhost:3000 | Vault credentials |
 | Vault UI | http://localhost:8200 | Token: `aixcl-dev-token` |
 | Prometheus | http://localhost:9090 | No auth (localhost only) |
+| Loki | http://localhost:3100 | No auth (localhost only) |
+| Alertmanager | http://localhost:9093 | No auth (localhost only) |
 | Ollama API | http://localhost:11434 | No auth (localhost only) |
 
 Get current service credentials:


### PR DESCRIPTION
# Pull Request

## Summary

Refresh README with all sys profile services and current access points.

### Description of Changes

- Added Loki (port 3100) to Access Points table
- Added Alertmanager (port 9093) to Access Points table
- Simplified Vault credentials notes for consistency with actual CLI
- Verified all table entries match docker-compose.yml service definitions

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### Testing Notes
- Verified README markdown renders correctly in preview
- Confirmed missing services from issue #1030 are now listed

### Verification
- [x] README renders correctly with no broken markdown
- [x] All listed ports match docker-compose.yml
- [x] Access Points table is complete for sys profile

### Related Issues
- Fixes #1030
