### PR TITLE
Replace fragile JSON assertion with round-trip verification (#1263)

### DIFF
--- a/tests/security/test_openwebui_json.sh
+++ b/tests/security/test_openwebui_json.sh
@@ -13,7 +13,7 @@ echo "Testing security of JSON generation fallback..."
 # Mock variables with special characters that would break simple string interpolation
 # or cause injection if not properly escaped.
 # shellcheck disable=SC2089
-OPENWEBUI_EMAIL='admin@localhost"}'
+OPENWEBUI_EMAIL='admin@example.com"}'
 # shellcheck disable=SC2089
 OPENWEBUI_PASSWORD='password" --payload "injection'
 # shellcheck disable=SC2090
@@ -40,21 +40,21 @@ else
     exit 1
 fi
 
-# Check if injection characters are escaped
-# The email 'admin@localhost"}' should be escaped as "admin@localhost\"}"
-if [[ "$PAYLOAD" == *"admin@localhost\"}"* ]] || [[ "$PAYLOAD" == *"admin@localhost\"}"* ]]; then
-    if echo "$PAYLOAD" | grep -q 'admin@localhost\"}'; then
-        echo -e "${GREEN}PASS: Special characters escaped${NC}"
-    elif echo "$PAYLOAD" | grep -q 'admin@localhost"}'; then
-        echo -e "${GREEN}PASS: JSON is valid (implies escaping)${NC}"
-    else
-        echo -e "${RED}FAIL: Payload content mismatch${NC}"
-        exit 1
-    fi
+# Check if special characters survive JSON round-trip
+# This is the correct security test: can malicious payloads be serialized to JSON
+# and deserialized back to their exact original values?
+parsed_email=$(python3 -c "import json, sys; print(json.loads(sys.argv[1])['email'])" "$PAYLOAD")
+parsed_password=$(python3 -c "import json, sys; print(json.loads(sys.argv[1])['password'])" "$PAYLOAD")
+
+if [ "$parsed_email" = "admin@example.com\"}" ] && [ "$parsed_password" = 'password" --payload "injection' ]; then
+    echo -e "${GREEN}PASS: Special characters preserved through JSON round-trip${NC}"
 else
-     echo -e "${RED}FAIL: Special characters not properly handled${NC}"
-     echo "Payload: $PAYLOAD"
-     exit 1
+    echo -e "${RED}FAIL: Values corrupted during JSON generation${NC}"
+    echo "  Expected email:    admin@example.com\"}"
+    echo "  Got email:         $parsed_email"
+    echo "  Expected password: password\" --payload \"injection"
+    echo "  Got password:      $parsed_password"
+    exit 1
 fi
 
 echo "Testing empty variables behavior (Issue: null vs empty string)..."


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1263

### Description of Changes
Replaced fragile shell glob pattern matching in `test_openwebui_json.sh` with a robust JSON round-trip verification. The old test used `[[ "\$PAYLOAD" == *...* ]]` which fails when jq emits JSON in a different field order. The new test parses the generated JSON with Python and asserts the exact deserialized values match the original inputs.

Also updated the test email from `admin@localhost` to `admin@example.com` as a best-practice hardening measure.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:testing
- [x] **Title Format**: No colons

### Testing Notes
- Ran `./tests/security/test_openwebui_json.sh` locally -- all 3 assertions pass
- Verified JSON payload validity with Python json.loads
- Verified round-trip fidelity: email and password survive serialization and deserialization unchanged

### Verification
- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1263
