### PR TITLE
document Vault unseal requirement after stack restart (#1248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ Vault initializes automatically during stack startup. The process takes 2-3 minu
 ./aixcl vault passwords
 ```
 
+**Important:** Vault auto-seals whenever its container restarts (e.g. after `./aixcl stack stop` or host reboot). If services fail to start, unseal Vault first:
+
+```bash
+# Unseal Vault after every stack restart
+./aixcl vault unseal
+
+# Wait 30 seconds for bootstrap agents, then verify
+./aixcl stack status
+```
+
 ### Step 5: Test Inference (Hello World)
 
 **A. Via Open WebUI (Browser)**


### PR DESCRIPTION
Adds explicit documentation in README Step 4 explaining that Vault auto-seals on container restart and must be manually unsealed before services can authenticate.

Fixes developer friction observed during v1.1.21 VM testing where stack services failed to start because bootstrap agents could not read from a sealed Vault.

Changes:
- Added warning callout after Step 4 vault status check
- Included [INFO] Vault is sealed — decrypting key shares... [INFO] Submitting key shares 1, 2, 3... [INFO] Vault unsealed successfully command example
- Explained why (Shamir's Secret Sharing in dev mode)
