### PR TITLE
Fix Vault bootstrap wait loop circular dependency (#1095)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -548,36 +548,10 @@ function start() {
             echo "Vault is running. Auto-initializing..."
             echo ""
             
-            # Source vault-init functions and run initialization inline
-            # This ensures bootstrap agents have had time to write passwords
             local vault_init_script="${SCRIPT_DIR}/lib/aixcl/commands/vault-init.sh"
             if [ -f "$vault_init_script" ]; then
-                # Poll Vault KV until bootstrap agents have written passwords
-                # (Bootstrap agents start with vault and retry every 30s on failure)
-                echo "Waiting for bootstrap agents to write passwords to Vault KV..."
-                local wait_attempt=0
-                local kv_ready=false
-                while [ $wait_attempt -lt 180 ]; do
-                    if curl -sf "http://127.0.0.1:8200/v1/kv/data/bootstrap/postgres" \
-                        --header "X-Vault-Token: ${VAULT_DEV_TOKEN:-aixcl-dev-token}" >/dev/null 2>&1; then
-                        kv_ready=true
-                        echo "Bootstrap passwords found in Vault KV."
-                        break
-                    fi
-                    echo "Waiting for bootstrap agents... ($wait_attempt/90)"
-                    sleep 1
-                    wait_attempt=$((wait_attempt + 1))
-                done
-                
-                if [ "$kv_ready" != true ]; then
-                    echo ""
-                    echo "WARNING: Bootstrap agents did not populate Vault KV within 90 seconds."
-                    echo "Run manually after services stabilize:"
-                    echo "  ./aixcl vault init"
-                    echo ""
-                fi
-                
-                # Run vault init via CLI wrapper (handles env, checks, etc.)
+                # Run vault init directly — vault-init.sh waits for Vault internally
+                # and generates all bootstrap passwords itself. No pre-poll needed.
                 if bash "$vault_init_script" 2>&1 | grep -E "\[INFO\]|\[WARN\]|\[ERROR\]"; then
                     echo ""
                     echo "Vault initialization complete."


### PR DESCRIPTION
## Summary

- Removes the pre-init KV poll loop from stack start that could never succeed on first run
- The loop polled kv/data/bootstrap/postgres waiting for data that only vault-init.sh writes, but vault-init.sh ran after the loop
- Fixes counter display overflow (100/90, 150/90) caused by loop condition lt 180 vs displayed /90
- vault-init.sh already waits for Vault internally and generates all bootstrap passwords

## Test plan

- [x] Run ./aixcl stack start --profile bld and confirm no bootstrap wait loop is printed
- [x] Confirm Vault auto-initializes cleanly after stack start
- [x] Run ./aixcl vault passwords to verify bootstrap passwords are present

Generated with Claude Code