### PR TITLE
Fix stack start pulling all service images regardless of active profile (#1274)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -543,7 +543,7 @@ function start() {
     fi
 
     echo "Pulling latest images..."
-    run_compose pull
+    run_compose pull "${profile_services[@]}"
     
     # Initialize external volumes if they don't exist
     # This ensures volumes are created before services try to use them


### PR DESCRIPTION
Fixes #1274

## Summary

One-line fix to pass the active profile's service list to `run_compose pull`, preventing images for unused services from being downloaded on every fresh installation.

### Description of Changes

In `lib/aixcl/commands/stack.sh`, `run_compose pull` was called without arguments, causing Docker/Podman to pull all images defined in `services/docker-compose.yml` regardless of the active profile. This meant vLLM (~4.5GB) and llama.cpp (~2.8GB) were downloaded even when running with the Ollama engine.

The fix passes `"${profile_services[@]}"` to `run_compose pull`, matching the existing behaviour of `run_compose up` on the following line.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1274/fix-stack-pull-profile)
- [x] Commit message follows conventional style
- [x] One-line change, minimal scope
- [x] check-paths.sh passes
- [x] check-generated-files.sh passes
- [x] ShellCheck passes (0.11.0)
- [x] bash -n syntax check passes

### Testing Notes

- Verified locally that `stack start --profile sys` with Ollama engine no longer attempts to pull vLLM or llama.cpp images
- `run_compose up` already used this pattern correctly -- fix aligns pull with up

### Verification

- [x] Fresh install with `--profile sys` and Ollama engine does not pull vLLM or llama.cpp
- [x] All profile services pull and start successfully
- [x] CI checks pass

### Related Issues

- Closes #1274
