### PR TITLE
Treat HTTP 401 as healthy for auth-required services (#1261)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1387,7 +1387,7 @@ function status() {
                 display_status="${ICON_SUCCESS:-✅}"
                 is_healthy=true
             else
-                if [ "$health_result" = "200" ] || [ "$health_result" = "302" ] || [ "$health_result" = "307" ] || [ "$health_result" = "healthy" ]; then
+                if [ "$health_result" = "200" ] || [ "$health_result" = "302" ] || [ "$health_result" = "307" ] || [ "$health_result" = "401" ] || [ "$health_result" = "healthy" ]; then
                     display_status="${ICON_SUCCESS:-✅}"
                     is_healthy=true
                 elif [ "$health_result" = "503" ] || [ "$health_result" = "starting" ] || [ "$health_result" = "000" ]; then


### PR DESCRIPTION
Fixes #1261

## Summary
After desktop mode change (#1259), pgAdmin returns 401 on root path because authentication is required. The status() function previously flagged 401 as unhealthy, causing false alarms in ./aixcl stack status.

## Changes
- Added HTTP 401 to the list of acceptable healthy status codes in check_service_status()

## Testing Notes
- Verified on local sys profile deployment with pgAdmin desktop mode enabled
- ./aixcl stack status now shows pgAdmin as healthy
- Browser access to http://localhost:5050 continues to work correctly

## Verification
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] ShellCheck passes on modified file
- [x] Behavior works as expected
- [x] No regressions observed ▣ AIXCL Context Agent · kimi-k2.6 · 6.1s
