### PR TITLE
Fix vault_status jq treats false as unreachable breaking vault passwords and credentials (#1159)

### DIFF
--- a/scripts/vault/vault-commands.sh
+++ b/scripts/vault/vault-commands.sh
@@ -28,7 +28,7 @@ vault_status() {
     health_response=$(curl -sf "${VAULT_ADDR}/v1/sys/health?sealedok=true&uninitok=true" 2>/dev/null || echo '{}')
 
     local sealed
-    sealed=$(echo "$health_response" | jq -r '.sealed // "unreachable"')
+    sealed=$(echo "$health_response" | jq -r 'if has("sealed") then (.sealed | tostring) else "unreachable" end')
 
     case "$sealed" in
         "false")


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1159

### Description of Changes
jq's \`//\` alternative operator returns the right-hand side when the left side is \`false\` or \`null\`. \`.sealed\` is \`false\` when Vault is unsealed, so \`.sealed // "unreachable"\` always evaluated to \`"unreachable"\`. This caused \`vault_status\` to always exit 1, silently killing \`vault passwords\` and \`vault credentials\` before they ran.

Fixed by replacing \`.sealed // "unreachable"\` with \`if has("sealed") then (.sealed | tostring) else "unreachable" end\` -- correctly distinguishing a \`false\` value from a missing key.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:cli, component:runtime-core
- [x] **Title Format**: \`fix vault_status jq treats false as unreachable breaking vault passwords and credentials (#1159)\`

### Testing Notes
Reproduce: \`\`\`bash ./aixcl vault passwords   # returned exit 1 with no output ./aixcl vault credentials # same silent failure \`\`\` Root cause confirmed via debug script -- \`vault_status\` received valid JSON with \`sealed: false\` but jq returned \`"unreachable"\` due to the \`//\` operator treating \`false\` as falsy.

After fix: \`\`\`bash ./aixcl vault passwords   # shows bootstrap passwords from Vault KV ./aixcl vault credentials # shows dynamic database credentials \`\`\`

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1159
