### PR TITLE
Fix Vault auto-init engine detection when Podman and Docker both installed (#1275)

### DIFF
--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -85,13 +85,17 @@ load_vault_token() {
 # ---------------------------------------------------------------------------
 
 is_vault_running() {
-    if command -v podman >/dev/null 2>&1; then
-        podman ps --format "{{.Names}}" | grep -q "^vault$"
-    elif command -v docker >/dev/null 2>&1; then
-        docker ps --format "{{.Names}}" | grep -q "^vault$"
-    else
-        return 1
+    local bin="${DOCKER_BIN:-}"
+    if [ -z "$bin" ]; then
+        if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+            bin="podman"
+        elif command -v docker >/dev/null 2>&1; then
+            bin="docker"
+        else
+            return 1
+        fi
     fi
+    "$bin" ps --format "{{.Names}}" | grep -q "^vault$"
 }
 
 # Returns true if the Vault HTTP API is responding (even when sealed/uninitialized)


### PR DESCRIPTION
Fixes #1275

## Summary

Fix `is_vault_running()` to use the active container engine rather than always preferring the Podman binary, which caused Vault auto-init to fail when Podman was installed alongside Docker.

### Description of Changes

`is_vault_running()` in `lib/aixcl/commands/vault-init.sh` previously checked for the Podman binary first unconditionally. If Podman was installed but Docker was managing the stack, `podman ps` returned no containers and the function incorrectly reported Vault as not running.

The fix uses `DOCKER_BIN` if already exported by `docker_utils.sh`, otherwise applies the same detection logic as `docker_utils.sh`: check Podman with `podman info` to confirm it is actually running before using it, then fall back to Docker.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly
- [x] Commit message follows conventional style
- [x] Consistent with engine detection logic in docker_utils.sh
- [x] check-paths.sh passes
- [x] check-generated-files.sh passes
- [x] ShellCheck passes (0.11.0)

### Testing Notes

- Verified fix correctly identifies Docker as active engine when Podman is installed but not managing containers
- DOCKER_BIN path ensures no redundant detection when already set by docker_utils.sh

### Verification

- [x] Vault auto-init succeeds when Podman is installed but Docker manages the stack
- [x] Vault auto-init succeeds when Podman manages the stack
- [x] No regression in Docker-only environments
- [x] CI checks pass

### Related Issues

- Closes #1275
