### PR TITLE
Fix Grafana dashboard and Prometheus file_sd leak on app remove and utils prune (#1319)

### DIFF
--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -641,13 +641,20 @@ app_cmd_remove() {
         rm -f "$prom_file"
     fi
 
-    # 4. Remove Grafana dashboard files if present
+    # 3a. Remove Grafana dashboard files if present (handle both lowercase and uppercase app names)
     local grafana_dash="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/${app_name}"
     if [ -d "$grafana_dash" ]; then
         rm -rf "$grafana_dash"
     fi
 
-    # 4a. Clean up old symlink path (backward compatibility)
+    # 3b. Handle uppercase app name variant (e.g., ftso -> FTSO for display names)
+    local grafana_dash_upper
+    grafana_dash_upper="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/$(echo "$app_name" | tr '[:lower:]' '[:upper:]')"
+    if [ -d "$grafana_dash_upper" ] && [ "$grafana_dash_upper" != "$grafana_dash" ]; then
+        rm -rf "$grafana_dash_upper"
+    fi
+
+    # 4. Clean up old symlink path (backward compatibility)
     local old_grafana_dash="${SCRIPT_DIR}/grafana/provisioning/dashboards/${app_name}"
     if [ -L "$old_grafana_dash" ] || [ -d "$old_grafana_dash" ]; then
         rm -rf "$old_grafana_dash"

--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -50,6 +50,16 @@ function prune() {
     fi
     echo ""
 
+    # Remove runtime-generated artifacts from host filesystem (bind-mounted directories)
+    # These are not tracked in git (see .gitignore) and must be cleaned explicitly.
+    echo "Removing runtime-generated dashboard provisioning..."
+    rm -rf "${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/"* 2>/dev/null || true
+    echo ""
+
+    echo "Removing runtime-generated Prometheus file_sd targets..."
+    rm -f "${SCRIPT_DIR}/prometheus/file_sd/"*.json 2>/dev/null || true
+    echo ""
+
     echo "Prune complete. Images retained for fast restart."
     echo "Run './aixcl stack init && ./aixcl stack start --profile sys' to bring the stack back up."
 }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1319

### Description of Changes

Resolves Grafana dashboard and Prometheus file_sd target leaks when removing apps or pruning the stack.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- `bash -n` syntax check passed for both modified files
- Verified `SCRIPT_DIR` is available in both contexts (set by `aixcl` dispatcher)
- Case variant logic handles apps using uppercase display names (e.g., `FTSO`)

### Related Issues

- Closes #1319
