### PR TITLE
Fix GPU support for Podman via CDI device allocation (#1118)

### DIFF
--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -31,7 +31,7 @@ COMPOSE_WORKDIR="${SERVICES_DIR}"
 # Podman is preferred over Docker for rootless security
 set_compose_cmd() {
     local files=( -f "${SERVICES_DIR}/${COMPOSE_FILE}" )
-    
+
     # Check for ARM64 architecture
     if is_arm64 && [ -f "${SERVICES_DIR}/docker-compose.arm.yml" ]; then
         if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
@@ -39,38 +39,24 @@ set_compose_cmd() {
         fi
         files+=( -f "${SERVICES_DIR}/docker-compose.arm.yml" )
     fi
-    
-    # Check for NVIDIA GPU hardware AND toolkit availability
-    if has_nvidia && has_nvidia_container_toolkit && [ -f "${SERVICES_DIR}/docker-compose.gpu.yml" ]; then
-        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
-            echo "Detected NVIDIA GPU hardware and Container Toolkit. Enabling GPU overrides."
-        fi
-        files+=( -f "${SERVICES_DIR}/docker-compose.gpu.yml" )
-    else
-        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
-            echo "No NVIDIA GPU support detected. Running without GPU overrides."
-        fi
-    fi
-    
-    # Detect appropriate compose command - Podman preferred for rootless security
+
+    # Detect container runtime first — GPU overlay selection depends on it
     local cmd=()
     local bin="docker"
-    
-    # Check if Podman is available and functional (preferred for security)
+
+    # Podman preferred for rootless security
     if command -v podman &>/dev/null && podman info &>/dev/null; then
-        # Podman is installed and working
         if command -v podman-compose &>/dev/null; then
             bin="podman"
             cmd=(podman-compose)
             [ "${AIXCL_VERBOSE:-0}" = "1" ] && echo "Using Podman (rootless mode) with podman-compose"
         else
-            # podman installed but podman-compose missing
             echo "⚠️  Podman found but podman-compose not installed" >&2
             echo "   Install: pip3 install podman-compose" >&2
             echo "   Falling back to Docker..." >&2
         fi
     fi
-    
+
     # Docker fallback
     if [[ "$bin" == "docker" ]]; then
         if command -v docker &>/dev/null; then
@@ -80,11 +66,31 @@ set_compose_cmd() {
             exit 1
         fi
     fi
-    
+
     # Export DOCKER_BIN for use in other scripts
     export DOCKER_BIN="$bin"
     if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
         echo "Using container engine: $DOCKER_BIN"
+    fi
+
+    # Check for NVIDIA GPU hardware AND toolkit availability
+    # Runtime must be detected above before this block runs
+    if has_nvidia && has_nvidia_container_toolkit && [ -f "${SERVICES_DIR}/docker-compose.gpu.yml" ]; then
+        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+            echo "Detected NVIDIA GPU hardware and Container Toolkit. Enabling GPU overrides."
+        fi
+        files+=( -f "${SERVICES_DIR}/docker-compose.gpu.yml" )
+        # Podman ignores deploy.resources.reservations.devices — load CDI overlay instead
+        if [[ "$bin" == "podman" ]] && [ -f "${SERVICES_DIR}/docker-compose.gpu-podman.yml" ]; then
+            if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+                echo "Podman runtime detected: enabling CDI GPU device overlay."
+            fi
+            files+=( -f "${SERVICES_DIR}/docker-compose.gpu-podman.yml" )
+        fi
+    else
+        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+            echo "No NVIDIA GPU support detected. Running without GPU overrides."
+        fi
     fi
 
     if [ ${#cmd[@]} -eq 0 ]; then

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -202,6 +202,55 @@ setup_volume_permissions() {
   log_info "Volume permissions configured"
 }
 
+# Generate NVIDIA CDI spec so Podman can allocate GPU devices to containers
+setup_nvidia_cdi() {
+  log_step "Configuring NVIDIA CDI for Podman GPU support..."
+
+  if ! command -v nvidia-ctk >/dev/null 2>&1; then
+    log_info "nvidia-ctk not found — skipping GPU setup (no NVIDIA Container Toolkit)"
+    return 0
+  fi
+
+  if ! nvidia-smi >/dev/null 2>&1; then
+    log_info "No NVIDIA GPU detected — skipping CDI setup"
+    return 0
+  fi
+
+  # Check if CDI spec already has devices
+  local cdi_count
+  cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+  if [[ "$cdi_count" -gt 0 ]]; then
+    log_info "[OK] NVIDIA CDI already configured ($cdi_count devices)"
+    return 0
+  fi
+
+  log_info "Generating NVIDIA CDI specification..."
+
+  # Try system-level CDI spec first, fall back to user-level
+  if sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>/dev/null; then
+    log_info "[OK] NVIDIA CDI spec written to /etc/cdi/nvidia.yaml"
+  else
+    log_warn "Could not write system CDI spec — trying user-level"
+    mkdir -p "${HOME}/.config/cdi"
+    if nvidia-ctk cdi generate --output="${HOME}/.config/cdi/nvidia.yaml" 2>/dev/null; then
+      log_info "[OK] NVIDIA CDI spec written to ${HOME}/.config/cdi/nvidia.yaml"
+    else
+      log_error "Failed to generate NVIDIA CDI spec"
+      log_info "Run manually: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+      return 1
+    fi
+  fi
+
+  # Verify
+  local device_count
+  device_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+  if [[ "$device_count" -gt 0 ]]; then
+    log_info "[OK] NVIDIA CDI devices available: $device_count"
+  else
+    log_warn "CDI spec written but no devices visible yet — a re-login may be required"
+  fi
+}
+
 # Create Podman-specific configuration
 create_podman_config() {
   log_step "Creating Podman configuration..."
@@ -346,6 +395,18 @@ verify_setup() {
     log_error "[FAIL] Test container failed"
     all_good=false
   fi
+
+  # Check NVIDIA CDI (optional — only relevant when GPU hardware is present)
+  if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+    local cdi_count
+    cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+    if [[ "$cdi_count" -gt 0 ]]; then
+      log_info "[OK] NVIDIA CDI configured ($cdi_count devices)"
+    else
+      log_warn "[WARN] NVIDIA GPU detected but CDI not configured — GPU unavailable in containers"
+      log_info "       Run: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+    fi
+  fi
   
   if $all_good; then
     log_info ""
@@ -418,6 +479,7 @@ What This Does:
   3. Sets up Podman socket for Docker compatibility
   4. Configures volume permissions
   5. Creates Podman-optimized configuration
+  6. Generates NVIDIA CDI spec for GPU support (if NVIDIA GPU detected)
 
 Security Benefits:
   - No daemon process (eliminates attack surface)
@@ -447,6 +509,7 @@ case "${1:-}" in
     setup_podman_socket
     setup_volume_permissions
     create_podman_config
+    setup_nvidia_cdi
     verify_setup
     ;;
   *)

--- a/services/docker-compose.gpu-podman.yml
+++ b/services/docker-compose.gpu-podman.yml
@@ -1,0 +1,17 @@
+# Podman CDI GPU support overlay for AIXCL
+# Loaded alongside docker-compose.gpu.yml when Podman is the container runtime
+# podman-compose translates devices entries to --device CDI flags
+# Requires: nvidia-ctk cdi generate (run setup-podman-rootless.sh)
+
+services:
+  ollama:
+    devices:
+      - nvidia.com/gpu=all
+
+  vllm:
+    devices:
+      - nvidia.com/gpu=all
+
+  llamacpp:
+    devices:
+      - nvidia.com/gpu=all


### PR DESCRIPTION
## Summary

Fixes #1118

### Description of Changes

Restores GPU support broken by the Docker-to-Podman migration (d829f4d).

Root cause: `podman-compose` silently ignores `deploy.resources.reservations.devices` (Docker Swarm syntax). Additionally, NVIDIA CDI was never configured, so Podman had no mechanism to pass GPU devices to containers.

Three changes:

**1. `services/docker-compose.gpu-podman.yml`** (new file) Podman-specific GPU overlay using CDI device strings. `podman-compose` translates `devices` entries to `--device` CDI flags, which is how Podman allocates GPU hardware to containers.

**2. `lib/core/docker_utils.sh`** Restructured `set_compose_cmd()` to detect the container runtime (Podman vs Docker) before applying GPU overlays. When Podman is detected with an NVIDIA GPU, both `docker-compose.gpu.yml` (entrypoint overrides) and `docker-compose.gpu-podman.yml` (CDI devices) are loaded.

**3. `scripts/utils/setup-podman-rootless.sh`** Added `setup_nvidia_cdi()` function that generates the NVIDIA CDI spec (`/etc/cdi/nvidia.yaml`) required for Podman GPU allocation. Called automatically during setup when NVIDIA hardware is detected. Added CDI status check to `verify_setup()`.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:runtime-core
- [x] Title Format: correct

### Testing Notes
1. Run: `./scripts/utils/setup-podman-rootless.sh`
2. Verify CDI: `nvidia-ctk cdi list` shows nvidia.com devices
3. Restart stack: `./aixcl stack stop && ./aixcl stack start --profile sys`
4. Verify: `podman inspect ollama | grep -A5 Devices` shows GPU entries
5. Verify: Ollama logs show GPU detected
6. Verify: Grafana GPU Metrics dashboard shows data

### Verification
- [x] nvidia-ctk cdi list shows NVIDIA devices after setup
- [x] podman inspect ollama shows Devices populated
- [x] GPU metrics visible in Grafana AIXCL dashboard

### Related Issues
- Closes #1118
