### PR TITLE
Fix incorrect test email address in OpenWebUI security test (#1278)

### DIFF
--- a/tests/security/test_openwebui_json.sh
+++ b/tests/security/test_openwebui_json.sh
@@ -13,7 +13,7 @@ echo "Testing security of JSON generation fallback..."
 # Mock variables with special characters that would break simple string interpolation
 # or cause injection if not properly escaped.
 # shellcheck disable=SC2089
-OPENWEBUI_EMAIL='admin@localhost"}'
+OPENWEBUI_EMAIL='admin@example.com"}'
 # shellcheck disable=SC2089
 OPENWEBUI_PASSWORD='password" --payload "injection'
 # shellcheck disable=SC2090
@@ -55,7 +55,7 @@ try:
     password = obj.get('password', '')
     
     # Verify the original values were preserved correctly
-    expected_email = 'admin@localhost"}'
+    expected_email = 'admin@example.com"}'
     expected_password = 'password" --payload "injection'
     
     if email == expected_email and password == expected_password:


### PR DESCRIPTION
Fixes #1278

## Summary

Correct `admin@localhost` to `admin@example.com` in the Open WebUI JSON security test. This is a two-line fix correcting an invalid test email address.

### Description of Changes

In `tests/security/test_openwebui_json.sh`, the test email `admin@localhost"}` was used as both the input value and the expected value in the round-trip verification. `admin@localhost` is not a valid example email address and does not match the email used by `stack init` (`admin@example.com`).

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly
- [x] Commit message follows conventional style
- [x] ShellCheck passes
- [x] No CRLF line endings
- [x] check-paths.sh passes
- [x] check-generated-files.sh passes

### Testing Notes

- Two occurrences replaced: input variable and expected value in Python verification block
- Test logic unchanged, only the email address corrected

### Verification

- [x] Security test passes with corrected email
- [x] CI checks pass

### Related Issues

- Part of #1278
