### PR TITLE
Gitignore opencode.json and ship vanilla config template (#1154)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ build/
 opencode/config.json
 !opencode/config.json.example
 
+# OpenCode runtime config (models added via `aixcl` CLI; template at config/opencode.json.example)
+opencode.json
+
 # System files
 Thumbs.db
 ehthumbs.db

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,7 +24,15 @@ This checks:
 
 ## 2. Start OpenCode
 
-Navigate to your repository and start OpenCode:
+`./aixcl stack init` (run during setup) creates `opencode.json` from `config/opencode.json.example`
+and pre-configures the AIXCL local provider. Add a model before starting OpenCode so the provider
+has something to connect to:
+
+```bash
+./aixcl models add qwen2.5-coder:0.5b
+```
+
+Then start OpenCode:
 
 ```bash
 cd /path/to/aixcl

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Or run each step manually:
 
 ```bash
 ./aixcl utils check-env          # Verify environment prerequisites
-./aixcl stack init               # Generate .env, credentials and Vault secrets (one-time)
+./aixcl stack init               # Generate .env, opencode.json, credentials and Vault secrets (one-time)
 ./aixcl stack start --profile sys  # Start the full stack
 
 # Wait for healthy status (about 2-3 minutes for full stabilization)
@@ -150,8 +150,12 @@ Vault initializes automatically during stack startup. The process takes 2-3 minu
 
 **B. Via OpenCode CLI**
 
+`opencode.json` is created from `config/opencode.json.example` by `stack init`. It pre-configures
+the `aixcl-local` provider pointing at the Ollama endpoint (`http://localhost:11434/v1`). Models
+are registered into it automatically when you run `./aixcl models add`.
+
 ```bash
-# Add the model (for local provider)
+# Add the model (registers it in opencode.json and pulls it via Ollama)
 ./aixcl models add qwen2.5-coder:0.5b
 
 # Start OpenCode

--- a/config/README.md
+++ b/config/README.md
@@ -7,6 +7,7 @@ This directory contains configuration files for AIXCL.
 ```
 config/
 ├── .env.example           # Template for environment variables
+├── opencode.json.example  # Template for OpenCode AI configuration
 ├── README.md              # This file
 └── profiles/
     ├── bld.env            # Observability-focused profile
@@ -20,6 +21,18 @@ Template for environment configuration. Copy this to `.env` in the project root:
 
 ```bash
 cp config/.env.example .env
+```
+
+### opencode.json.example
+Template for OpenCode configuration. Defines the AIXCL local provider pointing to the Ollama
+OpenAI-compatible endpoint. The live `opencode.json` is gitignored because `./aixcl models add`
+writes model entries into it at runtime.
+
+`./aixcl stack init` copies this file to `opencode.json` automatically on first run. To reset
+a customised config back to the vanilla state:
+
+```bash
+cp config/opencode.json.example opencode.json
 ```
 
 ### profiles/*.env

--- a/config/opencode.json.example
+++ b/config/opencode.json.example
@@ -5,7 +5,6 @@
   "snapshot": true,
   "share": "manual",
   "autoupdate": "notify",
-  "username": "sbadakhc",
   "watcher": {
     "ignore": [
       "node_modules/",
@@ -60,11 +59,7 @@
       "options": {
         "baseURL": "http://localhost:11434/v1"
       },
-      "models": {
-        "Qwen/Qwen2.5-Coder-0.5B-Instruct": {
-          "name": "Qwen/Qwen2.5-Coder-0.5B-Instruct"
-        }
-      }
+      "models": {}
     }
   }
 }

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -135,6 +135,18 @@ function init_stack() {
         fi
     fi
 
+    # Create opencode.json from example if not exists
+    local opencode_file="${SCRIPT_DIR}/opencode.json"
+    local opencode_example="${SCRIPT_DIR}/config/opencode.json.example"
+    if [ ! -f "$opencode_file" ]; then
+        if [ -f "$opencode_example" ]; then
+            cp "$opencode_example" "$opencode_file"
+            echo "Created opencode.json from config/opencode.json.example"
+        else
+            echo "Warning: config/opencode.json.example not found, skipping opencode.json creation"
+        fi
+    fi
+
     # Load current values
     load_env_file "$env_file"
 


### PR DESCRIPTION
Fixes #1154

## Summary
- Rename opencode.json to config/opencode.json.example with vanilla AIXCL provider config
- Remove hardcoded model entry and username from shipped config
- Add opencode.json to .gitignore so runtime model additions are never tracked
- Wire stack init to copy config/opencode.json.example on first run
- Update config/README.md, README.md, and QUICKSTART.md

## Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

## PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:runtime-core
- [x] Title Format: description (#1154) with no colons

## Testing Notes
- Verified opencode.json no longer appears in git status after model additions
- config/opencode.json.example contains only the aixcl-local provider with baseURL and empty models
- stack init wired to copy example on first run, matching .env.example pattern

## Verification
- [x] Behavior works as expected
- [x] No regressions observed

## Related Issues
- Closes #1154
