### PR TITLE
Remove bld profile from test suite, sys only (#1103)

### DIFF
--- a/tests/aixcl-test
+++ b/tests/aixcl-test
@@ -38,7 +38,6 @@ TEST_DIR="${SCRIPT_DIR}/command-tests"
 ENGINE="current"  # current, ollama, vllm, llamacpp, all
 MODEL=""
 TEST_RANGE="all"
-PROFILE="sys"
 # shellcheck disable=SC2034
 VERBOSE=false
 
@@ -73,10 +72,6 @@ OPTIONS
         Formats: 1 (single), 1-5 (range), 1,3,5 (list), all
         Default: all
 
-    -p, --profile <profile>
-        Stack profile: bld, sys
-        Default: sys
-
     -v, --verbose
         Enable verbose output
 
@@ -90,11 +85,6 @@ ENGINES
     llamacpp    llama.cpp engine (GGUF models)
     all         Run tests against all engines sequentially
     current     Use currently configured engine
-
-PROFILES
-
-    bld     Builder-focused (monitoring/logging)
-    sys     System runtime (full stack)
 
 EXAMPLES
 
@@ -144,10 +134,6 @@ parse_arguments() {
                 TEST_RANGE="$2"
                 shift 2
                 ;;
-            -p|--profile)
-                PROFILE="$2"
-                shift 2
-                ;;
             -v|--verbose)
                 # shellcheck disable=SC2034
                 VERBOSE=true
@@ -171,11 +157,6 @@ parse_arguments() {
         exit 1
     fi
 
-    # Validate profile
-    if [[ ! "$PROFILE" =~ ^(bld|sys)$ ]]; then
-        echo "Error: Invalid profile '$PROFILE'. Must be: bld, sys" >&2
-        exit 1
-    fi
 }
 
 # ============================================================================
@@ -260,7 +241,7 @@ start_stack() {
     local model="${2:-}"
 
     log_info "Starting stack with engine: $engine"
-    "${REPO_DIR}/aixcl" stack start --profile "$PROFILE" > /dev/null 2>&1
+    "${REPO_DIR}/aixcl" stack start --profile sys > /dev/null 2>&1
 
     # Wait for container
     local container
@@ -393,7 +374,7 @@ generate_comparison_report() {
 
 **Generated**: $(date -Iseconds)
 **Test Range**: $TEST_RANGE
-**Profile**: $PROFILE
+**Profile**: sys
 
 ## Engine Comparison
 
@@ -446,7 +427,7 @@ main() {
     echo "Engine:  $ENGINE"
     echo "Model:   ${MODEL:-auto-detect}"
     echo "Tests:   $TEST_RANGE"
-    echo "Profile: $PROFILE"
+    echo "Profile: sys"
     echo ""
 
     # Parse test range

--- a/tests/integration/platform-tests.sh
+++ b/tests/integration/platform-tests.sh
@@ -11,7 +11,6 @@
 #
 # Usage:
 #   ./tests/platform-tests.sh                    # Run all tests (backward compatible)
-#   ./tests/platform-tests.sh --profile bld      # Run tests for bld profile
 #   ./tests/platform-tests.sh --profile sys      # Run tests for sys profile
 #   ./tests/platform-tests.sh --component runtime-core  # Test runtime core only
 #   ./tests/platform-tests.sh --component database     # Test database components
@@ -974,24 +973,6 @@ test_component_ui() {
 # PROFILE-BASED TEST RUNNERS
 # ============================================================================
 
-# Test bld profile (runtime core + database + monitoring/logging, no UI)
-test_profile_bld() {
-    echo "Running tests for profile: bld"
-    echo "Profile includes: runtime core, database, monitoring, logging"
-    echo ""
-
-    test_environment_check
-    test_component_runtime_core
-    test_component_database
-    test_component_monitoring
-    test_component_logging
-    test_llm_state
-    test_model_inference
-    test_opencode_integration
-    test_cli_aliases
-    test_security_validation
-}
-
 # Test sys profile (all services)
 test_profile_sys() {
     echo "Running tests for profile: sys"
@@ -1186,10 +1167,9 @@ main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --profile|-p)
-                # Check if argument exists before accessing it
                 if [[ $# -lt 2 ]] || [[ -z "${2:-}" ]]; then
                     echo "Error: Profile name is required after --profile" >&2
-                    echo "Usage: $0 --profile <bld|sys>" >&2
+                    echo "Usage: $0 --profile sys" >&2
                     exit 1
                 fi
                 test_profile="$2"
@@ -1218,8 +1198,7 @@ main() {
                 echo "  $0 --component <component>   # Run tests for specific component"
                 echo "  $0 --list                    # List available targets"
                 echo ""
-                echo "Profiles:"
-                echo "  bld   - Runtime core + database + monitoring + logging"
+                echo "Profile:"
                 echo "  sys   - All services (complete stack)"
                 echo ""
                 echo "Components:"
@@ -1245,8 +1224,7 @@ main() {
         echo "Available Test Targets"
         echo "======================"
         echo ""
-        echo "Profiles:"
-        echo "  bld   - Runtime core + database + monitoring + logging"
+        echo "Profile:"
         echo "  sys   - All services (complete stack)"
         echo ""
         echo "Components:"
@@ -1269,8 +1247,7 @@ main() {
         echo "  $0 --list                    # List available targets"
         echo "  $0 --help                    # Show detailed help"
         echo ""
-        echo "Profiles:"
-        echo "  bld   - Runtime core + database + monitoring + logging ($INFERENCE_ENGINE, postgres)"
+        echo "Profile:"
         echo "  sys   - All services (complete stack)"
         echo ""
         echo "Components:"
@@ -1299,16 +1276,13 @@ main() {
     # Run tests based on arguments
     if [ -n "$test_profile" ]; then
         # Validate profile
-        if ! is_valid_profile "$test_profile" 2>/dev/null; then
+        if [[ "$test_profile" != "sys" ]]; then
             echo "Error: Invalid profile: $test_profile" >&2
-            echo "Valid profiles: bld, sys" >&2
+            echo "Valid profile: sys" >&2
             exit 1
         fi
-        
+
         case "$test_profile" in
-            bld)
-                test_profile_bld
-                ;;
             sys)
                 test_profile_sys
                 ;;


### PR DESCRIPTION
﻿# Pull Request

## Summary
Fixes #1103

### Description of Changes
- Remove all `bld` profile references from the test suite
- Tests now run exclusively with `sys` profile for maximum coverage
- Hardcoded `--profile sys` in `start_stack()` within `tests/aixcl-test`
- Removed `-p/--profile` CLI option, `PROFILE` variable, profile validation block, and `bld` case from `tests/integration/platform-tests.sh`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes
- Verified `grep -r 'bld' tests/` returns no matches after change
- Test suite runs with `sys` profile only

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1103
