### PR TITLE
Fix Grafana dashboard provisioning duplicate folder (#1116)

### DIFF
--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -4,9 +4,9 @@
 apiVersion: 1
 
 providers:
-  - name: 'AIXCL Dashboards'
+  - name: 'AIXCL'
     orgId: 1
-    folder: 'AIXCL Dashboards'
+    folder: 'AIXCL'
     type: file
     disableDeletion: false
     updateIntervalSeconds: 10


### PR DESCRIPTION
## Summary

Fixes #1116

### Description of Changes

Renames the Grafana dashboard provider `name` and `folder` from `AIXCL Dashboards` to `AIXCL` in `grafana/provisioning/dashboards/dashboard.yml`. This aligns the dashboard provisioning with the folder name already used in `alert-rules.yml`, resulting in a single `AIXCL` folder in the Grafana UI.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:observability
- [x] Title Format: correct

### Testing Notes
- Start stack with `./aixcl stack start --profile sys`
- Navigate to http://localhost:3000/dashboards
- Verify single AIXCL folder containing all 4 dashboards

### Verification
- [x] Only one folder named AIXCL visible in Grafana dashboards page
- [x] All 4 dashboards present in the AIXCL folder
- [x] No regressions in alert rule folder references

### Related Issues
- Closes #1116
