### PR TITLE
Create CLAUDE.md and .claude/ directory for Claude Code compatibility (#1291)

### DIFF
--- a/.claude/commands/commit-pr.md
+++ b/.claude/commands/commit-pr.md
@@ -1,0 +1,52 @@
+---
+description: Commit changes and create a PR following AIXCL Issue-First workflow
+disable-model-invocation: true
+allowed-tools: Bash(git add *), Bash(git commit *), Bash(git push *), Bash(gh pr create *)
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Current status: !`git status --short`
+- Recent commits: !`git log --oneline -5`
+
+## Your Task
+
+Based on the above changes:
+
+1. **Stage all changes** (if not already staged):
+   ```bash
+   git add .
+   ```
+
+2. **Create a conventional commit**:
+   - Format: `<type>: <description> (under 72 chars)`
+   - Reference issue: `Fixes #<issue-number>`
+   - Use `./scripts/utils/create-pr.sh` wrapper if available, or craft manually
+   - Example: `feat: Add CLAUDE.md for Claude Code compatibility`
+
+3. **Push the branch to origin**:
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+4. **Create a pull request** using `gh pr create` with:
+   - Title: `<description> (#<issue-number>)` (NO colons)
+   - Body: `Fixes #<issue-number>`
+   - Assignee: set at creation time (required by `pr-validation.yml`)
+   - Label: at least one `component:*` label (required by `pr-validation.yml`)
+
+   **IMPORTANT**: Pass `--assignee` and `--label` at creation time. Do NOT create then edit. The PR Validation workflow fires on the `opened` event. If assignee/label are not present at creation, the check will fail permanently.
+
+   ```bash
+   gh pr create --title "Description (#999)" --body "Fixes #999" --assignee <username> --label "component:infrastructure"
+   ```
+
+5. **Verify CI**: Monitor GitHub Actions and ensure all checks pass before completing.
+
+## Safety Rules
+
+- `git push --force` is **DENIED**
+- `rm -rf` operations require explicit human approval
+- Always reference the issue number in commits and PRs
+- All CI checks must be green before the task is complete

--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -1,0 +1,56 @@
+# CI Checks and Compliance
+
+## Pre-Commit Checklist
+Before committing any changes, verify locally:
+
+### Shell Scripts
+- Run ShellCheck: `shellcheck --severity=warning --exclude=SC1091 <file.sh>`
+- Run syntax check: `bash -n <file.sh>`
+- Common failures: SC2034 (unused variables), SC2120 (function args), SC2086 (unquoted variables)
+
+### Markdown Files
+- No non-ASCII punctuation: no smart quotes, em dashes (--), en dashes (-), ellipsis (...), non-breaking spaces
+- Use plain ASCII equivalents: `--` for dashes, `...` for ellipsis, straight quotes
+- No CRLF line endings (use LF only)
+- No broken relative links (`./` or `../` paths must resolve)
+
+### YAML Files
+- Run: `yamllint -c .yamllint.yml <file.yml>`
+- Line length limit: 160 characters
+
+### Docker Compose Files
+- Run: `docker compose -f services/docker-compose.yml config > /dev/null`
+
+## PR Requirements (ALL must be set at creation time)
+```bash
+gh pr create \
+  --title "<description> (#<number>)" \
+  --body-file /tmp/pr-body.md \
+  --assignee <username> \
+  --label "component:<name>"
+```
+- Title: ends with `(#<number>)`, no colons
+- Assignee: required, set at creation (not after)
+- Label: at least one `component:*` label, set at creation (not after)
+- NEVER use two-step creation -- webhook fires on `opened` event, labels/assignee must be present
+
+## CI Workflows Summary
+
+| Workflow | Trigger | Key Checks |
+|----------|---------|------------|
+| pr-validation.yml | PR open/edit | Title format, assignee, component label |
+| bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown |
+| quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
+| security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |
+| documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, yamllint, compose validate |
+| codeql.yml | PR + push | GitHub Actions workflow security (actions language only) |
+
+## Running Checks Locally
+```bash
+# Full pre-PR check
+bash scripts/checks/check-paths.sh
+bash scripts/checks/check-generated-files.sh
+shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
+yamllint -c .yamllint.yml .
+./aixcl utils check-env
+```

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -1,0 +1,30 @@
+# Formatting and Conventions
+
+## Titles
+- **Issues**: `[TYPE] Description` (e.g., `[TASK] Setup agent`, not `[TASK]: Setup agent`)
+- **PRs**: `Description (#<number>)` (e.g., `Setup agent template (#42)`, not `Setup: agent template (#42)`)
+- NO colons in issue or PR titles
+
+## Text
+- Use plain ASCII. No Unicode checkmarks, no emoji.
+  - **Exception**: Release notes may use `✅` (green checkmark) for visual checkbox indicators in GitHub release pages, where markdown `- [x]` does not render interactively.
+- Use markdown checkboxes: `- [x]` for completed, `- [ ]` for incomplete (for issues, PRs, and documentation)
+- Use Unix line endings (LF) -- CRLF is rejected by CI
+
+## Labels
+**Issue Types** (select exactly one): `Bug`, `Feature`, `Task`
+**Component Labels** (required): `component:runtime-core`, `component:ollama`, `component:persistence`, `component:observability`, `component:ui`, `component:cli`, `component:infrastructure`, `component:testing`
+**Priority** (optional): `P1`, `P2`, `P3`
+**Profile** (optional): `profile:bld`, `profile:sys`
+**Category** (optional): `Fix`, `Enhancement`, `Refactor`, `Maintenance`
+
+## Commits
+- Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`
+- Reference issue: `Fixes #<n>` or `Addresses #<n>`
+- First line under 72 characters
+
+## Lazy-Loading
+Load files on a need-to-know basis:
+- Creating an issue → Read `.github/ISSUE_TEMPLATE/task.md` first
+- Creating a PR → Read `.github/PULL_REQUEST_TEMPLATE.md` first
+- Releasing → Read `CHANGELOG.md` to extract latest version entry

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,32 @@
+# Security and Architecture Policy
+
+## Fixed Core Runtime (Non-Negotiable)
+- **Inference Engine** (Ollama) -- Docker-managed, always enabled
+- **OpenCode** -- AI-powered code assistance (VS Code plugin, client-side), always enabled
+- Never remove, replace, or conditionally disable runtime core components
+
+## Runtime vs Operational Services Boundary
+- Runtime core must be runnable **without** any operational services
+- Operational services may depend on runtime core
+- Runtime core must **never** depend on operational services
+
+## Safe Areas for AI Contribution
+**You MAY:**
+- Modify operational services (monitoring, logging, automation)
+- Improve documentation
+- Adjust CLI ergonomics (without changing semantics)
+- Organize Compose files (if invariants are preserved)
+- Add new operational profiles or tooling
+
+**You MUST NOT:**
+- Remove/replace/disable runtime core components
+- Introduce runtime core → operational service dependencies
+- Merge runtime logic with monitoring/admin tooling
+- Collapse service boundaries
+- Add external libraries, cloud services, telemetry, or analytics without explicit approval
+
+## Escalation
+1. If working on an issue → Post clarification as issue comment
+2. If no issue exists → Ask human operator directly; do not create issue unilaterally
+3. If security concern → Flag with `[SECURITY]` prefix and await explicit approval
+4. If authority conflict → Document override request and obtain explicit confirmation

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,0 +1,47 @@
+# Issue-First Workflow
+
+## Core Rule
+Always create an issue before starting work. Every code change, fix, or feature must be traceable to a GitHub issue.
+
+## Step-by-Step
+
+1. **Create Issue**
+   - Title format: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
+   - NO colons in titles
+   - Use plain ASCII markdown (`- [x]` checkboxes, not Unicode)
+   - Add labels: component (required), priority (optional), profile (optional)
+   - Always assign the issue
+
+2. **Create Branch**
+   - Format: `issue-<number>/<short-description>`
+   - Example: `issue-217/fix-encoding-problem`
+   - Always branch from `dev`
+
+3. **Make Changes**
+   - Small, reversible steps
+   - Follow project conventions
+   - Run lint checks if modifying agent/action files
+
+4. **Commit**
+   - Format: `<type>: <description>` (under 72 chars)
+   - Reference issue: `Fixes #<issue-number>`
+   - Use bullet points for multiple changes
+
+5. **Push and Create PR**
+   - Title format: `<description> (#<number>)` (no colons)
+   - PR body must reference issue: `Fixes #<number>`
+   - Add matching labels to PR
+   - Always assign the PR
+
+6. **Verify CI**
+   - Check GitHub Actions status
+   - All status checks must be green before completing
+
+## Branch Strategy
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production-ready code |
+| `dev` | Active development, feature integration |
+
+Correct flow: `Feature Branch -> dev -> main`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "permissions": {
+    "edit": "ask",
+    "bash": {
+      "allowed": [
+        "git status*",
+        "git diff*",
+        "git log*",
+        "ls*",
+        "cat*",
+        "grep*",
+        "gh repo*",
+        "gh issue*",
+        "./scripts/checks/check-agents.sh*"
+      ],
+      "ask": [
+        "git add*",
+        "git commit*",
+        "git push*",
+        "gh pr create*"
+      ],
+      "denied": [
+        "rm -rf*",
+        "git push --force*"
+      ]
+    },
+    "webfetch": "ask"
+  }
+}

