### PR TITLE
revert email defaults to admin@example.com for service compatibility (#1243)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -89,7 +89,7 @@ jobs:
           POSTGRES_DATABASE=webui
 
           # PGAdmin configuration
-          PGADMIN_EMAIL=admin@test.com
+          PGADMIN_EMAIL=admin@example.com
           PGADMIN_PASSWORD=test
 
           # Open WebUI configuration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
           POSTGRES_USER=admin
           POSTGRES_PASSWORD=test
           POSTGRES_DATABASE=webui
-          PGADMIN_EMAIL=admin@test.com
+          PGADMIN_EMAIL=admin@example.com
           PGADMIN_PASSWORD=test
           GRAFANA_ADMIN_USER=admin
           GRAFANA_ADMIN_PASSWORD=test

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ curl http://localhost:11434/v1/chat/completions \
 | Service | URL | Login |
 |---------|-----|-------|
 | Open WebUI | http://localhost:8080 | Username: `admin`, Password: `./aixcl vault passwords` |
-| pgAdmin | http://localhost:5050 | Email: `pgadmin@admin.com`, Password: `./aixcl vault passwords` |
+| pgAdmin | http://localhost:5050 | Email: `admin@example.com`, Password: `./aixcl vault passwords` |
 | Grafana | http://localhost:3000 | Username: `admin`, Password: `./aixcl vault passwords` |
 | Vault UI | http://localhost:8200 | Token: `VAULT_DEV_TOKEN` env var |
 | Prometheus | http://localhost:9090 | No auth (localhost only) |

--- a/scripts/security/init-secrets.sh
+++ b/scripts/security/init-secrets.sh
@@ -28,9 +28,9 @@ NC='\033[0m' # No Color
 SECRETS=(
   "postgres_user:postgres"
   "postgres_password:32"
-  "pgadmin_email:pgadmin@localhost"
+  "pgadmin_email:admin@example.com"
   "pgadmin_password:32"
-  "openwebui_email:admin@localhost"
+  "openwebui_email:admin@example.com"
   "openwebui_password:32"
   "grafana_admin_user:grafana"
   "grafana_admin_password:32"


### PR DESCRIPTION
Standardizes all email defaults to admin@example.com since localhost domains are rejected by some services during first-start validation. Updates init-secrets.sh, README.md, integration-tests.yml, documentation-checks.yml.

Fixes startup failures caused by invalid email domain formats.