### PR TITLE
Tighten PR creation governance to prevent label-assignee race condition (#1067)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,25 @@ Labels: Must match issue
 Assignee: Required
 ```
 
-**Post-creation label and assignee enforcement**
+**PR creation — pass labels at creation time**
+
+The PR Validation workflow fires on the `opened` event. Labels and assignees must be passed together to `gh pr create` to prevent a race condition.
+
+**Required approach:**
+```bash
+# Use the wrapper script (validates title, passes --label and --assignee)
+./scripts/utils/create-pr.sh "<title> (#<number>)" "Fixes #<number>" "component:cli" "<username>"
+
+# Or pass explicitly:
+git push -u origin issue-<number>/<description>
+gh pr create --title "<description> (#<number>)" --body "Fixes #<number>" --assignee <username> --label "component:..."
+```
+
+**Never** use two-step creation (`gh pr create` then `gh pr edit --add-label`). The fallback creates a race condition where the first validation run sees no labels and permanently blocks the PR. See DEVELOPMENT.md for details.
+
+**Post-creation label enforcement (issues only)**
 ```bash
 gh issue edit <number> --add-label "component:cli" --add-assignee <username>
-gh pr edit <number> --add-label "component:cli" --add-assignee <username>
 ```
 
 **Template loading (MANDATORY before composing any issue/PR body)**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -227,13 +227,30 @@ Additional PR rules:
 - All CI checks must be green before the PR is considered complete
 
 ```bash
-gh pr create --title "<description> (#<number>)" --body "Fixes #<number>" --assignee <github-username>
-gh pr edit <number> --add-assignee <github-username> --add-label "component:..."
+# CORRECT: Pass assignee and labels at creation time
+gh pr create --title "<description> (#<number>)" --body "Fixes #<number>" --assignee <github-username> --label "component:..."
+
+# INCORRECT: Two-step creates race condition
+# gh pr create --title "..." --body "..." --assignee <github-username>
+# gh pr edit <number> --add-label "component:..."
 ```
 
-**Critical**: Always pass `--assignee` to `gh pr create`. The PR Validation workflow fires immediately on PR creation. If the assignee is not set at creation time, the "Validate PR Assignee" check will fail on the `opened` event. The fallback two-step (`create` then `gh pr edit`) creates a race condition where the first check run sees no assignee and permanently blocks the PR.
+**Critical**: Always pass `--assignee` and `--label` to `gh pr create` at creation time. The PR Validation workflow fires immediately on PR creation. If the assignee or label is not set at creation time, the validation check will fail on the `opened` event. The fallback two-step (`create` then `gh pr edit`) creates a race condition where the first check run sees no assignee/label and permanently blocks the PR.
 
-**Recommended**: Use the wrapper script `./scripts/utils/create-pr.sh` which validates the title format, validates the branch name, uses `/tmp` for body files, and always passes `--assignee` at creation time.
+**Required**: Use the wrapper script `./scripts/utils/create-pr.sh` for all PRs. This script validates the title format, validates the branch name, uses `/tmp` for body files, and always passes `--assignee` and `--label` at creation time.
+
+If you must use raw `gh pr create`, always include `--label`:
+```bash
+git push -u origin issue-<number>/<description>
+gh pr create --title "<description> (#<number>)" --body "Fixes #<number>" --assignee <github-username> --label "component:..."
+```
+
+**Never** use `gh pr edit` to add labels after creation. The validation workflow has already fired and the failed check will persist.
+
+**Workaround if race condition occurs:**
+1. Close the PR
+2. Reopen the PR immediately (this triggers a new check run)
+3. Or: Merge with admin privileges if all current checks pass
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes 1067

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes 1067

## Additional Notes

Fixes #1067
