### PR TITLE
Fix utils prune defaulting to docker instead of podman (#1106)

### DIFF
--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -19,7 +19,7 @@ function needs_rebuild() {
 }
 
 function prune() {
-    local docker_cmd="${DOCKER_BIN:-docker}"
+    local docker_cmd="${DOCKER_BIN:-podman}"
 
     echo "Pruning AIXCL stack (volumes and state, images kept)..."
     echo ""
@@ -45,7 +45,7 @@ function prune() {
 }
 
 function prune_all() {
-    local docker_cmd="${DOCKER_BIN:-docker}"
+    local docker_cmd="${DOCKER_BIN:-podman}"
 
     echo "SCORCHED EARTH: Removing ALL container resources including images..."
     echo "Using container engine: $docker_cmd"


### PR DESCRIPTION
﻿# Pull Request

## Summary
Fixes #1106

### Description of Changes
Change `${DOCKER_BIN:-docker}` to `${DOCKER_BIN:-podman}` in both `prune()` and `prune_all()` functions in `lib/aixcl/commands/utils.sh`. The stack is Podman-rootless; docker is not installed and the fallback silently caused all volume operations to be skipped.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes
- Run `./aixcl utils prune` without `DOCKER_BIN` set — volumes are now removed correctly using podman
- Run `./aixcl utils prune --all` — full cleanup completes without error

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1106
