### PR TITLE
[FIX] Disable pgAdmin server mode to prevent login prompt on every session (#1260)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -355,6 +355,8 @@ services:
       PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
       PGADMIN_USER_ID: "5050"
       PGADMIN_GROUP_ID: "5050"
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
     volumes:
       - aixcl-pgadmin-storage:/var/lib/pgadmin/storage
       - aixcl-pgadmin-main:/var/lib/pgadmin


### PR DESCRIPTION
## Problem

pgAdmin defaults to server mode, which requires an email/password login on every browser session. For local single-user AIXCL deployments this is pure friction — there is no security benefit.

## Fix

Add two environment variables to the pgadmin service:

```yaml
PGADMIN_CONFIG_SERVER_MODE: "False"
PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
```

This runs pgAdmin in desktop mode: direct access to the database UI with no login screen. Once in, all server connections and credentials continue to work as normal via Vault.

## Scope

Safe for all local deployments. Does not affect postgres authentication — only the pgAdmin web UI login layer.