### PR TITLE
Call stack stop before force-removing containers in prune --all (#1133)

### DIFF
--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -70,7 +70,11 @@ function prune_all() {
     fi
     echo ""
 
-    echo "Stopping all containers..."
+    echo "Stopping stack gracefully..."
+    ./aixcl stack stop 2>/dev/null || true
+    echo ""
+
+    echo "Stopping all remaining containers..."
     $docker_cmd stop -a 2>/dev/null || true
     echo "Removing all containers..."
     $docker_cmd rm -f -a 2>/dev/null || true


### PR DESCRIPTION
﻿## Summary Fixes #1133

### Description of Changes
- Add `./aixcl stack stop` to `prune_all` before force-removing containers, matching the graceful shutdown behaviour already present in `prune`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1133/prune-all-graceful-stop)
- [x] Commit messages follow conventional style

### Testing Notes
- Minimal one-line change; graceful stop runs first then falls through to podman stop -a for any remaining containers

### Verification
- [x] Run `./aixcl utils prune --all` on a running stack and confirm stack stop output appears before container removal

### Related Issues
- Closes #1133
