### PR TITLE
consistent Vault secret wait loops for grafana and pgAdmin (#1244)

### DIFF
--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # grafana-entrypoint.sh — Grafana entrypoint wrapper
-# On first start: sets initial admin password from Vault
+# On first start: waits for Vault secret, then sets initial admin password
 # On restart: skips password reset, respecting user changes
-# Never falls back to hardcoded defaults; fails fast if Vault secret missing
+# Never falls back to hardcoded defaults; waits up to 60s for Vault secret
 set -euo pipefail
 
 echo "=== Grafana Vault-Secure Entrypoint ==="
@@ -23,12 +23,20 @@ if [ "$IS_FIRST_START" = false ]; then
     exec /run.sh
 fi
 
-# --- First-start: require Vault password ---
-if [ -f /run/secrets/grafana-password ] && [ -s /run/secrets/grafana-password ]; then
-    GRAFANA_ADMIN_PASSWORD="$(tr -d '\n' < /run/secrets/grafana-password)"
-    echo "[Vault] Grafana admin password loaded from /run/secrets/grafana-password"
-else
-    echo "[Vault] ERROR: /run/secrets/grafana-password not found or empty."
+# --- First-start: wait for Vault password ---
+GRAFANA_ADMIN_PASSWORD=""
+for i in $(seq 1 60); do
+    if [ -f /run/secrets/grafana-password ] && [ -s /run/secrets/grafana-password ]; then
+        GRAFANA_ADMIN_PASSWORD="$(tr -d '\n' < /run/secrets/grafana-password)"
+        echo "[Vault] Grafana admin password loaded from /run/secrets/grafana-password"
+        break
+    fi
+    echo "[Vault] Waiting for grafana-password secret... ($i/30)"
+    sleep 2
+done
+
+if [ -z "$GRAFANA_ADMIN_PASSWORD" ]; then
+    echo "[Vault] ERROR: /run/secrets/grafana-password not found or empty after 60 seconds."
     echo "  Cannot create initial admin on first start without Vault-generated password."
     echo "  Ensure Vault is initialized and bootstrap has run."
     exit 1

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # pgAdmin entrypoint wrapper
-# On first start: creates initial admin from Vault secrets
+# On first start: waits for Vault secret, then creates initial admin
 # On restart: skips all admin creation, preserves user changes
-# Never falls back to hardcoded defaults; fails fast if secrets missing
+# Never falls back to hardcoded defaults; waits up to 60s for Vault secret
 set -euo pipefail
 
 echo "=== pgAdmin Non-Root Entrypoint ==="
@@ -80,12 +80,19 @@ fi
 
 # Admin password: only from Vault (no env, no fallback)
 PGADMIN_DEFAULT_PASSWORD=""
-if [ -f /run/secrets/pgadmin-password ] && [ -s /run/secrets/pgadmin-password ]; then
-    PGADMIN_DEFAULT_PASSWORD="$(tr -d '\n' < /run/secrets/pgadmin-password)"
-    export PGADMIN_DEFAULT_PASSWORD
-    echo "[Vault] pgAdmin password loaded from /run/secrets/pgadmin-password"
-else
-    echo "[Vault] ERROR: /run/secrets/pgadmin-password not found or empty"
+for i in $(seq 1 60); do
+    if [ -f /run/secrets/pgadmin-password ] && [ -s /run/secrets/pgadmin-password ]; then
+        PGADMIN_DEFAULT_PASSWORD="$(tr -d '\n' < /run/secrets/pgadmin-password)"
+        export PGADMIN_DEFAULT_PASSWORD
+        echo "[Vault] pgAdmin password loaded from /run/secrets/pgadmin-password"
+        break
+    fi
+    echo "[Vault] Waiting for pgadmin-password secret... ($i/30)"
+    sleep 2
+done
+
+if [ -z "$PGADMIN_DEFAULT_PASSWORD" ]; then
+    echo "[Vault] ERROR: /run/secrets/pgadmin-password not found or empty after 60 seconds"
     echo "  Cannot create initial admin on first start without Vault-generated password."
     exit 1
 fi


### PR DESCRIPTION
Grafana and pgAdmin previously failed fast when Vault bootstrap secrets were not yet written to the shared volume, while postgres, open-webui, and postgres-exporter already polled for 60 seconds.

Changes:
- Added 60-second wait-and-retry loops to grafana-entrypoint.sh and pgadmin-entrypoint.sh
- Updated file headers to reflect the new wait behavior
- All Vault-dependent services now use the same resilient startup pattern

Fixes startup race condition on fresh deployments.