### PR TITLE
Fix prune --all to restore pre-install state and fix ./aixcl completion (#1130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ Services started (12 in sys profile):
 | **Secrets** | Vault | 8200 |
 | **UI** | Open WebUI | 8080 |
 
+### Step 4: Install Bash Completion (Recommended)
+
+Enable tab completion for all `aixcl` commands and flags, including `./aixcl utils prune --all`:
+
+```bash
+./aixcl utils bash-completion
+source ~/.local/share/bash-completion/completions/aixcl
+```
+
+The second line activates completion in your current shell. New shell sessions pick it up automatically.
+
 ### Step 5: Verify Vault (Auto-Initialized)
 
 Vault initializes automatically during stack startup. The process takes 2-3 minutes:
@@ -234,6 +245,8 @@ git log --show-signature -1
 | Vault credentials | `./aixcl vault credentials` |
 | Rotate credentials | `./aixcl vault rotate` |
 | Verify GPG | `gpg --list-secret-keys --keyid-format LONG` |
+| Install bash completion | `./aixcl utils bash-completion` |
+| Full clean removal | `./aixcl utils prune --all` |
 
 ---
 

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -187,7 +187,6 @@ _aixcl_complete() {
     return 0
 }
 
-# Register the completion function
-# This will work for: aixcl, ./aixcl, /path/to/aixcl, etc.
-# -o default is not set, so filename completion won't be used as fallback
+# Register the completion function for both PATH and relative invocation
 complete -F _aixcl_complete aixcl
+complete -F _aixcl_complete ./aixcl

--- a/docs/reference/manpage.txt
+++ b/docs/reference/manpage.txt
@@ -75,15 +75,26 @@ COMMANDS
               Validate environment setup
 
         utils bash-completion
-               Install bash completion support
+               Install bash completion for aixcl and ./aixcl. Enables tab
+               completion for all commands, subcommands, and flags. Run once
+               after initial setup; new shell sessions pick it up automatically.
+               To activate in the current shell:
+                 source ~/.local/share/bash-completion/completions/aixcl
 
         utils prune
-               Remove volumes and state files, keep images for fast restart
-               (mirrors podman system prune)
+               Remove volumes and state files, keep images for fast restart.
 
         utils prune --all
-               Remove everything including images — full scorched-earth wipe
-               (mirrors podman system prune --all)
+               Full removal of all AIXCL resources and configuration. Requires
+               typing 'PURGE' at the confirmation prompt. Removes: containers,
+               images, volumes, networks, state files, project directories
+               (logs/, .security/, .audit/), AIXCL Podman configuration
+               (~/.config/containers/), NVIDIA CDI user config, and bash
+               completion files. Intentionally preserves /etc/subuid,
+               /etc/subgid, ~/.local/share/containers/, and podman.socket as
+               these are standard system config shared with other tools.
+               The system remains fully operational after this command.
+               To also reset Podman storage: podman system reset --force
 
         help
                Show help message

--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -47,8 +47,27 @@ function prune() {
 function prune_all() {
     local docker_cmd="${DOCKER_BIN:-podman}"
 
-    echo "SCORCHED EARTH: Removing ALL container resources including images..."
-    echo "Using container engine: $docker_cmd"
+    echo "WARNING: This will remove all AIXCL container resources AND system configuration."
+    echo "The system will remain operational. This cannot be undone."
+    echo ""
+    echo "Will remove:"
+    echo "  - All containers, images, volumes, networks"
+    echo "  - State files (.env, .aixcl.initialized, pgadmin-servers.json)"
+    echo "  - Project directories (logs/, .security/, .audit/)"
+    echo "  - AIXCL Podman configuration (~/.config/containers/)"
+    echo "  - AIXCL NVIDIA CDI user config (~/.config/cdi/nvidia.yaml, if present)"
+    echo "  - Bash completion files and ~/.bashrc AIXCL entries"
+    echo ""
+    echo "Will NOT remove (standard system config, shared with other tools):"
+    echo "  - /etc/subuid, /etc/subgid"
+    echo "  - ~/.local/share/containers/ (Podman storage)"
+    echo "  - podman.socket systemd service"
+    echo ""
+    read -r -p "Type 'PURGE' to confirm: " reply
+    if [[ "$reply" != "PURGE" ]]; then
+        echo "Aborted."
+        return 0
+    fi
     echo ""
 
     echo "Stopping all containers..."
@@ -81,15 +100,52 @@ function prune_all() {
     $docker_cmd system prune -f --all --volumes 2>/dev/null || true
     echo ""
 
-    if [ -f "pgadmin-servers.json" ]; then
-        rm -f pgadmin-servers.json
-        echo "Cleaned up pgAdmin configuration file"
-    fi
-    rm -f .aixcl.initialized .env
+    echo "Removing state files..."
+    rm -f .aixcl.initialized .env pgadmin-servers.json .env.podman
     echo ""
 
-    echo "Purge complete. All container resources removed."
-    $docker_cmd system df 2>/dev/null || echo "No resources found (good!)"
+    echo "Removing project directories..."
+    rm -rf logs .security .audit
+    echo ""
+
+    echo "Removing AIXCL Podman configuration..."
+    if [[ -d "${HOME}/.config/containers" ]]; then
+        rm -rf "${HOME}/.config/containers"
+        echo "  Removed ~/.config/containers"
+    fi
+    if [[ -f "${HOME}/.config/cdi/nvidia.yaml" ]]; then
+        rm -f "${HOME}/.config/cdi/nvidia.yaml"
+        rmdir "${HOME}/.config/cdi" 2>/dev/null || true
+        echo "  Removed ~/.config/cdi/nvidia.yaml"
+    fi
+    echo ""
+
+    echo "Removing bash completion..."
+    rm -f "${HOME}/.local/share/bash-completion/completions/aixcl"
+    rm -f "/etc/bash_completion.d/aixcl" 2>/dev/null || true
+    if [[ -f "${HOME}/.bashrc" ]]; then
+        local temp_bashrc
+        temp_bashrc="$(mktemp)"
+        sed '/Added by aixcl installer/,/^[[:space:]]*fi[[:space:]]*$/d' "${HOME}/.bashrc" > "$temp_bashrc" \
+            || cp "${HOME}/.bashrc" "$temp_bashrc"
+        if ! cmp -s "${HOME}/.bashrc" "$temp_bashrc"; then
+            cp "${HOME}/.bashrc" "${HOME}/.bashrc.backup.$(date +%s)" 2>/dev/null || true
+            mv "$temp_bashrc" "${HOME}/.bashrc"
+            echo "  Cleaned AIXCL entries from ~/.bashrc"
+        else
+            rm -f "$temp_bashrc"
+        fi
+    fi
+    echo ""
+
+    echo "Purge complete. All AIXCL resources removed."
+    echo ""
+    echo "NOTE: The following standard system config was intentionally preserved:"
+    echo "  /etc/subuid, /etc/subgid   -- required for rootless containers system-wide"
+    echo "  ~/.local/share/containers/ -- Podman storage (may contain non-AIXCL data)"
+    echo "  podman.socket              -- standard Podman systemd service"
+    echo ""
+    echo "To also reset Podman storage: podman system reset --force"
 }
 
 function utils_cmd() {


### PR DESCRIPTION
﻿## Summary Fixes #1130

### Description of Changes
- Extend `prune_all` in `lib/aixcl/commands/utils.sh` to restore pre-install state:
 - Add confirmation prompt (type 'PURGE') with upfront summary of what will and will not be removed
 - Remove project dirs (logs/, .security/, .audit/) and .env.podman
 - Remove AIXCL-specific Podman config (~/.config/containers/) -- safe as it uses non-default host networking not present in Podman built-in defaults
 - Remove user-level NVIDIA CDI config (~/.config/cdi/nvidia.yaml) if present
 - Remove bash completion files and strip AIXCL blocks from ~/.bashrc
 - Preserve /etc/subuid, /etc/subgid, ~/.local/share/containers/, and podman.socket (standard system config shared with other tools)
 - Print clear post-run note about what was preserved and why
- Fix `completion/aixcl.bash` to register for `./aixcl` in addition to `aixcl` so `--all` is offered when invoking from project root
- Add bash completion install as Step 4 in README quick start
- Add bash-completion and prune --all to README common commands table
- Expand manpage entries for both commands

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1130/fix-prune-all)
- [x] Commit messages follow conventional style
- [x] Tested against a live deployed stack -- prune --all ran cleanly, system remained operational

### Testing Notes
- Ran `./aixcl utils prune --all` against full sys profile deployment
- All 17 images, volumes, containers removed
- ~/.config/containers removed
- State files and project dirs removed
- podman, shell, and other tools unaffected after completion

### Verification
- [x] Run `./aixcl utils prune --all` on a deployed stack and confirm clean output
- [x] Confirm system remains operational (podman runs, shell works)
- [x] Confirm `./aixcl utils prune <TAB>` offers `--all`

### Related Issues
- Closes #1130
