### PR TITLE
Fix GPU support for Podman via CDI device allocation (#1118)

### DIFF
--- a/grafana/provisioning/dashboards/AIXCL/gpu-metrics.json
+++ b/grafana/provisioning/dashboards/AIXCL/gpu-metrics.json
@@ -92,7 +92,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "nvidia_smi_utilization_gpu",
+          "expr": "nvidia_smi_utilization_gpu_ratio * 100",
           "refId": "A",
           "legendFormat": "GPU {{gpu}}"
         }
@@ -173,7 +173,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "(nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes) * 100",
+          "expr": "(nvidia_smi_memory_bytes{type=\"used\"} / nvidia_smi_memory_bytes{type=\"total\"}) * 100",
           "refId": "A",
           "legendFormat": "GPU {{gpu}}"
         }
@@ -238,7 +238,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "nvidia_smi_temperature_gpu",
+          "expr": "nvidia_smi_temperature_gpu_celsius",
           "refId": "A",
           "legendFormat": "GPU {{gpu}}"
         }
@@ -368,12 +368,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "nvidia_smi_memory_used_bytes / 1024 / 1024",
+          "expr": "nvidia_smi_memory_bytes{type=\"used\"} / 1024 / 1024",
           "refId": "A",
           "legendFormat": "GPU {{gpu}} Used"
         },
         {
-          "expr": "(nvidia_smi_memory_total_bytes - nvidia_smi_memory_used_bytes) / 1024 / 1024",
+          "expr": "(nvidia_smi_memory_bytes{type=\"total\"} - nvidia_smi_memory_bytes{type=\"used\"}) / 1024 / 1024",
           "refId": "B",
           "legendFormat": "GPU {{gpu}} Free"
         }

--- a/grafana/provisioning/dashboards/AIXCL/gpu-metrics.json
+++ b/grafana/provisioning/dashboards/AIXCL/gpu-metrics.json
@@ -173,7 +173,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "(nvidia_smi_memory_bytes{type=\"used\"} / nvidia_smi_memory_bytes{type=\"total\"}) * 100",
+          "expr": "(nvidia_smi_memory_used_bytes / nvidia_smi_memory_total_bytes) * 100",
           "refId": "A",
           "legendFormat": "GPU {{gpu}}"
         }
@@ -238,7 +238,7 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "nvidia_smi_temperature_gpu_celsius",
+          "expr": "nvidia_smi_temperature_gpu",
           "refId": "A",
           "legendFormat": "GPU {{gpu}}"
         }