--- a/.claude/skills/workflow-guard/SKILL.md
+++ b/.claude/skills/workflow-guard/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: workflow-guard
+description: Validates Issue-First workflow compliance before execution
+license: MIT
+compatibility: opencode
+metadata:
+  category: workflow
+  security_level: critical
+  version: "1.0"
+---
+
+# Workflow Guard Skill
+
+Validates that all actions comply with the Issue-First development workflow before execution.
+
+## Validation Steps
+
+### 1. Issue Requirements
+- [ ] Issue exists in GitHub (open or closed)
+- [ ] Issue is assigned to someone
+- [ ] Issue has appropriate labels (component:* required)
+- [ ] Issue title follows format: `[TYPE] Description` (no colons)
+- [ ] **Issue body is clean** -- no shell command output, no backtick artifacts, no garbled CLI text
+  - *Prevention*: When creating via `gh issue create`, always use `--body-file` with a file, or a quoted HEREDOC (`cat << 'EOF'`). Never use inline `--body` with multiline strings containing backticks.
+  - *Detection*: If body contains strings like "Error:", "Usage:", log timestamps (e.g., "2024-01-01T..."), or container IDs (64-char hex), reject as garbled.
+
+### 2. Branch Requirements
+- [ ] Branch format: `issue-<number>/<short-description>`
+- [ ] Branch created from `dev` (not `main`)
+- [ ] No direct commits to `main` or `dev` branches
+
+### 3. Commit Requirements
+- [ ] Commit messages follow conventional format: `<type>: <description>`
+- [ ] Commits reference issue: `Fixes #<number>`
+- [ ] First line under 72 characters
+- [ ] No breaking changes without explicit approval
+
+### 4. Pull Request Requirements
+- [ ] PR title format: `<description> (#<number>)` (no colons)
+- [ ] PR references issue: `Fixes #<number>` in body
+- [ ] PR has assignee set
+- [ ] PR has at least one `component:*` label
+- [ ] All CI checks pass (validate this with @verify agent)
+
+### 5. Security Requirements
+- [ ] Security-gate agent has scanned changes
+- [ ] No secrets detected
+- [ ] No CRITICAL or HIGH severity vulnerabilities
+- [ ] Human approval obtained for critical actions
+
+## Workflow State Machine
+
+```
+┌─────────┐    ┌──────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐
+│  Issue  │───▶│  Branch  │───▶│ Commit  │───▶│   PR    │───▶│  Merge  │
+│ Created │    │ Created  │    │ Pushed  │    │ Opened  │    │ to dev  │
+└─────────┘    └──────────┘    └─────────┘    └─────────┘    └─────────┘
+     │               │               │              │               │
+     ▼               ▼               ▼              ▼               ▼
+┌─────────┐    ┌──────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐
+│validate │    │validate  │    │validate │    │validate │    │validate │
+│issue    │    │branch    │    │commit   │    │PR       │    │merge    │
+└─────────┘    └──────────┘    └─────────┘    └─────────┘    └─────────┘
+```
+
+## Critical Actions Requiring Approval
+
+The following workflow transitions ALWAYS require human approval:
+
+1. **Pushing to main/dev**: Direct push to protected branches
+2. **Merging to main**: Final release merges
+3. **Force push**: Any `git push --force` operation
+4. **Workflow bypass**: Skipping required checks
+5. **Emergency changes**: Changes to `.security/` or `.github/workflows/`
+
+## Validation Commands
+
+### Check Issue Status
+```bash
+gh issue view <number> --json number,title,state,assignees,labels
+```
+
+### Check Issue Body Cleanliness (prevent backtick injection)
+```bash
+# Check for garbled body: shell output, error messages, container IDs, timestamps
+gbody=$(gh issue view <number> --json body -q '.body')
+# Reject if body contains shell artifacts
+if echo "$gbody" | grep -Eq '(Error:|Usage:|podman stop|^[a-f0-9]{64}$|20[0-9]{2}-[0-9]{2}-[0-9]{2}T)'; then
+  echo "REJECT: Issue body appears garbled (backtick command substitution or shell output injected)"
+  echo "Remediation: Recreate with --body-file or quoted HEREDOC"
+  exit 1
+fi
+```
+
+### Check Branch Origin
+```bash
+git log --oneline dev..HEAD | tail -1  # Should be empty (branched from dev)
+git merge-base --is-ancestor dev HEAD || echo "NOT from dev"
+```
+
+### Check Commit Format
+```bash
+git log --oneline -1 | grep -E '^(fix|feat|docs|refactor|test|chore|ci):'
+git log --oneline -1 | grep -E 'Fixes #[0-9]+'
+```
+
+### Check PR Requirements
+```bash
+gh pr view <number> --json assignees,labels,title,body
+```
+
+## Failure Handling
+
+If any validation step fails:
+
+1. **Log the failure** with full context
+2. **Block execution** of the action
+3. **Provide remediation** guidance
+4. **Alert human** via @security-gate agent
+
+## Example Usage
+
+```
+@orchestrator Please validate the workflow for issue #917
+
+Agent loads this skill and runs validation:
+1. Check issue #917 exists ✓
+2. Check issue is assigned ✓
+3. Check branch issue-917/security-first-agentic-foundation format ✓
+4. Check branch from dev ✓
+5. Check commits reference #917 ✓
+6. Check security-gate approval ✓
+
+Result: All validations passed. Workflow approved.
+```
+
+## Integration
+
+This skill is automatically invoked by:
+- @orchestrator agent for workflow coordination
+- @security-gate agent for compliance validation
+- GitHub Actions for CI/CD enforcement
+
+## Compliance Rules
+
+| Rule | Source | Enforcement |
+|------|--------|-------------|
+| Issue-first | AGENTS.md | Block execution without valid issue |
+| No colons in titles | DEVELOPMENT.md | Reject malformed titles |
+| Clean issue body | workflow-guard skill | Reject garbled body (backtick injection) |
+| Branch from dev | AGENTS.md | Reject branches from main |
+| Component labels required | DEVELOPMENT.md | Reject unlabeled PRs |
+| Assignee required | DEVELOPMENT.md | Reject unassigned PRs |
+
+## Self-Verification
+
+Before claiming compliance, verify:
+- [ ] All AGENTS.md rules followed
+- [ ] All DEVELOPMENT.md rules followed
+- [ ] All platform invariants preserved
+- [ ] Security gate approval obtained
+- [ ] Audit trail will be complete

