### PR TITLE
Fix deprecated profile references in tests/aixcl-test (#1087)

### DIFF
--- a/tests/aixcl-test
+++ b/tests/aixcl-test
@@ -38,7 +38,7 @@ TEST_DIR="${SCRIPT_DIR}/command-tests"
 ENGINE="current"  # current, ollama, vllm, llamacpp, all
 MODEL=""
 TEST_RANGE="all"
-PROFILE="usr"
+PROFILE="sys"
 # shellcheck disable=SC2034
 VERBOSE=false
 
@@ -74,8 +74,8 @@ OPTIONS
         Default: all
 
     -p, --profile <profile>
-        Stack profile: sys, usr
-        Default: usr
+        Stack profile: bld, sys
+        Default: sys
 
     -v, --verbose
         Enable verbose output
@@ -93,7 +93,7 @@ ENGINES
 
 PROFILES
 
-    usr     User runtime (minimal footprint)
+    bld     Builder-focused (monitoring/logging)
     sys     System runtime (full stack)
 
 EXAMPLES
@@ -172,8 +172,8 @@ parse_arguments() {
     fi
 
     # Validate profile
-    if [[ ! "$PROFILE" =~ ^(sys|usr)$ ]]; then
-        echo "Error: Invalid profile '$PROFILE'. Must be: sys, usr" >&2
+    if [[ ! "$PROFILE" =~ ^(bld|sys)$ ]]; then
+        echo "Error: Invalid profile '$PROFILE'. Must be: bld, sys" >&2
         exit 1
     fi
 }


### PR DESCRIPTION
Fixes #1087

## Summary
The tests/aixcl-test file was missed during the deprecated profile cleanup (PR #1086) as it has no .sh extension and was not caught by the grep patterns.

### Description of Changes
- Updated default PROFILE from usr to sys
- Updated help text: profile list and default now show bld/sys
- Updated profile validation regex from ^(sys|usr)$ to ^(bld|sys)$
- Updated error message to reference bld and sys

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1087/fix-aixcl-test-profiles)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:testing
- [x] Title Format: description (#number) with NO colons

### Testing Notes
- Verified no remaining usr/dev/ops profile references in tests/aixcl-test
- Preflight test confirmed passing

### Related Issues
- Closes #1087