### PR TITLE
Fix PR validation race condition on assignee and label checks (#1079)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,6 +10,9 @@ on:
       - dev
     types: [opened, edited, synchronize, reopened, labeled, unlabeled, assigned, unassigned]
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   validate-pr-title:
     name: Validate PR Title Format
@@ -44,19 +47,19 @@ jobs:
     steps:
       - name: Check PR has assignee
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ASSIGNEES_JSON: ${{ toJson(github.event.pull_request.assignees) }}
         run: |
-          # Retry to handle API propagation delay
-          for i in 1 2 3; do
-            assignees=$(gh pr view "$PR_NUMBER" --json assignees --jq '.assignees[].login' 2>/dev/null)
-            if [[ -n "$assignees" ]]; then
-              echo "PR has assignee(s): $assignees"
-              exit 0
-            fi
-            echo "Attempt $i: No assignee found yet, retrying in 2s..."
-            sleep 2
-          done
+          set -euo pipefail
+          
+          # Use event payload directly to avoid API race conditions
+          # github.event.pull_request.assignees is a JSON array of user objects
+          count=$(echo "$PR_ASSIGNEES_JSON" | jq 'length')
+          
+          if [[ "$count" -gt 0 ]]; then
+            echo "PR has $count assignee(s)"
+            echo "$PR_ASSIGNEES_JSON" | jq -r '.[].login'
+            exit 0
+          fi
           
           echo "ERROR: PR must have at least one assignee"
           exit 1
@@ -67,19 +70,18 @@ jobs:
     steps:
       - name: Check PR has component label
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         run: |
-          # Retry to handle API propagation delay on 'opened' event
-          for i in 1 2 3; do
-            labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null)
-            if echo "$labels" | grep -q "component:"; then
-              echo "PR has component label: $(echo "$labels" | grep "component:" | head -1)"
-              exit 0
-            fi
-            echo "Attempt $i: No component label found yet, retrying in 2s..."
-            sleep 2
-          done
+          set -euo pipefail
+          
+          # Use event payload directly to avoid API race conditions
+          # github.event.pull_request.labels is a JSON array of label objects
+          labels=$(echo "$PR_LABELS_JSON" | jq -r '.[].name')
+          
+          if echo "$labels" | grep -q "component:"; then
+            echo "PR has component label: $(echo "$labels" | grep "component:" | head -1)"
+            exit 0
+          fi
           
           echo "ERROR: PR must have at least one component label (component:*)"
           echo "Available component labels: component:cli, component:infrastructure, component:runtime-core, etc."


### PR DESCRIPTION
# Pull Request

## Summary
Fixes 1079

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes 1079

## Additional Notes

Fixes #1079
