### PR TITLE
Improve utils commands with prune and setup alias docs (#1091)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,27 +69,26 @@ podman info | grep "rootless"
 # Should show: "rootless: true"
 ```
 
-### Step 3: Initialize the Stack (Interactive)
+### Step 3: Check, Initialize and Start
+
+The quickest way to get started — add this alias to your shell:
 
 ```bash
-# Generate .env file, admin credentials, and Vault secrets (one-time)
-# You will be prompted for admin username and email
-./aixcl stack init
-
-# Start with bld profile (monitoring-focused) or sys profile (complete stack)
-./aixcl stack start --profile bld
-# or
-./aixcl stack start --profile sys
-
-# Wait for healthy status (about 2-3 minutes for full stabilization)
-./aixcl stack status
+alias aixcl-setup='./aixcl utils check-env && ./aixcl stack init && ./aixcl stack start --profile sys'
 ```
 
-### Step 4: Start the Stack
+Then run:
 
 ```bash
-# Start with system profile (includes all services)
-./aixcl stack start --profile sys
+aixcl-setup
+```
+
+Or run each step manually:
+
+```bash
+./aixcl utils check-env          # Verify environment prerequisites
+./aixcl stack init               # Generate .env, credentials and Vault secrets (one-time)
+./aixcl stack start --profile sys  # Start the full stack
 
 # Wait for healthy status (about 2-3 minutes for full stabilization)
 ./aixcl stack status
@@ -313,13 +312,13 @@ sudo lsof -i :11434  # Ollama
 sudo lsof -i :8080   # Open WebUI
 sudo lsof -i :8200   # Vault
 
-# Base build (clean restart without wiping images)
-./aixcl stack stop
-rm -f .aixcl.initialized .env pgadmin-servers.json
-podman ps -aq | xargs podman rm -f 2>/dev/null
-podman volume ls -q | xargs podman volume rm 2>/dev/null
-./aixcl stack init
-./aixcl stack start --profile sys
+# Soft reset — removes volumes and state, keeps images for fast restart
+./aixcl utils prune
+aixcl-setup
+
+# Full wipe — removes everything including images (slow rebuild)
+./aixcl utils prune --all
+aixcl-setup
 ```
 
 ---

--- a/docs/reference/manpage.txt
+++ b/docs/reference/manpage.txt
@@ -77,9 +77,13 @@ COMMANDS
         utils bash-completion
                Install bash completion support
 
-        utils clean
-               Clean up unused Docker resources (dangling images, unused images,
-               stopped containers, unused volumes)
+        utils prune
+               Remove volumes and state files, keep images for fast restart
+               (mirrors podman system prune)
+
+        utils prune --all
+               Remove everything including images — full scorched-earth wipe
+               (mirrors podman system prune --all)
 
         help
                Show help message

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -857,7 +857,7 @@ function restart() {
             echo "  ./aixcl stack start -p bld                  # Start bld profile" >&2
             echo "  ./aixcl stack status                        # Show all service status" >&2
             echo "  ./aixcl stack logs -f engine                # Follow logs for active engine" >&2
-            echo "  ./aixcl utils clean                      # Clean unused Docker resources" >&2
+            echo "  ./aixcl utils prune                      # Remove volumes and state, keep images" >&2
             exit 1
         fi
     fi

--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -18,27 +18,49 @@ function needs_rebuild() {
     esac
 }
 
-function clean() {
-    # Use DOCKER_BIN from environment (set by .env or docker_utils.sh), default to 'docker'
+function prune() {
     local docker_cmd="${DOCKER_BIN:-docker}"
-    
-    echo "SCORCHED EARTH: Removing ALL container resources..."
+
+    echo "Pruning AIXCL stack (volumes and state, images kept)..."
+    echo ""
+
+    echo "Stopping stack..."
+    ./aixcl stack stop 2>/dev/null || true
+    echo ""
+
+    echo "Removing state files..."
+    rm -f .aixcl.initialized .env pgadmin-servers.json
+    echo ""
+
+    echo "Removing volumes..."
+    local all_volumes
+    all_volumes=$($docker_cmd volume ls -q 2>/dev/null || true)
+    if [ -n "$all_volumes" ]; then
+        echo "$all_volumes" | xargs -r $docker_cmd volume rm -f 2>/dev/null || true
+    fi
+    echo ""
+
+    echo "Prune complete. Images retained for fast restart."
+    echo "Run './aixcl stack init && ./aixcl stack start --profile sys' to bring the stack back up."
+}
+
+function prune_all() {
+    local docker_cmd="${DOCKER_BIN:-docker}"
+
+    echo "SCORCHED EARTH: Removing ALL container resources including images..."
     echo "Using container engine: $docker_cmd"
     echo ""
-    
-    # Stop and remove ALL containers (running and stopped)
+
     echo "Stopping all containers..."
     $docker_cmd stop -a 2>/dev/null || true
     echo "Removing all containers..."
     $docker_cmd rm -f -a 2>/dev/null || true
     echo ""
-    
-    # Remove ALL images (force)
+
     echo "Removing all images..."
     $docker_cmd rmi -f -a 2>/dev/null || true
     echo ""
-    
-    # Remove ALL volumes by name (not just prune)
+
     echo "Removing all volumes..."
     local all_volumes
     all_volumes=$($docker_cmd volume ls -q 2>/dev/null || true)
@@ -46,8 +68,7 @@ function clean() {
         echo "$all_volumes" | xargs -r $docker_cmd volume rm -f 2>/dev/null || true
     fi
     echo ""
-    
-    # Remove custom networks (not system networks)
+
     echo "Removing custom networks..."
     local networks
     networks=$($docker_cmd network ls -q 2>/dev/null | grep -v "^podman$" || true)
@@ -55,45 +76,36 @@ function clean() {
         echo "$networks" | xargs -r $docker_cmd network rm 2>/dev/null || true
     fi
     echo ""
-    
-    # System prune for anything left
+
     echo "System prune..."
     $docker_cmd system prune -f --all --volumes 2>/dev/null || true
     echo ""
-    
-    # Clean up pgAdmin configuration file for security
+
     if [ -f "pgadmin-servers.json" ]; then
         rm -f pgadmin-servers.json
         echo "Cleaned up pgAdmin configuration file"
     fi
-    
+    rm -f .aixcl.initialized .env
     echo ""
-    echo "✅ SCORCHED EARTH CLEAN COMPLETE"
-    echo ""
-    echo "Container engine should now be empty:"
+
+    echo "Purge complete. All container resources removed."
     $docker_cmd system df 2>/dev/null || echo "No resources found (good!)"
 }
 
 function utils_cmd() {
     if [[ $# -lt 1 ]]; then
         echo "Error: Utils action is required"
-        echo "Usage: $0 utils {check-env|bash-completion|clean}"
+        echo "Usage: $0 utils {check-env|bash-completion|prune [--all]}"
         echo "Examples:"
         echo "  $0 utils check-env         - Verify environment setup"
         echo "  $0 utils bash-completion   - Install bash completion"
-        echo "  $0 utils clean              - Clean up unused Docker resources"
+        echo "  $0 utils prune             - Remove volumes and state, keep images"
+        echo "  $0 utils prune --all       - Remove everything including images"
         return 1
     fi
 
     local action="$1"
     shift
-
-    # Check for extra arguments for actions that don't take them
-    if [ $# -gt 0 ] && [ "$action" != "clean" ]; then
-        echo "Error: Unknown argument '$1'"
-        echo "Usage: $0 utils {check-env|bash-completion|clean}"
-        return 1
-    fi
 
     case "$action" in
         check-env)
@@ -102,16 +114,21 @@ function utils_cmd() {
         bash-completion)
             install_completion
             ;;
-        clean)
-            clean
+        prune)
+            if [[ "${1:-}" == "--all" ]]; then
+                prune_all
+            else
+                prune
+            fi
             ;;
         *)
             echo "Error: Unknown utils action '$action'"
-            echo "Usage: $0 utils {check-env|bash-completion|clean}"
+            echo "Usage: $0 utils {check-env|bash-completion|prune [--all]}"
             echo "Examples:"
             echo "  $0 utils check-env         - Verify environment setup"
             echo "  $0 utils bash-completion   - Install bash completion"
-            echo "  $0 utils clean              - Clean up unused Docker resources"
+            echo "  $0 utils prune             - Remove volumes and state, keep images"
+            echo "  $0 utils prune --all       - Remove everything including images"
             return 1
             ;;
     esac


### PR DESCRIPTION
Fixes #1091

## Summary
Replaces utils clean with prune and prune --all following Docker/Podman naming conventions, and documents the aixcl-setup alias for simple one-command onboarding.

### Description of Changes
- Add utils prune: soft reset (stop stack, remove volumes and state files, keep images for fast restart)
- Add utils prune --all: full wipe including images, replaces utils clean
- Naming mirrors podman system prune / prune --all conventions
- Merge README Steps 3 and 4 into a single step with aixcl-setup alias
- Update troubleshooting section to use utils prune instead of manual commands
- Update all references across stack.sh, manpage.txt, and README

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:cli
- [x] Title Format: description (#number) with NO colons

### Testing Notes
- shellcheck passes on updated utils.sh
- Scanned all docs and confirmed only CHANGELOG.md retains utils clean (historical)

### Related Issues
- Closes #1091