### PR TITLE
Fix Grafana provisioning warnings at startup (#1089)

### DIFF
--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -6,11 +6,11 @@ apiVersion: 1
 providers:
   - name: 'AIXCL Dashboards'
     orgId: 1
+    folder: 'AIXCL Dashboards'
     type: file
     disableDeletion: false
     updateIntervalSeconds: 10
     allowUiUpdates: true
     options:
       path: /etc/grafana/provisioning/dashboards
-      foldersFromFilesStructure: true
 


### PR DESCRIPTION
Fixes #1089

## Summary
Resolves two low severity Grafana provisioning warnings logged at every startup.

### Description of Changes
- Add explicit folder: AIXCL Dashboards to dashboard provider config, replacing foldersFromFilesStructure, to resolve the dashboard has no folder warning
- Create grafana/provisioning/plugins/ directory with .gitkeep so the path exists when the provisioning volume is mounted, suppressing the missing directory error

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1089/fix-grafana-provisioning-warnings)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:observability
- [x] Title Format: description (#number) with NO colons

### Testing Notes
- Grafana startup logs should no longer show the folder or plugins directory warnings
- Dashboard provisioning continues to work with explicit folder config

### Related Issues
- Closes #1089