### PR TITLE
Fix shell script bugs and eliminate duplicate logic (#1145)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -41,7 +41,7 @@ _aixcl_complete() {
     cword=$COMP_CWORD
     
     # List of all possible commands (must stay in sync with lib/aixcl/dispatcher.sh)
-    local commands="stack service models engine utils vault help restart config"
+    local commands="stack service models engine utils vault help restart"
     
     # Service categorization per AIXCL governance model (docs/architecture/governance/00_invariants.md)
     # Runtime Core (Strict): Always enabled, required for AIXCL to function

--- a/lib/aixcl/commands/engine.sh
+++ b/lib/aixcl/commands/engine.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 # Engine management commands for AIXCL
 
+_clear_opencode_model() {
+    local opencode_config="${SCRIPT_DIR}/opencode.json"
+    if [ -f "$opencode_config" ]; then
+        if command -v jq >/dev/null 2>&1; then
+            local temp_json
+            temp_json=$(mktemp)
+            jq '.provider."aixcl-local".models = {} | .model = "aixcl-local/"' "$opencode_config" > "$temp_json" && mv "$temp_json" "$opencode_config"
+            echo "   Note: Model configuration cleared in opencode.json. Please add a model for the new engine."
+        else
+            echo "   Note: Install jq to auto-clear model config in opencode.json"
+        fi
+    fi
+}
+
 function engine() {
     local action="${1:-}"
     
@@ -82,20 +96,8 @@ function engine() {
             fi
         fi
         
-        # Clear opencode.json model when engine changes (model will need to be re-added)
-        local opencode_config="${SCRIPT_DIR}/opencode.json"
-        if [ -f "$opencode_config" ]; then
-            if command -v jq >/dev/null 2>&1; then
-                local temp_json
-                temp_json=$(mktemp)
-                # Clear the models dictionary - user will need to add a model for the new engine
-                jq '.provider."aixcl-local".models = {} | .model = "aixcl-local/"' "$opencode_config" > "$temp_json" && mv "$temp_json" "$opencode_config"
-                echo "   Note: Model configuration cleared in opencode.json. Please add a model for the new engine."
-            else
-                echo "   Note: Install jq to auto-clear model config in opencode.json"
-            fi
-        fi
-        
+        _clear_opencode_model
+
         echo "Note: Restart the stack for the change to take effect:"
         echo "  ./aixcl stack restart"
     elif [ "$action" = "auto" ]; then
@@ -134,20 +136,8 @@ function engine() {
             echo "[x] Open WebUI Ollama API disabled (using OpenAI-compatible API)"
         fi
         
-        # Clear opencode.json model when engine changes (model will need to be re-added)
-        local opencode_config="${SCRIPT_DIR}/opencode.json"
-        if [ -f "$opencode_config" ]; then
-            if command -v jq >/dev/null 2>&1; then
-                local temp_json
-                temp_json=$(mktemp)
-                # Clear the models dictionary - user will need to add a model for the new engine
-                jq '.provider."aixcl-local".models = {} | .model = "aixcl-local/"' "$opencode_config" > "$temp_json" && mv "$temp_json" "$opencode_config"
-                echo "   Note: Model configuration cleared in opencode.json. Please add a model for the new engine."
-            else
-                echo "   Note: Install jq to auto-clear model config in opencode.json"
-            fi
-        fi
-        
+        _clear_opencode_model
+
         echo "Note: Restart the stack for the change to take effect:"
         echo "  ./aixcl stack restart"
     else

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -4,6 +4,38 @@
 # Container name for Open WebUI - must match docker-compose service name
 readonly CONTAINER_NAME="open-webui"
 
+_print_stopped_status() {
+    local profile="$1"
+    echo ""
+    echo "AIXCL Stack Stopped"
+    echo "==================="
+    echo ""
+    echo "Profile: $profile"
+    echo "Status: Stopped"
+    echo ""
+    echo "Services"
+    echo "--------------------------------------------------"
+    echo ""
+    echo "Runtime Core"
+    for service in "${RUNTIME_CORE_SERVICES[@]}"; do
+        echo "  ❌ $service"
+    done
+    echo ""
+    echo "Operational Services"
+    local profile_services
+    profile_services=$(get_profile_services "$profile" 2>/dev/null) || true
+    for service in $profile_services; do
+        local is_core=false
+        for core in "${RUNTIME_CORE_SERVICES[@]}"; do
+            [ "$service" = "$core" ] && is_core=true && break
+        done
+        [ "$is_core" = true ] && continue
+        echo "  ❌ $service"
+    done
+    echo ""
+    echo "All services have been stopped."
+}
+
 function ensure_databases() {
     # Ensure required databases exist (webui)
     # This function is idempotent - it won't fail if databases already exist
@@ -277,11 +309,7 @@ function start() {
                 # Update or add PROFILE in .env file
                 if grep -qE "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null; then
                     # Update existing PROFILE line
-                    if [[ "$(uname)" == "Darwin" ]]; then
-                        sed -i '' "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
-                    else
-                        sed -i "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
-                    fi
+                    sed -i "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
                 else
                     # Add PROFILE line at the end
                     {
@@ -295,7 +323,7 @@ function start() {
         fi
     fi
     
-    echo "Starting Docker Compose deployment with profile: $profile"
+    echo "Starting services with profile: $profile"
     print_profile_info "$profile"
     
     # Check for .env file and restore from backup or create from .env.example if missing
@@ -653,35 +681,7 @@ function stop() {
     local all_services_pattern
     all_services_pattern=$(IFS="|"; echo "${ALL_SERVICES[*]}")
     if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "$CONTAINER_NAME|$all_services_pattern"; then
-        # Services already stopped - show status
-        echo ""
-        echo "AIXCL Stack Stopped"
-        echo "==================="
-        echo ""
-        echo "Profile: $profile"
-        echo "Status: Stopped"
-        echo ""
-        echo "Services"
-        echo "--------------------------------------------------"
-        echo ""
-        echo "Runtime Core"
-        for service in "${RUNTIME_CORE_SERVICES[@]}"; do
-            echo "  ❌ $service"
-        done
-        echo ""
-        echo "Operational Services"
-        local profile_services
-        profile_services=$(get_profile_services "$profile" 2>/dev/null) || true
-        for service in $profile_services; do
-            local is_core=false
-            for core in "${RUNTIME_CORE_SERVICES[@]}"; do
-                [ "$service" = "$core" ] && is_core=true && break
-            done
-            [ "$is_core" = true ] && continue
-            echo "  ❌ $service"
-        done
-        echo ""
-        echo "All services have been stopped."
+        _print_stopped_status "$profile"
         return 0
     fi
     
@@ -692,34 +692,7 @@ function stop() {
     echo "Waiting for containers to stop..."
     for i in {1..30}; do
         if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "$CONTAINER_NAME|$all_services_pattern"; then
-            echo ""
-            echo "AIXCL Stack Stopped"
-            echo "==================="
-            echo ""
-            echo "Profile: $profile"
-            echo "Status: Stopped"
-            echo ""
-            echo "Services"
-            echo "--------------------------------------------------"
-            echo ""
-            echo "Runtime Core"
-            for service in "${RUNTIME_CORE_SERVICES[@]}"; do
-                echo "  ❌ $service"
-            done
-            echo ""
-            echo "Operational Services"
-            local profile_services
-            profile_services=$(get_profile_services "$profile" 2>/dev/null) || true
-            for service in $profile_services; do
-                local is_core=false
-                for core in "${RUNTIME_CORE_SERVICES[@]}"; do
-                    [ "$service" = "$core" ] && is_core=true && break
-                done
-                [ "$is_core" = true ] && continue
-                echo "  ❌ $service"
-            done
-            echo ""
-            echo "All services have been stopped."
+            _print_stopped_status "$profile"
             return 0
         fi
         echo "Waiting for services to stop... ($i/15)"
@@ -730,35 +703,8 @@ function stop() {
     run_compose down --remove-orphans -v
     "${DOCKER_BIN:-docker}" ps -q | xargs -r "${DOCKER_BIN:-docker}" stop
     
-    echo ""
-    echo "AIXCL Stack Stopped"
-    echo "==================="
-    echo ""
-    echo "Profile: $(get_profile_services "$profile" 2>/dev/null || echo 'N/A')"
-    echo "Status: Stopped"
-    echo ""
-    echo "Services"
-    echo "--------------------------------------------------"
-    echo ""
-    echo "Runtime Core"
-    for service in "${RUNTIME_CORE_SERVICES[@]}"; do
-        echo "  ❌ $service"
-    done
-    echo ""
-    echo "Operational Services"
-    local profile_services
-    profile_services=$(get_profile_services "$profile" 2>/dev/null) || true
-    for service in $profile_services; do
-        local is_core=false
-        for core in "${RUNTIME_CORE_SERVICES[@]}"; do
-            [ "$service" = "$core" ] && is_core=true && break
-        done
-        [ "$is_core" = true ] && continue
-        echo "  ❌ $service"
-    done
-    echo ""
-    echo "All services have been stopped."
-    
+    _print_stopped_status "$profile"
+
     # Clean up pgAdmin configuration file for security
     if [ -f "pgadmin-servers.json" ]; then
         rm -f pgadmin-servers.json
@@ -902,11 +848,7 @@ function restart() {
                 # Update or add PROFILE in .env file
                 if grep -qE "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null; then
                     # Update existing PROFILE line
-                    if [[ "$(uname)" == "Darwin" ]]; then
-                        sed -i '' "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
-                    else
-                        sed -i "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
-                    fi
+                    sed -i "s/^[[:space:]]*PROFILE[[:space:]]*=.*/PROFILE=$profile/" "$env_file"
                 else
                     # Add PROFILE line at the end
                     {

--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -69,15 +69,19 @@ ALL_SERVICES=(
     "pgadmin"
     "prometheus"
     "grafana"
+    "alertmanager"
     "cadvisor"
     "node-exporter"
     "postgres-exporter"
     "nvidia-gpu-exporter"
     "loki"
     "vault"
+    "vault-agent-postgres"
+    "vault-agent-openwebui"
     "vault-agent-postgres-bootstrap"
     "vault-agent-openwebui-bootstrap"
     "vault-agent-pgadmin-bootstrap"
+    "vault-agent-grafana-bootstrap"
 )
 
 # Function to validate service name
@@ -117,7 +121,7 @@ get_container_name() {
 }
 
 # Detect if NVIDIA GPU is available (hardware OR toolkit OR runtime)
- has_nvidia() {
+has_nvidia() {
      # Check for NVIDIA hardware via nvidia-smi
      if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
          return 0
@@ -150,8 +154,8 @@ get_container_name() {
      return 1
  }
  
- # Check for NVIDIA Container Toolkit (specifically for GPU monitoring)
- has_nvidia_container_toolkit() {
+# Check for NVIDIA Container Toolkit (specifically for GPU monitoring)
+has_nvidia_container_toolkit() {
      # Check for NVIDIA Container Toolkit CLI (primary method)
      if command -v nvidia-ctk >/dev/null 2>&1; then
          return 0

--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -22,9 +22,7 @@ if [[ ! "$COMPOSE_FILE" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$COMPOSE_FILE" =~ \.\. ]
     exit 1
 fi
 
-# Default compose command (before set_compose_cmd detects GPU/ARM overrides)
-# Initialize with a basic command that will be updated by set_compose_cmd
-COMPOSE_CMD=(docker-compose -f "${SERVICES_DIR}/${COMPOSE_FILE}")
+COMPOSE_CMD=()
 COMPOSE_WORKDIR="${SERVICES_DIR}"
 
 # Build docker-compose command with optional GPU and ARM overrides if present


### PR DESCRIPTION
Fixes audit findings from #1145 and #1146: removes macOS dead code, fixes ALL_SERVICES missing entries, strips leading whitespace from function defs, clears stale COMPOSE_CMD init, fixes profile display bug, removes deprecated config command from completion, extracts duplicate stop() status block into _print_stopped_status(), and extracts duplicate opencode.json clearing into _clear_opencode_model().