### PR TITLE
Remove phantom Ollama and Open WebUI Prometheus jobs and alerts (#1321)

### DIFF
--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -162,64 +162,6 @@ groups:
           summary: "High memory usage in container {{ $labels.name }}"
           description: "Container {{ $labels.name }} memory usage is above 80% for more than 5 minutes. Current usage: {{ $value }}%"
 
-  # Ollama Alerts
-  - name: aixcl_ollama
-    interval: 30s
-    rules:
-      - alert: OllamaDown
-        expr: ollama_up == 0
-        for: 1m
-        labels:
-          severity: critical
-          component: ai-engine
-        annotations:
-          summary: "Ollama AI engine is down"
-          description: "Ollama has been down or unresponsive for more than 1 minute. Inference engine is unavailable."
-
-      - alert: OllamaNoModels
-        expr: ollama_models_loaded_total == 0
-        for: 5m
-        labels:
-          severity: warning
-          component: ai-engine
-        annotations:
-          summary: "Ollama has no models loaded"
-          description: "Ollama has no models loaded for more than 5 minutes. Users cannot perform inference."
-
-      - alert: OllamaContainerDown
-        expr: up{job="ollama"} == 0
-        for: 1m
-        labels:
-          severity: critical
-          component: ai-engine
-        annotations:
-          summary: "Ollama exporter is down"
-          description: "Ollama metrics exporter is not responding. Check if ollama-exporter service is running."
-
-  # Open WebUI Alerts
-  - name: aixcl_openwebui
-    interval: 30s
-    rules:
-      - alert: OpenWebUIDown
-        expr: openwebui_up == 0
-        for: 1m
-        labels:
-          severity: critical
-          component: ui
-        annotations:
-          summary: "Open WebUI is down"
-          description: "Open WebUI has been down or unresponsive for more than 1 minute. Users cannot access the interface."
-
-      - alert: OpenWebUIAPIDown
-        expr: openwebui_api_up == 0
-        for: 2m
-        labels:
-          severity: warning
-          component: ui
-        annotations:
-          summary: "Open WebUI API is not responding"
-          description: "Open WebUI API endpoint is not responding for more than 2 minutes. Chat functionality may be impacted."
-
   # GPU Alerts (using nvidia-smi metrics for rootless Podman compatibility)
   # Note: DCGM metrics don't work in rootless mode, using custom exporter instead
   - name: aixcl_gpu
@@ -303,17 +245,5 @@ groups:
           summary: "Alertmanager is down"
           description: "Alertmanager is not responding for more than 2 minutes. Alert notifications may not be delivered."
 
-  # Ollama Capacity Alerts
-  - name: aixcl_ollama_capacity
-    interval: 30s
-    rules:
-      - alert: OllamaHighModelStorage
-        expr: ollama_model_storage_bytes > 107374182400  # 100GB
-        for: 5m
-        labels:
-          severity: warning
-          component: ai-engine
-        annotations:
-          summary: "Ollama model storage is high"
-          description: "Ollama model storage is above 100GB. Current usage: {{ $value | humanize1024 }}B. Consider removing unused models."
+
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -49,15 +49,6 @@ scrape_configs:
           service: 'postgres'
           database: 'aixcl'
 
-  # Ollama - LLM Engine
-  # Uses custom exporter on port 11435 that polls Ollama API
-  # Provides model info, version, and availability metrics
-  - job_name: 'ollama'
-    static_configs:
-      - targets: ['localhost:11435']
-        labels:
-          service: 'ollama'
-
   # NVIDIA GPU Exporter - GPU metrics (utilization, memory, temperature, power)
   # Uses custom exporter (nvidia-smi) on port 9445 in rootless mode
   # DCGM exporter (port 9400) requires root/Docker socket and doesn't work in rootless
@@ -90,14 +81,6 @@ scrape_configs:
       - targets: ['localhost:9093']
         labels:
           service: 'alertmanager'
-
-  # Open WebUI - User interface metrics
-  # Uses custom exporter on port 11436
-  - job_name: 'open-webui'
-    static_configs:
-      - targets: ['localhost:11436']
-        labels:
-          service: 'open-webui'
 
   # Application services - discovered via file_sd_configs
   # Apps write their targets to prometheus/app-targets/<app_name>.json


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1321

Removes phantom Prometheus scrape jobs and alert rules for Ollama and Open WebUI that reference non-existent custom exporters.

### Description of Changes

Both Ollama and Open WebUI do not expose Prometheus /metrics endpoints or exporter sidecars. The existing jobs targeting ports 11435 and 11436 are permanently DOWN, and associated alert rules reference metrics (ollama_up, openwebui_up, etc.) that are never emitted.

This removes the dead configuration while preserving real monitoring signals:
- cAdvisor continues to provide container CPU/memory/uptime for all services
- Health checks remain via ./aixcl stack status
- Prometheus target-down alert (up==0) still covers all real targets

### Files Changed

- `prometheus/prometheus.yml`: Removed `ollama` and `open-webui` static scrape jobs
- `prometheus/alerts.yml`: Removed `aixcl_ollama`, `aixcl_openwebui`, and `aixcl_ollama_capacity` alert groups

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] `docker compose config` validates successfully
- [x] YAML files parse correctly

### Related Issues

- Closes #1321
- Builds on fix from #1320 (runtime artifact cleanup)

### Future Work

Real LLM observability (model request latency, queue depth, token throughput, user session metrics) will require a dedicated `aixcl-ollama-exporter` sidecar. Tracked separately via feature issue when prioritized.
