### PR TITLE
Fix bash completion offering clean instead of prune (#1097)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -148,7 +148,7 @@ _aixcl_complete() {
             return 0
             ;;
         'utils')
-            local utils_actions="check-env bash-completion clean"
+            local utils_actions="check-env bash-completion prune"
             mapfile -t COMPREPLY < <(compgen -W "$utils_actions" -- "$cur")
             return 0
             ;;


### PR DESCRIPTION
## Summary

- Updates utils subcommand completion from clean to prune in completion/aixcl.bash
- Missed during the clean-to-prune rename in #1091

## Test plan

- [x] Run ./aixcl utils bash-completion to reinstall
- [x] Tab-complete ./aixcl utils and confirm prune appears, clean does not

Generated with Claude Code