### PR TITLE
Fix ShellCheck version mismatch between CI and local environment (#1281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ podman --version  # Should show 4.9+
 gpg --version     # Should show 2.2+
 ```
 
+### Install ShellCheck (Development Only)
+
+ShellCheck is required for local CI parity. The Ubuntu apt package (0.9.0) is too old -- install from GitHub releases:
+
+```bash
+# Download and install ShellCheck 0.11.0
+curl -sSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz | tar -xJ -C /tmp
+sudo cp /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+sudo chmod +x /usr/local/bin/shellcheck
+
+# Verify
+shellcheck --version  # Should show 0.11.0
+```
+
+> **Note:** Only required for contributors running CI checks locally. Not needed to run the AIXCL stack.
+
 ### Step 2: Configure Podman Rootless
 
 AIXCL requires rootless Podman. Run the setup script once per machine:

--- a/scripts/checks/check-environment.sh
+++ b/scripts/checks/check-environment.sh
@@ -269,6 +269,37 @@ check_docker() {
     fi
 }
 
+# Check ShellCheck version
+check_shellcheck() {
+    info "Checking ShellCheck..."
+
+    local min_version="0.10.0"
+
+    if ! command -v shellcheck &>/dev/null; then
+        warn "shellcheck not installed (required for CI parity)"
+        info "Install v${min_version}+ from: https://github.com/koalaman/shellcheck/releases"
+        info "Ubuntu apt package is outdated -- use GitHub releases"
+        return
+    fi
+
+    local installed_version
+    installed_version=$(shellcheck --version | grep "^version:" | awk '{print $2}')
+
+    # Compare versions using sort -V
+    local min_ok
+    min_ok=$(printf '%s\n%s\n' "$min_version" "$installed_version" | sort -V | head -1)
+
+    if [ "$min_ok" = "$min_version" ]; then
+        pass "shellcheck $installed_version installed (>= $min_version required)"
+    else
+        warn "shellcheck $installed_version is below minimum $min_version"
+        info "CI uses shellcheck 0.11.0 -- older versions may miss warnings"
+        info "Install from: https://github.com/koalaman/shellcheck/releases"
+        info "Ubuntu apt package (0.9.0) is too old -- use GitHub releases"
+    fi
+}
+
+
 # Main execution
 main() {
     echo "═══════════════════════════════════════════════════════════════"
@@ -300,6 +331,7 @@ main() {
     
     # Optional checks
     check_docker
+    check_shellcheck
     
     echo ""
     echo "═══════════════════════════════════════════════════════════════"


### PR DESCRIPTION
Fixes #1281

## Summary

Add ShellCheck version validation to `check-environment.sh` and document installation of the correct version in README.md. The Ubuntu 24.04 apt package (0.9.0) is below the minimum required for CI parity with GitHub Actions (0.11.0).

### Description of Changes

- Added `check_shellcheck()` function to `scripts/checks/check-environment.sh` that warns when the installed ShellCheck version is below 0.10.0 and directs users to GitHub releases
- Added ShellCheck installation instructions to README.md Step 1 prerequisites section, clearly noting the apt package is too old and providing the correct install commands for 0.11.0
- Called `check_shellcheck()` from `main()` alongside other optional checks

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly
- [x] Commit message follows conventional style
- [x] check-paths.sh passes
- [x] check-generated-files.sh passes
- [x] ShellCheck passes (0.11.0)
- [x] No non-ASCII punctuation in markdown
- [x] No CRLF line endings

### Testing Notes

- Verified `check-environment.sh` correctly warns when ShellCheck 0.9.0 is installed
- Verified pass message shown when ShellCheck 0.11.0 is installed
- README instructions tested on Ubuntu 24.04

### Verification

- [x] `./scripts/checks/check-environment.sh` warns when ShellCheck below 0.10.0
- [x] `./scripts/checks/check-environment.sh` passes when ShellCheck 0.11.0 installed
- [x] README installation instructions work on Ubuntu 24.04
- [x] CI checks pass

### Related Issues

- Closes #1281
