### PR TITLE
Verify GPG commit signing workflow end-to-end (#1046)

### DIFF
--- a/scripts/utils/setup-gpg.sh
+++ b/scripts/utils/setup-gpg.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 # Note: This script operates on user-global paths (~/.gnupg/, ~/.gitconfig)
 # No project-relative paths needed for GPG key operations
+# GPG signing test marker: issue-1046
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1046

### Description of Changes
Adds a harmless comment marker to `scripts/utils/setup-gpg.sh` to test the end-to-end GPG signing workflow.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-1046/verify-gpg-signing)
- [x] Commit messages follow conventional style
- [x] All tests run and pass
- [x] Commit is GPG-signed (gpg: Good signature)

### Testing Notes
- Verified GPG signature locally: `git log -1 --show-signature` shows Good signature
- Confirmed commit was signed with key 6EEFE8F40013DD63

### Verification
- [x] GitHub shows green Verified badge on the commit
- [x] Branch protection does not block merge due to unsigned commits
- [x] No GPG prompts or errors during commit

### Related Issues
- Closes #1046