### PR TITLE
Fix vault_passwords empty output due to jq false handling (#1229)

### DIFF
--- a/scripts/vault/vault-commands.sh
+++ b/scripts/vault/vault-commands.sh
@@ -28,7 +28,7 @@ vault_status() {
     health_response=$(curl -sf "${VAULT_ADDR}/v1/sys/health?sealedok=true&uninitok=true" 2>/dev/null || echo '{}')
 
     local sealed
-    sealed=$(echo "$health_response" | jq -r '.sealed // "unreachable"')
+    sealed=$(echo "$health_response" | jq -r 'if has("sealed") then (.sealed | tostring) else "unreachable" end')
 
     case "$sealed" in
         "false")


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1229

Fix vault_passwords empty output due to jq treating JSON false as falsy

### Description of Changes

Changed the jq query in `vault_status()` from:
```bash
jq -r '.sealed // "unreachable"'
```
to:
```bash
jq -r 'if has("sealed") then (.sealed | tostring) else "unreachable" end'
```

This fixes a bug where `vault_status()` always returned 1 (error) when Vault was actually unsealed, because jq's `//` operator treats `false` as a falsy value and falls through to `"unreachable"`.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-1229/fix-vault-jq-false`)
- [x] Commit messages follow conventional style (`fix: ...`)
- [x] All tests run and pass (17/17 CI checks green)

### Testing Notes

Tested locally on Ubuntu 22.04 (WSL2):

- Verified Vault returns `"sealed": false` via API
- Confirmed `vault_passwords` now displays bootstrap passwords
- Confirmed `vault_credentials` now displays dynamic DB credentials
- Confirmed `vault_status` correctly reports unsealed state
- Verified commands still fail gracefully when Vault is actually unreachable

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1229
