### PR TITLE
Repo hygiene hotfix tracked env dead profile code stale CI and docs (#1113)

### DIFF
--- a/.env.podman
+++ b/.env.podman
@@ -1,1 +1,0 @@
-export DOCKER_HOST="unix:///run/user/1000//podman/podman.sock"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
           
           # Create minimal .env
           echo "INFERENCE_ENGINE=ollama" > .env
-          echo "PROFILE=usr" >> .env
+          echo "PROFILE=sys" >> .env
           
           # Test engine set commands
           chmod +x ./aixcl
@@ -136,7 +136,7 @@ jobs:
           
           # Create minimal .env
           echo "INFERENCE_ENGINE=ollama" > .env
-          echo "PROFILE=usr" >> .env
+          echo "PROFILE=sys" >> .env
           
           # Validate stack configs without starting
           ./aixcl stack status 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.local
 .env.backup.*
 .env.*.local
+.env.podman
 config/.env
 .pythonenv
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ### Documentation
 
-- **README Quick Start**: Added `./aixcl stack init` step and `utils bash-completion` / `utils clean` commands (Fixes #1020)
+- **README Quick Start**: Added `./aixcl stack init` step and `utils bash-completion` / `utils prune` commands (Fixes #1020)
 
 ### Related Issues
 

--- a/lib/cli/profile.sh
+++ b/lib/cli/profile.sh
@@ -29,8 +29,6 @@ get_runtime_core_services() {
 
 # Profile descriptions
 declare -A PROFILE_DESCRIPTIONS=(
-    [usr]="DEPRECATED — Not supported (Vault now required for database secrets)"
-    [dev]="DEPRECATED — Not supported (Vault now required for database secrets)"
     [bld]="Builder-focused (monitoring/logging)"
     [sys]="System-oriented (complete stack)"
 )
@@ -45,12 +43,6 @@ get_profile_services_for_profile() {
     local engine="${INFERENCE_ENGINE:-ollama}"
     
     case "$profile" in
-        usr)
-            echo "$engine postgres"
-            ;;
-        dev)
-            echo "$engine open-webui postgres pgadmin"
-            ;;
         bld)
             echo "$engine vault postgres prometheus grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
             ;;
@@ -64,12 +56,8 @@ get_profile_services_for_profile() {
     esac
 }
 
-# Deprecated: Static array kept for backward compatibility
-# Use get_profile_services_for_profile() or get_profile_services() instead
 # shellcheck disable=SC2034
 declare -A PROFILE_SERVICES=(
-    [usr]="INFERENCE_ENGINE_PLACEHOLDER vault postgres vault-agent-postgres-bootstrap"
-    [dev]="INFERENCE_ENGINE_PLACEHOLDER vault open-webui postgres pgadmin vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap"
     [bld]="INFERENCE_ENGINE_PLACEHOLDER vault postgres prometheus grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
     [sys]="INFERENCE_ENGINE_PLACEHOLDER vault open-webui postgres pgadmin prometheus alertmanager grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter vault-agent-postgres vault-agent-openwebui vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap"
 )
@@ -77,8 +65,6 @@ declare -A PROFILE_SERVICES=(
 # Profile database storage settings
 # All profiles use database storage for persistence
 declare -A PROFILE_DB_STORAGE=(
-    [usr]="true"
-    [dev]="true"
     [bld]="true"
     [sys]="true"
 )
@@ -89,8 +75,6 @@ is_valid_profile() {
     if [ -z "$profile" ]; then
         return 1
     fi
-    # Only bld and sys are supported — usr and dev removed because Vault is now
-    # required for database secrets and all services depend on Vault agents.
     case "$profile" in
         bld|sys)
             return 0
@@ -149,10 +133,6 @@ list_profiles() {
     echo ""
     echo "  - bld: $(get_profile_description "bld")"
     echo "  - sys: $(get_profile_description "sys")"
-    echo ""
-    echo "Deprecated (not supported):"
-    echo "  - usr: DEPRECATED — Not supported (Vault now required for database secrets)"
-    echo "  - dev: DEPRECATED — Not supported (Vault now required for database secrets)"
     echo ""
     echo "For detailed profile information, see: docs/architecture/governance/02_profiles.md"
 }

--- a/scripts/exporters/gpu-exporter.service.template
+++ b/scripts/exporters/gpu-exporter.service.template
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /home/sbadakhc/src/github.com/xencon/aixcl/scripts/exporters/gpu-exporter.py
+ExecStart=/usr/bin/python3 @INSTALL_PATH@/scripts/exporters/gpu-exporter.py
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/scripts/exporters/ollama-exporter.service.template
+++ b/scripts/exporters/ollama-exporter.service.template
@@ -5,7 +5,7 @@ After=network.target ollama.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /home/sbadakhc/src/github.com/xencon/aixcl/scripts/exporters/ollama-exporter.py
+ExecStart=/usr/bin/python3 @INSTALL_PATH@/scripts/exporters/ollama-exporter.py
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1113

### Description of Changes
- Untrack .env.podman from git and add to .gitignore
- Replace deprecated PROFILE=usr with PROFILE=sys in .github/workflows/integration-tests.yml
- Remove dead usr and dev profile cases from lib/cli/profile.sh
- Replace hardcoded developer path with @INSTALL_PATH@ placeholder in exporter service templates
- Update CHANGELOG.md from utils clean to utils prune

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one component label
- [x] **Title Format**: description with issue number, no colons

### Testing Notes
- git ls-files .env.podman returns no output
- grep PROFILE=usr .github/ returns no matches
- Service templates contain no hardcoded absolute paths

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1113
