### PR TITLE
Fix Prometheus Ollama port and remove phantom Open WebUI exporter (#1266)

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -50,11 +50,11 @@ scrape_configs:
           database: 'aixcl'
 
   # Ollama - LLM Engine
-  # Uses custom exporter on port 11435 that polls Ollama API
-  # Provides model info, version, and availability metrics
+  # Native Prometheus metrics at /metrics on main port 11434
+  # (requires OLLAMA_METRICS=1 in docker-compose.yml)
   - job_name: 'ollama'
     static_configs:
-      - targets: ['localhost:11435']
+      - targets: ['localhost:11434']
         labels:
           service: 'ollama'
 
@@ -91,13 +91,13 @@ scrape_configs:
         labels:
           service: 'alertmanager'
 
-  # Open WebUI - User interface metrics
-  # Uses custom exporter on port 11436
-  - job_name: 'open-webui'
-    static_configs:
-      - targets: ['localhost:11436']
-        labels:
-          service: 'open-webui'
+  # Open WebUI - no native Prometheus metrics endpoint
+  # Container-level metrics available via cAdvisor
+  # - job_name: 'open-webui'
+  #   static_configs:
+  #     - targets: ['localhost:8080']
+  #       labels:
+  #         service: 'open-webui'
 
   # Blackbox HTTP probes - UP/DOWN for services without native /metrics
   - job_name: 'blackbox-http'


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1266

### Description of Changes
Corrected Prometheus scrape configuration to fix two broken jobs:

1. **Ollama port**: Changed target from `localhost:11435` to `localhost:11434`. Port 11435 has no exporter — Ollama exposes native Prometheus metrics at `/metrics` on its main port 11434 when `OLLAMA_METRICS=1` is set.

2. **Open WebUI**: Commented out the `open-webui` job. No native Prometheus endpoint exists for Open WebUI. Container-level metrics are already covered by the cAdvisor scrape job.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] ShellCheck passes on modified files

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:observability
- [x] **Title Format**: No colons

### Testing Notes
- Verified prometheus.yml syntax is valid
- Confirmed localhost:11434 is Ollama's native metrics port
- Confirmed no Open WebUI exporter exists on any port

### Verification
- [x] Prometheus targets page shows Ollama at 11434 as UP (when metrics enabled)
- [x] No scrape errors for port 11435 or 11436
- [x] CI Docker Compose validation passes

### Related Issues
- Closes #1266
