### PR TITLE
vault rotate fails because vault CLI is not installed on host (#1048)

### DIFF
--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -158,8 +158,9 @@ function cmd_vault_rotate() {
     fi
     echo "Triggering manual credential rotation..."
     
-    # Check if Vault is accessible
-    if ! vault status >/dev/null 2>&1; then
+    # Check if Vault is accessible (via HTTP API, not vault CLI)
+    local vault_addr="${VAULT_ADDR:-http://127.0.0.1:8200}"
+    if ! curl -sf "${vault_addr}/v1/sys/health" >/dev/null 2>&1; then
         echo "Error: Vault is not running or not accessible"
         echo "Run: ./aixcl vault init"
         return 1


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1048

### Description of Changes
Replaces the `vault status` CLI call in `cmd_vault_rotate()` with an HTTP API health check via curl.

This aligns `vault rotate` with `vault status`, which already uses curl to check Vault accessibility. The HashiCorp Vault CLI is only available inside the Docker container, not on the host, causing `vault rotate` to incorrectly error out.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-1048/fix-vault-rotate-cli)
- [x] Commit messages follow conventional style
- [x] Commit is GPG-signed (gpg: Good signature)
- [x] All tests run and pass

### Testing Notes
- Verified the original bug: `vault rotate` fails with "Vault is not running" despite Vault being healthy
- Confirmed `vault status` works because it uses `curl` to the HTTP API
- The fix applies the same `curl -sf ${VAULT_ADDR}/v1/sys/health` check to `vault rotate`

### Verification
- [x] `vault rotate` does not fail when Vault is running
- [x] `vault rotate` still shows proper error when Vault is stopped
- [x] Code style preserved (minimal, focused change)

### Related Issues
- Closes #1048