@@ -368,12 +368,12 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "nvidia_smi_memory_bytes{type=\"used\"} / 1024 / 1024",
+          "expr": "nvidia_smi_memory_used_bytes / 1024 / 1024",
           "refId": "A",
           "legendFormat": "GPU {{gpu}} Used"
         },
         {
-          "expr": "(nvidia_smi_memory_bytes{type=\"total\"} - nvidia_smi_memory_bytes{type=\"used\"}) / 1024 / 1024",
+          "expr": "(nvidia_smi_memory_total_bytes - nvidia_smi_memory_used_bytes) / 1024 / 1024",
           "refId": "B",
           "legendFormat": "GPU {{gpu}} Free"
         }

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1405,7 +1405,7 @@ function status() {
     if is_operational_in_profile "nvidia-gpu-exporter"; then
         if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^nvidia-gpu-exporter$"; then
             # shellcheck disable=SC2034
-            NVIDIA_GPU_EXPORTER_STATUS=$(curl --connect-timeout 2 -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9400/metrics 2>/dev/null || echo "000")
+            NVIDIA_GPU_EXPORTER_STATUS=$(curl --connect-timeout 2 -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9445/metrics 2>/dev/null || echo "000")
             check_service_status "NVIDIA GPU Exporter" "nvidia-gpu-exporter" "status_var" "NVIDIA_GPU_EXPORTER_STATUS"
         else
             echo "  ${ICON_ERROR:-❌} NVIDIA GPU Exporter"

--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -31,7 +31,7 @@ COMPOSE_WORKDIR="${SERVICES_DIR}"
 # Podman is preferred over Docker for rootless security
 set_compose_cmd() {
     local files=( -f "${SERVICES_DIR}/${COMPOSE_FILE}" )
-    
+
     # Check for ARM64 architecture
     if is_arm64 && [ -f "${SERVICES_DIR}/docker-compose.arm.yml" ]; then
         if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
@@ -39,38 +39,24 @@ set_compose_cmd() {
         fi
         files+=( -f "${SERVICES_DIR}/docker-compose.arm.yml" )
     fi
-    
-    # Check for NVIDIA GPU hardware AND toolkit availability
-    if has_nvidia && has_nvidia_container_toolkit && [ -f "${SERVICES_DIR}/docker-compose.gpu.yml" ]; then
-        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
-            echo "Detected NVIDIA GPU hardware and Container Toolkit. Enabling GPU overrides."
-        fi
-        files+=( -f "${SERVICES_DIR}/docker-compose.gpu.yml" )
-    else
-        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
-            echo "No NVIDIA GPU support detected. Running without GPU overrides."
-        fi
-    fi
-    
-    # Detect appropriate compose command - Podman preferred for rootless security
+
+    # Detect container runtime first — GPU overlay selection depends on it
     local cmd=()
     local bin="docker"
-    
-    # Check if Podman is available and functional (preferred for security)
+
+    # Podman preferred for rootless security
     if command -v podman &>/dev/null && podman info &>/dev/null; then
-        # Podman is installed and working
         if command -v podman-compose &>/dev/null; then
             bin="podman"
             cmd=(podman-compose)
             [ "${AIXCL_VERBOSE:-0}" = "1" ] && echo "Using Podman (rootless mode) with podman-compose"
         else
-            # podman installed but podman-compose missing
             echo "⚠️  Podman found but podman-compose not installed" >&2
             echo "   Install: pip3 install podman-compose" >&2
             echo "   Falling back to Docker..." >&2
         fi
     fi
-    
+
     # Docker fallback
     if [[ "$bin" == "docker" ]]; then
         if command -v docker &>/dev/null; then
@@ -80,11 +66,31 @@ set_compose_cmd() {
             exit 1
         fi
     fi
-    
+
     # Export DOCKER_BIN for use in other scripts
     export DOCKER_BIN="$bin"
     if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
         echo "Using container engine: $DOCKER_BIN"
+    fi
+
+    # Check for NVIDIA GPU hardware AND toolkit availability
+    # Runtime must be detected above before this block runs
+    if has_nvidia && has_nvidia_container_toolkit && [ -f "${SERVICES_DIR}/docker-compose.gpu.yml" ]; then
+        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+            echo "Detected NVIDIA GPU hardware and Container Toolkit. Enabling GPU overrides."
+        fi
+        files+=( -f "${SERVICES_DIR}/docker-compose.gpu.yml" )
+        # Podman ignores deploy.resources.reservations.devices — load CDI overlay instead
+        if [[ "$bin" == "podman" ]] && [ -f "${SERVICES_DIR}/docker-compose.gpu-podman.yml" ]; then
+            if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+                echo "Podman runtime detected: enabling CDI GPU device overlay."
+            fi
+            files+=( -f "${SERVICES_DIR}/docker-compose.gpu-podman.yml" )
+        fi
+    else
+        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+            echo "No NVIDIA GPU support detected. Running without GPU overrides."
+        fi
     fi
 
     if [ ${#cmd[@]} -eq 0 ]; then

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -227,7 +227,7 @@ setup_nvidia_cdi() {
   log_info "Generating NVIDIA CDI specification..."
 
   # Try system-level CDI spec first, fall back to user-level
-  if sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>/dev/null; then
+  if sudo mkdir -p /etc/cdi && sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>/dev/null; then
     log_info "[OK] NVIDIA CDI spec written to /etc/cdi/nvidia.yaml"
   else
     log_warn "Could not write system CDI spec — trying user-level"
@@ -236,7 +236,7 @@ setup_nvidia_cdi() {
       log_info "[OK] NVIDIA CDI spec written to ${HOME}/.config/cdi/nvidia.yaml"
     else
       log_error "Failed to generate NVIDIA CDI spec"
-      log_info "Run manually: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+      log_info "Run manually: sudo mkdir -p /etc/cdi && sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
       return 1
     fi
   fi

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -202,6 +202,55 @@ setup_volume_permissions() {
   log_info "Volume permissions configured"
 }
 
+# Generate NVIDIA CDI spec so Podman can allocate GPU devices to containers
+setup_nvidia_cdi() {
+  log_step "Configuring NVIDIA CDI for Podman GPU support..."
+
+  if ! command -v nvidia-ctk >/dev/null 2>&1; then
+    log_info "nvidia-ctk not found — skipping GPU setup (no NVIDIA Container Toolkit)"
+    return 0
+  fi
+
+  if ! nvidia-smi >/dev/null 2>&1; then
+    log_info "No NVIDIA GPU detected — skipping CDI setup"
+    return 0
+  fi
+
+  # Check if CDI spec already has devices
+  local cdi_count
+  cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+  if [[ "$cdi_count" -gt 0 ]]; then
+    log_info "[OK] NVIDIA CDI already configured ($cdi_count devices)"
+    return 0
+  fi
+
+  log_info "Generating NVIDIA CDI specification..."
+
+  # Try system-level CDI spec first, fall back to user-level
+  if sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>/dev/null; then
+    log_info "[OK] NVIDIA CDI spec written to /etc/cdi/nvidia.yaml"
+  else
+    log_warn "Could not write system CDI spec — trying user-level"
+    mkdir -p "${HOME}/.config/cdi"
+    if nvidia-ctk cdi generate --output="${HOME}/.config/cdi/nvidia.yaml" 2>/dev/null; then
+      log_info "[OK] NVIDIA CDI spec written to ${HOME}/.config/cdi/nvidia.yaml"
+    else
+      log_error "Failed to generate NVIDIA CDI spec"
+      log_info "Run manually: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+      return 1
+    fi
+  fi
+
+  # Verify
+  local device_count
+  device_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+  if [[ "$device_count" -gt 0 ]]; then
+    log_info "[OK] NVIDIA CDI devices available: $device_count"
+  else
+    log_warn "CDI spec written but no devices visible yet — a re-login may be required"
+  fi
+}
+
 # Create Podman-specific configuration
 create_podman_config() {
   log_step "Creating Podman configuration..."
@@ -346,6 +395,18 @@ verify_setup() {
     log_error "[FAIL] Test container failed"
     all_good=false
   fi
+
+  # Check NVIDIA CDI (optional — only relevant when GPU hardware is present)
+  if command -v nvidia-ctk >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
+    local cdi_count
+    cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
+    if [[ "$cdi_count" -gt 0 ]]; then
+      log_info "[OK] NVIDIA CDI configured ($cdi_count devices)"
+    else
+      log_warn "[WARN] NVIDIA GPU detected but CDI not configured — GPU unavailable in containers"
+      log_info "       Run: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+    fi
+  fi
   
   if $all_good; then
     log_info ""
@@ -418,6 +479,7 @@ What This Does:
   3. Sets up Podman socket for Docker compatibility
   4. Configures volume permissions
   5. Creates Podman-optimized configuration
+  6. Generates NVIDIA CDI spec for GPU support (if NVIDIA GPU detected)
 
 Security Benefits:
   - No daemon process (eliminates attack surface)
@@ -447,6 +509,7 @@ case "${1:-}" in
     setup_podman_socket
     setup_volume_permissions
     create_podman_config
+    setup_nvidia_cdi
     verify_setup
     ;;
   *)

--- a/services/docker-compose.gpu-podman.yml
+++ b/services/docker-compose.gpu-podman.yml
@@ -15,3 +15,7 @@ services:
   llamacpp:
     devices:
       - nvidia.com/gpu=all
+
+  nvidia-gpu-exporter:
+    devices:
+      - nvidia.com/gpu=all

--- a/services/docker-compose.gpu-podman.yml
+++ b/services/docker-compose.gpu-podman.yml
@@ -1,0 +1,17 @@
+# Podman CDI GPU support overlay for AIXCL
+# Loaded alongside docker-compose.gpu.yml when Podman is the container runtime
+# podman-compose translates devices entries to --device CDI flags
+# Requires: nvidia-ctk cdi generate (run setup-podman-rootless.sh)
+
+services:
+  ollama:
+    devices:
+      - nvidia.com/gpu=all
+
+  vllm:
+    devices:
+      - nvidia.com/gpu=all
+
+  llamacpp:
+    devices:
+      - nvidia.com/gpu=all

--- a/services/docker-compose.gpu.yml
+++ b/services/docker-compose.gpu.yml
@@ -62,3 +62,12 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
     entrypoint: ["/usr/local/bin/llamacpp-entrypoint.sh"]
     command: ["--host", "0.0.0.0", "--port", "11434"]
+
+  nvidia-gpu-exporter:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -522,21 +522,16 @@ services:
     restart: unless-stopped
 
   nvidia-gpu-exporter:
-    image: nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04
+    image: docker.io/utkuozdemir/nvidia_gpu_exporter:1.3.2
     container_name: nvidia-gpu-exporter
     pull_policy: missing
-    user: "999:999"  # nvidia-dcgm user - official image default for GPU metrics
     cap_drop:
       - ALL
     security_opt:
       - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp:noexec,nosuid,size=10m
     network_mode: host
     restart: unless-stopped
-    environment:
-      - DCGM_EXPORTER_LISTEN=:9400
+    command: ["--web.listen-address=:9445"]
     # GPU resources are configured in docker-compose.gpu.yml when available
     # This service will gracefully fail on systems without NVIDIA GPUs
 


### PR DESCRIPTION
## Summary

Fixes #1118

### Description of Changes

Restores GPU support broken by the Docker-to-Podman migration (d829f4d) and fixes the GPU metrics pipeline end-to-end.

Root causes identified and resolved:

**1. Podman ignores Docker GPU syntax** podman-compose silently ignores deploy.resources.reservations.devices (Docker Swarm syntax). Added services/docker-compose.gpu-podman.yml with CDI device entries. Restructured set_compose_cmd() in docker_utils.sh to detect the container runtime before applying GPU overlays, loading the CDI overlay when Podman is in use.

**2. NVIDIA CDI not configured** CDI was never set up, so Podman had no mechanism to pass GPU devices to containers. Added setup_nvidia_cdi() to setup-podman-rootless.sh which generates /etc/cdi/nvidia.yaml when NVIDIA hardware is detected. Added CDI status check to verify_setup().

**3. Wrong GPU metrics exporter** The DCGM exporter requires NVML which is incompatible with WSL2. Replaced with utkuozdemir/nvidia_gpu_exporter which uses nvidia-smi and works on WSL2. Port aligned to 9445 per the existing prometheus.yml configuration.

**4. nvidia-gpu-exporter missing from GPU overlays** Added nvidia-gpu-exporter to docker-compose.gpu.yml (Docker) and docker-compose.gpu-podman.yml (Podman CDI) so it receives GPU device access.

**5. Dashboard metric expression corrected** Updated gpu-metrics.json: nvidia_smi_utilization_gpu -> nvidia_smi_utilization_gpu_ratio * 100.

**6. Stack status checking wrong port** Updated stack.sh health check from port 9400 (DCGM) to 9445.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:runtime-core
- [x] Title Format: correct

### Testing Notes
- Confirmed GPU utilization visible in Grafana AIXCL GPU Metrics dashboard
- Confirmed nvidia-gpu-exporter healthy in ./aixcl stack status
- Confirmed Ollama inference running on GPU via nvitop
- Validated on WSL2 with NVIDIA GeForce RTX 4060 Laptop GPU

### Verification
- [x] nvidia-ctk cdi list shows NVIDIA devices after setup-podman-rootless.sh
- [x] podman inspect ollama shows Devices populated
- [x] All GPU dashboard panels showing data
- [x] ./aixcl stack status shows NVIDIA GPU Exporter healthy

### Related Issues
- Closes #1118