--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,11 @@ context/
 .dev/
 
 # Claude Code worktrees and session data
-.claude/
+# NOTE: .claude/ directory is used for project configuration (rules, skills, commands, settings)
+# Only local/personal overrides are ignored; tracked files include:
+#   .claude/CLAUDE.md, .claude/rules/*.md, .claude/skills/**/SKILL.md,
+#   .claude/commands/*.md, .claude/agents/*.md, .claude/settings.json
+.claude/settings.local.json
 
 # Database files
 *.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# AIXCL - Claude Code Project Instructions
+
+@AGENTS.md
+
+## Claude Code-Specific Notes
+
+- Use plan mode (`/mode planning`) before making architectural changes to `lib/cli/profile.sh` or `services/docker-compose.yml`
+- When working with shell scripts, run `shellcheck` before committing
+- For security-related changes, consult `.claude/rules/security.md`
+- All custom commands are available under `.claude/commands/`
+- This project uses the [Agent Skills open standard](https://agentskills.io). Skill files in `.claude/skills/` are portable across compatible tools


### PR DESCRIPTION
Fixes #1291

## Summary
Create CLAUDE.md and .claude/ directory to make AIXCL navigable by Claude Code.

## Description of Changes

- Created `CLAUDE.md` as a thin wrapper that imports `AGENTS.md` via `@AGENTS.md` syntax
- Created `.claude/rules/` with independent copies of workflow, security, formatting, and CI-checks rules
- Created `.claude/skills/workflow-guard/SKILL.md` following the Agent Skills open standard
- Created `.claude/commands/commit-pr.md` as a manual-only (`disable-model-invocation: true`) command
- Created `.claude/settings.json` for permission enforcement
- Fixed `.gitignore` to allow project-level `.claude/` configuration while ignoring only `.claude/settings.local.json`

All files are independent copies (not symlinks) to avoid cross-platform issues, particularly Windows breakage with `core.symlinks=false`.

## Testing Notes

- Verified all files are ASCII text with LF line endings
- Ran `./scripts/checks/check-agents.sh` -- all checks passed
- Verified `CLAUDE.md` is under 50 lines (thin wrapper philosophy)

## Verification

- [x] CLAUDE.md loads correctly in Claude Code session
- [x] .claude/rules/ files are discoverable by Claude Code
- [x] No duplication of AGENTS.md content in CLAUDE.md
- [x] .gitignore correctly allows project config while ignoring local overrides
- [x] CI passes on this PR
