### PR TITLE
Add rootless Podman verification to check-env target (#1181)

### DIFF
--- a/lib/core/env_check.sh
+++ b/lib/core/env_check.sh
@@ -49,6 +49,15 @@ check_env() {
 
     # Check for rootless mode
     if [ $engine_found -eq 1 ]; then
+        # Explicit diagnostic for Podman (mirrors README manual verification step)
+        if command -v podman &> /dev/null; then
+            local rootless_info
+            rootless_info=$(podman info 2>/dev/null | grep "rootless" || true)
+            if [ -n "$rootless_info" ]; then
+                print_info "Podman rootless status: $rootless_info"
+            fi
+        fi
+
         if is_rootless; then
             print_success "Rootless container engine detected (Enhanced Security)"
         else


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1181

### Description of Changes
Adds an explicit rootless Podman diagnostic step to `./aixcl utils check-env`. When Podman is detected, the script now displays `podman info | grep "rootless"` output so users can see the actual `rootless: true/false` value directly in the environment check output. This mirrors the manual verification step documented in README.md (lines 71-76) and makes the automated check self-diagnosing.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-1181/add-rootless-verification-to-check-env`)
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: `component:cli`
- [x] **Title Format**: No colons

### Testing Notes
- Ran `./aixcl utils check-env` locally in both rootless and rootful Podman environments.
- Verified that `Podman rootless status: rootless: true` (or `false`) appears in the output before the existing `is_rootless()` check result.
- Confirmed no regressions in Docker-only environments (new block is guarded by `command -v podman`).

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Minimal, focused change scoped to `lib/core/env_check.sh` only

### Related Issues
- Closes #1181
