### PR TITLE
Add --all flag completion for utils prune (#1099)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -152,6 +152,12 @@ _aixcl_complete() {
             mapfile -t COMPREPLY < <(compgen -W "$utils_actions" -- "$cur")
             return 0
             ;;
+        'prune')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "utils" ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "--all" -- "$cur")
+                return 0
+            fi
+            ;;
         'vault')
             local vault_actions="init status credentials passwords rotate"
             mapfile -t COMPREPLY < <(compgen -W "$vault_actions" -- "$cur")


### PR DESCRIPTION
## Summary

- Adds --all as a tab-completion option after utils prune
- Previously only prune itself was offered, with no flag suggestions

## Test plan

- [x] Run ./aixcl utils bash-completion to reinstall completion
- [x] Tab-complete ./aixcl utils prune and confirm --all appears

Generated with Claude Code