### PR TITLE
Add declarative app provisioning contract for BYO apps (#1331)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ export/
 
 # Generated SSL/certificates
 .security/
+
+# Generated app integration files (written by ./aixcl app start)
+prometheus/file_sd/
+grafana/provisioning/dashboards/apps/

--- a/aixcl
+++ b/aixcl
@@ -50,6 +50,10 @@ source "${SCRIPT_DIR}/lib/cli/profile.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/core/app_parser.sh"
 
+# App provisioning (platform-side hook implementing the app.yaml provision contract)
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/core/app_provision.sh"
+
 # ── Source AIXCL modules ─────────────────────────────────────────────────────
 
 # CLI module (contains help_menu, install_completion)

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -108,10 +108,63 @@ cp -r /path/to/my-app-source/* provider/
 An array of service definitions used by the app command implementation. Each service can declare:
 - `name`: Service name (used for container naming)
 - `image`: Docker image reference
+- `built`: Set `true` if the platform should build the image
 - `build`: Build context and Dockerfile path
 - `ports`: Exposed ports
 - `environment`: Environment variables
 - `depends_on`: Upstream platform services (e.g., `ollama`)
+- `healthcheck`: Readiness probe used by `app start` and `app status`:
+  - `type: http` with `url` -- healthy on HTTP 200
+  - `type: cmd` with `command` -- run inside the container, healthy on exit 0
+  - `type: container_running` -- healthy if the container is up
+  - `startup_timeout` / `interval` -- wait behavior in seconds
+
+### `provision` Block
+
+Declares platform resources the app needs. The platform provisions them
+idempotently on every `./aixcl app start <app>` (and standalone via
+`./aixcl app provision <app>`). This is the demarcation line between
+platform and app: apps declare, the platform creates. Apps never hold
+Vault tokens, never mount the shared platform secrets volume, and never
+ship files into platform directories.
+
+```yaml
+provision:
+  secrets:
+    - db-password
+    - auth-password
+  postgres:
+    database: my_app
+    owner: my_app
+    password_secret: db-password
+```
+
+Behavior:
+
+- Each name under `secrets` becomes a field in Vault KV at
+  `kv/apps/<app>`. Missing fields are generated (32-char alphanumeric);
+  existing values are never overwritten, so re-provisioning is safe.
+- Every secret is rendered to the per-app volume
+  `aixcl-app-<app>-secrets` as `/run/secrets/<app>-<secret>` (mode 0600).
+  Mount that volume read-only in your compose file:
+
+  ```yaml
+  volumes:
+    my-secrets:
+      name: aixcl-app-my-app-secrets
+      external: true
+  ```
+
+- If `postgres.database` is set, the platform creates the role (LOGIN,
+  password synced from `password_secret`, default `db-password`) and the
+  database (owned by `owner`, default the database name) in the platform
+  PostgreSQL instance. Identifiers must match `[a-z][a-z0-9_]*`.
+- To inspect provisioned secret values during local development:
+  `./aixcl app secrets <app>`.
+
+A fresh or re-initialised stack heals itself: the next `app start`
+regenerates Vault entries, re-renders the secrets volume, and recreates
+the database role.
 
 ### `prometheus` Block
 
@@ -119,13 +172,14 @@ Defines scrape targets for this application:
 
 ```yaml
 prometheus:
+  metrics_path: "/api/metrics"   # optional, default /metrics
   targets:
     - "localhost:9000"
   labels:
     app: "my-app"
 ```
 
-These targets are written to `prometheus/file_sd/<app_name>.json` and picked up by Prometheus `file_sd_configs`.
+These targets are written to `prometheus/file_sd/<app_name>.json` and picked up by Prometheus `file_sd_configs`. `metrics_path` is emitted as a per-target `__metrics_path__` label, so apps with non-standard scrape paths do not require platform configuration changes. Label names must match `[a-zA-Z_][a-zA-Z0-9_]*`.
 
 ### `grafana` Block
 
@@ -171,6 +225,8 @@ The `docker-compose.yml` in the app directory must obey AIXCL invariants:
 | `./aixcl app restart <app>`      | Restart an application              |
 | `./aixcl app status <app>`       | Show application status             |
 | `./aixcl app build <app>`        | Build/rebuild application image     |
+| `./aixcl app provision <app>`    | Provision declared platform resources |
+| `./aixcl app secrets <app>`      | Show provisioned secrets (local dev) |
 | `./aixcl app scaffold <name>`    | Create scaffolding for a new app    |
 | `./aixcl app install <url>`      | Install from a git URL              |
 
@@ -188,7 +244,7 @@ To verify targets are detected:
 
 ## Grafana Integration
 
-Dashboards listed in the `grafana` block of the manifest are symlinked into Grafana's provisioning directory when the app starts. Regenerate or restart Grafana to pick up changes.
+Dashboards listed in the `grafana` block of the manifest are copied into `grafana/provisioning/dashboards/apps/<app>/` when the app starts (a dedicated subdirectory avoids UID collisions with platform dashboards). Grafana's provisioner picks up changes on its scan interval; restart Grafana to force a reload.
 
 ## Lifecycle and Isolation
 

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -17,13 +17,17 @@
 
 # Dependencies: app_parser.sh must be loaded first by the main script
 
-# ── Internal helpers ───────────────────────────────────────────────────────────
+# -- Internal helpers -----------------------------------------------------------
 
 # Guard: ensure the parser module is loaded
 _app_ensure_parser() {
     if ! command -v _app_load_manifest >& /dev/null 2>&1; then
         # shellcheck disable=SC1091
         source "${SCRIPT_DIR}/lib/core/app_parser.sh"
+    fi
+    if ! command -v _app_provision >& /dev/null 2>&1; then
+        # shellcheck disable=SC1091
+        source "${SCRIPT_DIR}/lib/core/app_provision.sh"
     fi
 }
 
@@ -39,6 +43,8 @@ Actions:
   restart <name>                 Restart an app's services
   status  <name>                 Show status of an app's services
   build   <name>                 Build containers for an app (built: true)
+  provision <name>               Provision declared vault secrets and postgres
+  secrets <name>                 Show an app's provisioned secrets (local dev)
   remove  <name>                 Stop, rm containers, and prune images
   scaffold <name>                Generate a new app skeleton from template
   install <git-url> [--name <n>] [--branch <b>]
@@ -70,7 +76,7 @@ _app_compose_cmd() {
     local compose_file="${app_dir}/docker-compose.yml"
 
     if [ ! -f "$compose_file" ]; then
-        echo "❌ Missing ${compose_file}" >&2
+        echo "${ICON_ERROR:-[ ]} Missing ${compose_file}" >&2
         return 1
     fi
 
@@ -83,7 +89,7 @@ _app_compose_cmd() {
     elif command -v podman-compose >/dev/null 2>&1; then
         cmd=(podman-compose -f "$compose_file" -p "aixcl-${app_name}")
     else
-        echo "❌ No compose tool found" >&2
+        echo "${ICON_ERROR:-[ ]} No compose tool found" >&2
         return 1
     fi
 
@@ -112,8 +118,8 @@ _app_compose_cmd() {
         /^using podman version:/ { next }
         /^Container / { next }
         /^\[\+/ { next }
-        /^ ✔/ { next }
-        /^ ✘/ { next }
+        /^ [x]/ { next }
+        /^ [ ]/ { next }
         { print }
     '
     return ${PIPESTATUS[0]:-0}
@@ -137,6 +143,11 @@ _app_service_healthcheck_type() {
 _app_service_healthcheck_url() {
     local index="$1"
     eval "echo \${APP_SERVICE_${index}_HEALTHCHECK_URL:-}" 2>/dev/null || true
+}
+
+_app_service_healthcheck_command() {
+    local index="$1"
+    eval "echo \${APP_SERVICE_${index}_HEALTHCHECK_COMMAND:-}" 2>/dev/null || true
 }
 
 _app_service_healthcheck_interval() {
@@ -196,6 +207,34 @@ _app_http_ok() {
     [ "$code" = "200" ]
 }
 
+# Run a manifest healthcheck of type `cmd` inside the service container
+_app_cmd_ok() {
+    local container="$1"
+    local check_cmd="$2"
+    "${DOCKER_BIN:-docker}" exec "$container" sh -c "$check_cmd" >/dev/null 2>&1
+}
+
+# Dispatch a single health probe for service <index> (container must be known)
+# Returns 0 if healthy. Supported types: http (url), cmd (command).
+_app_health_ok() {
+    local index="$1"
+    local container="$2"
+    local htype
+    htype="$(_app_service_healthcheck_type "$index")"
+    case "$htype" in
+        http)
+            _app_http_ok "$(_app_service_healthcheck_url "$index")"
+            ;;
+        cmd)
+            _app_cmd_ok "$container" "$(_app_service_healthcheck_command "$index")"
+            ;;
+        *)
+            # Unknown or container_running: healthy if the container is up
+            _app_container_running "$container"
+            ;;
+    esac
+}
+
 # Check if a container is running (same pattern as ftso.sh / stack.sh)
 _app_container_running() {
     local name="$1"
@@ -214,7 +253,7 @@ _app_container_id() {
     "${DOCKER_BIN:-docker}" ps -a --format "{{.ID}}" --filter "name=^${name}$" 2>/dev/null | head -n 1
 }
 
-# ── Public Actions ─────────────────────────────────────────────────────────────
+# -- Public Actions -------------------------------------------------------------
 
 # Usage: app_cmd list
 # Lists all registered apps discovered by manifest
@@ -266,7 +305,7 @@ app_cmd_start() {
     _app_ensure_compose
 
     if ! _app_load_manifest "$app_name"; then
-        echo "❌ Failed to load manifest for app: ${app_name}" >&2
+        echo "${ICON_ERROR:-[ ]} Failed to load manifest for app: ${app_name}" >&2
         return 1
     fi
 
@@ -279,10 +318,17 @@ app_cmd_start() {
     echo "=============================="
     echo ""
 
+    # Provision declared platform resources (vault secrets, postgres) first.
+    # Idempotent: safe to run on every start, heals a freshly re-initialised stack.
+    if ! _app_provision "$app_name"; then
+        echo "  ${ICON_ERROR:-[ ]} Provisioning failed for ${app_name}" >&2
+        return 1
+    fi
+
     local svc_count
     svc_count="$(_app_service_count)"
     if [ "$svc_count" -eq 0 ]; then
-        echo "  ❌ No services defined in manifest." >&2
+        echo "  [ ] No services defined in manifest." >&2
         return 1
     fi
 
@@ -292,7 +338,7 @@ app_cmd_start() {
         svc_name="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
         svc_container="$(_app_service_container_name $i)"
         if [ -z "$svc_name" ] || [ -z "$svc_container" ]; then
-            echo "  ❌ Service ${i} has no name or container_name" >&2
+            echo "  [ ] Service ${i} has no name or container_name" >&2
             continue
         fi
 
@@ -309,19 +355,24 @@ app_cmd_start() {
                     local df
                     df="$(_app_service_build_dockerfile "$i")"
                     if "${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" -t "localhost/${svc_container}:latest" "$abs_ctx" >/dev/null 2>&1; then
-                        echo "    ✅ ${svc_name} built"
+                        echo "    [x] ${svc_name} built"
                     else
-                        echo "    ❌ ${svc_name} build failed (non-fatal; compose up may pull instead)" >&2
+                        echo "    [ ] ${svc_name} build failed (non-fatal; compose up may pull instead)" >&2
                     fi
                 else
-                    echo "  ❌ Build context not found: ${abs_ctx}" >&2
+                    echo "  [ ] Build context not found: ${abs_ctx}" >&2
                 fi
             fi
         fi
 
+        # Remove stale container if it exists but isn't running
+        if _app_container_exists "$svc_container" && ! _app_container_running "$svc_container"; then
+            "${DOCKER_BIN:-docker}" rm -f "$svc_container" >/dev/null 2>&1 || true
+        fi
+
         # Start the service silently, then print single status line
         _app_compose_cmd "$app_name" up -d --no-deps "$svc_container" >/dev/null 2>&1 || {
-            echo "  ❌ ${svc_name}" >&2
+            echo "  [ ] ${svc_name}" >&2
             return 1
         }
 
@@ -330,36 +381,35 @@ app_cmd_start() {
         local timeout
         timeout="$(_app_service_healthcheck_timeout "$i")"
         if [ -n "$health_type" ] && [ "$health_type" != "container_running" ]; then
-            local url wait_start wait_inter elapsed
-            url="$(_app_service_healthcheck_url "$i")"
+            local wait_start wait_inter elapsed
             wait_inter="$(_app_service_healthcheck_interval "$i")"
             wait_start=$(date +%s)
             local wait_ok=false
             while true; do
-                if _app_http_ok "$url"; then
-                    wait_ok=true
-                    break
-                fi
-                elapsed=$(( $(date +%s) - wait_start ))
-                if [ "$elapsed" -ge "$timeout" ]; then
-                    break
-                fi
-                sleep "$wait_inter"
-            done
-            if [ "$wait_ok" = true ]; then
-                echo "  ✅ ${svc_name}"
-            else
-                echo "  ⚠️ ${svc_name} (starting up)"
+            if _app_health_ok "$i" "$svc_container"; then
+                wait_ok=true
+                break
             fi
+            elapsed=$(( $(date +%s) - wait_start ))
+            if [ "$elapsed" -ge "$timeout" ]; then
+                break
+            fi
+            sleep "$wait_inter"
+        done
+        if [ "$wait_ok" = true ]; then
+            echo "  ${ICON_SUCCESS:-[x]} ${svc_name}"
         else
-            # No health URL — just check if container is running
-            sleep 2
-            if _app_container_running "$svc_container"; then
-                echo "  ✅ ${svc_name}"
-            else
-                echo "  ❌ ${svc_name}" >&2
-            fi
+            echo "  ${ICON_WARNING:-[!]} ${svc_name} (starting up)"
         fi
+    else
+        # No health URL -- just check if container is running
+        sleep 2
+        if _app_container_running "$svc_container"; then
+            echo "  ${ICON_SUCCESS:-[x]} ${svc_name}"
+        else
+            echo "  ${ICON_ERROR:-[ ]} ${svc_name}" >&2
+        fi
+    fi
         started=$((started + 1))
     done
 
@@ -408,9 +458,11 @@ app_cmd_stop() {
         fi
         if _app_container_running "$svc_container"; then
             if _app_compose_cmd "$app_name" stop "$svc_container" >/dev/null 2>&1; then
-                echo "  ✅ ${svc_container}"
+                # Force remove to prevent restart policy from bringing it back
+                "${DOCKER_BIN:-docker}" rm -f "$svc_container" >/dev/null 2>&1 || true
+                echo "  ${ICON_SUCCESS:-[x]} ${svc_container}"
             else
-                echo "  ❌ ${svc_container}" >&2
+                echo "  ${ICON_ERROR:-[ ]} ${svc_container}" >&2
             fi
         fi
     done
@@ -459,28 +511,27 @@ app_cmd_status() {
     local svc_count
     svc_count="$(_app_service_count)"
     for i in $(seq 0 "$((svc_count - 1))"); do
-        local svc_name svc_container htype hurl display_status health_status is_healthy
+        local svc_name svc_container htype display_status health_status is_healthy
         svc_name="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
         svc_container="$(_app_service_container_name "$i")"
         [ -z "$svc_container" ] && continue
 
-        display_status="${ICON_ERROR:-❌}"
+        display_status="${ICON_ERROR:-[ ]}"
         health_status=""
         is_healthy=false
 
         if _app_container_running "$svc_container"; then
             htype="$(_app_service_healthcheck_type "$i")"
-            hurl="$(_app_service_healthcheck_url "$i")"
-            if [ -n "$htype" ] && [ "$htype" != "container_running" ] && [ -n "$hurl" ]; then
-                if _app_http_ok "$hurl"; then
-                    display_status="${ICON_SUCCESS:-✅}"
+            if [ -n "$htype" ] && [ "$htype" != "container_running" ]; then
+                if _app_health_ok "$i" "$svc_container"; then
+                    display_status="${ICON_SUCCESS:-[x]}"
                     is_healthy=true
                 else
-                    display_status="${ICON_WARNING:-⚠️}"
+                    display_status="${ICON_WARNING:-[!]}"
                     health_status=" (starting up)"
                 fi
             else
-                display_status="${ICON_SUCCESS:-✅}"
+                display_status="${ICON_SUCCESS:-[x]}"
                 is_healthy=true
             fi
         else
@@ -499,12 +550,12 @@ app_cmd_status() {
     if [ "$total_services" -gt 0 ]; then
         echo "Services: ${healthy_services}/${total_services} healthy"
         if [ "$healthy_services" -eq "$total_services" ]; then
-            echo "Overall:  ${ICON_SUCCESS:-✅} All services healthy"
+            echo "Overall:  ${ICON_SUCCESS:-[x]} All services healthy"
         else
-            echo "Overall:  ${ICON_ERROR:-❌} Some services unhealthy"
+            echo "Overall:  ${ICON_ERROR:-[ ]} Some services unhealthy"
         fi
     else
-        echo "Overall:  ${ICON_WARNING:-⚠️} No services running"
+        echo "Overall:  ${ICON_WARNING:-[!]} No services running"
     fi
     echo ""
 }
@@ -543,14 +594,14 @@ app_cmd_build() {
                     if "${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" \
                           -t "localhost/${svc_container}:latest" \
                           "$abs_ctx"; then
-                        echo "    ✅ Built ${svc_name}"
+                        echo "    [x] Built ${svc_name}"
                         built=$((built + 1))
                     else
-                        echo "    ❌ Build failed for ${svc_name}" >&2
+                        echo "    [ ] Build failed for ${svc_name}" >&2
                         return 1
                     fi
                 else
-                    echo "  ❌ Build context missing: ${abs_ctx}" >&2
+                    echo "  [ ] Build context missing: ${abs_ctx}" >&2
                 fi
             fi
         fi
@@ -558,11 +609,50 @@ app_cmd_build() {
     echo ""
 }
 
-# ── Remove Application ───────────────────────────────────────────────────────────
+# Usage: app_cmd provision <name>
+# Run the manifest provision contract standalone (vault secrets, postgres)
+app_cmd_provision() {
+    local app_name="${1:-}"
+    if [ -z "$app_name" ]; then
+        echo "Error: app name required." >&2
+        return 1
+    fi
+
+    _app_ensure_parser
+    if ! _app_load_manifest "$app_name"; then
+        return 1
+    fi
+
+    if ! _app_provision_required; then
+        echo "No provision section declared in apps/${app_name}/app.yaml -- nothing to do."
+        return 0
+    fi
+
+    _app_provision "$app_name"
+}
+
+# Usage: app_cmd secrets <name>
+# Show the app's provisioned secret values (local development convenience)
+app_cmd_secrets() {
+    local app_name="${1:-}"
+    if [ -z "$app_name" ]; then
+        echo "Error: app name required." >&2
+        return 1
+    fi
+
+    _app_ensure_parser
+    if ! _app_load_manifest "$app_name"; then
+        return 1
+    fi
+
+    _app_provision_show_secrets "$app_name"
+}
+
+# -- Remove Application -----------------------------------------------------------
 
 # Usage: app_cmd_remove <name>
 # Stops containers, removes them (docker rm -f), and wipes local image caches.
-# Does NOT delete the app source directory — caller must do that manually.
+# Does NOT delete the app source directory -- caller must do that manually.
 app_cmd_remove() {
     local app_name="${1:-}"
     if [ -z "$app_name" ]; then
@@ -611,10 +701,10 @@ app_cmd_remove() {
         fi
 
         if [ "$removed_ok" = true ]; then
-            echo "  ✅ ${svc_container}"
+            echo "  [x] ${svc_container}"
             removed=$((removed + 1))
         else
-            echo "  ❌ ${svc_container}"
+            echo "  [ ] ${svc_container}"
             failed=$((failed + 1))
         fi
     done
@@ -626,10 +716,10 @@ app_cmd_remove() {
         while IFS= read -r orphan_name; do
             [ -z "$orphan_name" ] && continue
             if "${DOCKER_BIN:-docker}" rm -f "$orphan_name" >/dev/null 2>&1; then
-                echo "  ✅ ${orphan_name}"
+                echo "  [x] ${orphan_name}"
                 removed=$((removed + 1))
             else
-                echo "  ❌ ${orphan_name}"
+                echo "  [ ] ${orphan_name}"
                 failed=$((failed + 1))
             fi
         done <<< "$orphan"
@@ -664,13 +754,13 @@ app_cmd_remove() {
     "${DOCKER_BIN:-docker}" image prune -f 2>/dev/null || true
 
     echo ""
-    echo "✅ Removed ${removed} container(s)."
+    echo "${ICON_SUCCESS:-[x]} Removed ${removed} container(s)."
     echo ""
     echo "NOTE: Source code in apps/${app_name}/ was NOT deleted."
     echo "      Run: rm -rf apps/${app_name}  to delete permanently."
 }
 
-# ── Scaffolding ────────────────────────────────────────────────────────────────
+# -- Scaffolding ----------------------------------------------------------------
 
 # Usage: app_cmd_scaffold <name>
 # Generates a new app skeleton in apps/<name>/
@@ -720,6 +810,18 @@ services:
       startup_timeout: 60
       interval: 5
     depends_on: []
+
+# Platform resources provisioned automatically on 'app start' (idempotent).
+# Secrets are generated into Vault and rendered to the per-app volume
+# aixcl-app-${app_name}-secrets as /run/secrets/${app_name}-<name>.
+# Uncomment what your app needs:
+# provision:
+#   secrets:
+#     - db-password
+#   postgres:
+#     database: ${app_name}
+#     owner: ${app_name}
+#     password_secret: db-password
 
 prometheus:
   enabled: true
@@ -803,7 +905,7 @@ EOF
     echo "  4. Run: ./aixcl app start ${app_name}"
 }
 
-# ── Installation (Git Submodule) ────────────────────────────────────────────────
+# -- Installation (Git Submodule) ------------------------------------------------
 
 # Usage: app_cmd_install <git-url> [--name <name>] [--branch <branch>]
 # Clones a builder repo as a submodule into apps/<name>/provider/
@@ -866,10 +968,10 @@ app_cmd_install() {
     # Add as submodule
     local submodule_path="${app_dir}/provider"
     if ! git submodule add -b "$branch" "$git_url" "$submodule_path" 2>/dev/null; then
-        echo "  ❌ git submodule add failed (already tracked or URL invalid)" >&2
+        echo "  [ ] git submodule add failed (already tracked or URL invalid)" >&2
         # Fallback: clone directly if submodule add fails (e.g. shallow history issue)
         git clone --depth=1 --branch "$branch" "$git_url" "$submodule_path" 2>/dev/null || {
-            echo "  ❌ Clone failed for ${git_url}" >&2
+            echo "  [ ] Clone failed for ${git_url}" >&2
             rm -rf "$app_dir"
             return 1
         }
@@ -922,7 +1024,7 @@ EOF
     mkdir -p "${app_dir}/prometheus" "${app_dir}/grafana/dashboards"
 
     echo ""
-    echo "✅ Installation complete: ${app_dir}/"
+    echo "${ICON_SUCCESS:-[x]} Installation complete: ${app_dir}/"
     echo ""
     echo "Next steps:"
     echo "  1. Edit ${app_dir}/app.yaml to define your services"
@@ -930,7 +1032,7 @@ EOF
     echo "  3. Start: ./aixcl app start ${app_name}"
 }
 
-# ── Internal helpers ─────────────────────────────────────────────────────────
+# -- Internal helpers ---------------------------------------------------------
 
 # Generate Prometheus target JSON from manifest variables
 _app_generate_prometheus_targets() {
@@ -967,6 +1069,8 @@ _app_generate_prometheus_targets() {
     # Collect labels
     local labels=""
     # Start with manifest labels (which already include 'app: ftso')
+    # NOTE: Prometheus label names must match [a-zA-Z_][a-zA-Z0-9_]* -- keep
+    # underscores as-is (converting to dashes produces invalid label names).
     local label_keys
     label_keys="$(env | grep "^APP_PROMETHEUS_LABELS_" | sed 's/^APP_PROMETHEUS_LABELS_//' | sed 's/=.*//' | sort -u)"
     if [ -n "$label_keys" ]; then
@@ -974,8 +1078,14 @@ _app_generate_prometheus_targets() {
             [ -z "$key" ] && continue
             local val
             val="$(eval "echo \${APP_PROMETHEUS_LABELS_${key}:-}" 2>/dev/null || true)"
-            [ -n "$val" ] && labels="${labels}, \"$(echo "$key" | tr '[:upper:]' '[:lower:]' | tr '_' '-')\": \"${val}\""
+            [ -n "$val" ] && labels="${labels}, \"$(echo "$key" | tr '[:upper:]' '[:lower:]')\": \"${val}\""
         done <<< "$label_keys"
+    fi
+
+    # Per-app scrape path override (manifest: prometheus.metrics_path).
+    # __metrics_path__ is honoured natively by Prometheus file_sd targets.
+    if [ -n "${APP_PROMETHEUS_METRICS_PATH:-}" ]; then
+        labels="${labels}, \"__metrics_path__\": \"${APP_PROMETHEUS_METRICS_PATH}\""
     fi
 
     # Fallback: if no labels at all, add app name
@@ -1000,7 +1110,7 @@ _app_generate_prometheus_targets() {
 ]
 EOF
 
-    echo "  ✅ Prometheus targets"
+    echo "  ${ICON_SUCCESS:-[x]} Prometheus targets"
 }
 
 # Copy Grafana dashboards from app into platform provisioning
@@ -1017,7 +1127,7 @@ _app_wire_grafana() {
     fi
 }
 
-# ── Dispatcher entry point ─────────────────────────────────────────────────────
+# -- Dispatcher entry point -----------------------------------------------------
 
 # This function is called by lib/aixcl/dispatcher.sh when the first arg is "app"
 # Usage: app [subcommand] [args]
@@ -1048,6 +1158,12 @@ app_cmd() {
             ;;
         build)
             app_cmd_build "$@"
+            ;;
+        provision)
+            app_cmd_provision "$@"
+            ;;
+        secrets)
+            app_cmd_secrets "$@"
             ;;
         remove)
             app_cmd_remove "$@"

--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -58,6 +58,8 @@ if 'app' in data:
 if 'services' in data:
     for i, svc in enumerate(data['services']):
         flatten(svc, f"APP_SERVICE_{i}")
+if 'provision' in data:
+    flatten(data['provision'], 'APP_PROVISION')
 if 'prometheus' in data:
     flatten(data['prometheus'], 'APP_PROMETHEUS')
 if 'grafana' in data:

--- a/lib/core/app_provision.sh
+++ b/lib/core/app_provision.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# App provisioning for AIXCL
+# Implements the declarative `provision:` contract from apps/<name>/app.yaml.
+#
+# The platform owns Vault, Postgres, and the per-app secrets volume. Apps
+# declare what they need; the platform creates it idempotently on app start.
+# Apps never hold Vault tokens and never mount the shared platform secrets
+# volume (aixcl-vault-secrets).
+#
+# Manifest contract:
+#
+#   provision:
+#     secrets:                  # generated if absent, stored in Vault KV
+#       - db-password           #   kv/data/apps/<app> (field per secret)
+#       - auth-password         # rendered to volume aixcl-app-<app>-secrets
+#     postgres:                 # optional
+#       database: myapp         # database created if absent
+#       owner: myapp            # role created/synced with LOGIN
+#       password_secret: db-password   # which secret is the role password
+#
+# Each secret is rendered to /run/secrets/<app>-<secret> inside the volume
+# aixcl-app-<app>-secrets, which the app's compose file mounts read-only.
+#
+# Dependencies: app_parser.sh (manifest already loaded), python3,
+#               _load_vault_token_for_stack (lib/aixcl/commands/stack.sh)
+
+# Vault KV v2 mount used for app secrets
+_APP_PROVISION_KV_BASE="kv/data/apps"
+
+# -- Helpers --------------------------------------------------------------------
+
+# Validate an identifier used for postgres roles/databases (injection guard)
+_app_provision_valid_ident() {
+    [[ "$1" =~ ^[a-z][a-z0-9_]{0,62}$ ]]
+}
+
+# Validate a secret name from the manifest (used in file names and KV fields)
+_app_provision_valid_secret_name() {
+    [[ "$1" =~ ^[a-z][a-z0-9-]{0,62}$ ]]
+}
+
+# Generate a random alphanumeric secret (32 chars).
+# python3 is already a hard dependency (app_parser.sh); avoids the
+# tr </dev/urandom | head SIGPIPE that trips pipefail.
+_app_provision_generate_secret() {
+    python3 -c "import secrets, string; print(''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(32)))"
+}
+
+# Collect declared secret names from loaded manifest variables.
+# Prints one name per line.
+_app_provision_secret_names() {
+    local i=0
+    while true; do
+        local name
+        name="$(eval "echo \${APP_PROVISION_SECRETS_${i}:-}" 2>/dev/null || true)"
+        if [ -z "$name" ]; then
+            break
+        fi
+        echo "$name"
+        i=$((i + 1))
+    done
+}
+
+# True if the loaded manifest declares anything to provision
+_app_provision_required() {
+    [ -n "${APP_PROVISION_SECRETS_0:-}" ] || [ -n "${APP_PROVISION_POSTGRES_DATABASE:-}" ]
+}
+
+# Ensure VAULT_ADDR/VAULT_TOKEN are available in this process.
+_app_provision_ensure_vault() {
+    export VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+    if [ -z "${VAULT_TOKEN:-}" ]; then
+        # Note: must run in this shell (it exports VAULT_TOKEN); piping or
+        # command substitution would subshell it and lose the export.
+        if command -v _load_vault_token_for_stack >/dev/null 2>&1; then
+            _load_vault_token_for_stack || true
+        fi
+    fi
+    if [ -z "${VAULT_TOKEN:-}" ]; then
+        echo "  ${ICON_ERROR:-[ ]} Vault token unavailable. Run: ./aixcl vault init" >&2
+        return 1
+    fi
+    return 0
+}
+
+# -- Vault KV -------------------------------------------------------------------
+
+# Read the app's KV entry and print "field<TAB>value" lines (empty if absent)
+_app_provision_kv_read() {
+    local app_name="$1"
+    local response
+    response="$(curl -sf "${VAULT_ADDR}/v1/${_APP_PROVISION_KV_BASE}/${app_name}" \
+        -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null || true)"
+    [ -z "$response" ] && return 0
+    printf '%s' "$response" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin).get("data", {}).get("data", {})
+except Exception:
+    sys.exit(0)
+for k, v in data.items():
+    print(f"{k}\t{v}")
+'
+}
+
+# Write fields to the app's KV entry. Reads "field<TAB>value" lines on stdin.
+_app_provision_kv_write() {
+    local app_name="$1"
+    local payload
+    payload="$(python3 -c '
+import json, sys
+data = {}
+for line in sys.stdin:
+    line = line.rstrip("\n")
+    if not line:
+        continue
+    k, _, v = line.partition("\t")
+    data[k] = v
+print(json.dumps({"data": data}))
+')"
+    curl -sf -X POST "${VAULT_ADDR}/v1/${_APP_PROVISION_KV_BASE}/${app_name}" \
+        -H "X-Vault-Token: ${VAULT_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$payload" >/dev/null
+}
+
+# -- Secrets volume -------------------------------------------------------------
+
+_app_provision_volume_name() {
+    echo "aixcl-app-${1}-secrets"
+}
+
+# Write one secret value (stdin) to a file inside the app secrets volume.
+# The value never appears in argv or the environment of the helper container.
+_app_provision_render_secret() {
+    local volume="$1"
+    local filename="$2"
+    "${DOCKER_BIN:-docker}" run --rm -i --network none \
+        -v "${volume}:/secrets" \
+        docker.io/library/alpine:latest \
+        sh -c "umask 077 && cat > /secrets/${filename}"
+}
+
+# -- Postgres -------------------------------------------------------------------
+
+# Ensure role + database exist in the platform postgres container.
+# Args: <database> <owner> <password>
+_app_provision_postgres() {
+    local database="$1"
+    local owner="$2"
+    local password="$3"
+
+    if ! _app_provision_valid_ident "$database" || ! _app_provision_valid_ident "$owner"; then
+        echo "  ${ICON_ERROR:-[ ]} Invalid postgres identifier in manifest (lowercase alnum/underscore only)" >&2
+        return 1
+    fi
+
+    if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" 2>/dev/null | grep -q "^postgres$"; then
+        echo "  ${ICON_ERROR:-[ ]} Platform postgres container is not running. Run: ./aixcl stack start" >&2
+        return 1
+    fi
+
+    # Escape single quotes for the SQL string literal (password is generated
+    # alphanumeric, but a manually rotated Vault value may contain anything)
+    local pw_sql="${password//\'/\'\'}"
+
+    "${DOCKER_BIN:-docker}" exec -i postgres sh -c \
+        'PGPASSWORD="$(cat /run/secrets/postgres-password)" psql -q -U "${POSTGRES_USER}" -d postgres -v ON_ERROR_STOP=1' << SQL
+DO \$do\$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${owner}') THEN
+        CREATE ROLE ${owner} LOGIN PASSWORD '${pw_sql}';
+    ELSE
+        ALTER ROLE ${owner} WITH LOGIN PASSWORD '${pw_sql}';
+    END IF;
+END
+\$do\$;
+SELECT 'CREATE DATABASE ${database} OWNER ${owner}'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${database}')\gexec
+SQL
+}
+
+# -- Entry point ----------------------------------------------------------------
+
+# Provision everything the loaded manifest declares. Idempotent.
+# Requires _app_load_manifest to have been called for this app.
+# Usage: _app_provision <app_name>
+_app_provision() {
+    local app_name="$1"
+
+    if ! _app_provision_required; then
+        return 0
+    fi
+
+    echo "  Provisioning ${app_name}..."
+
+    _app_provision_ensure_vault || return 1
+
+    # 1. Ensure all declared secrets exist in Vault KV (generate missing)
+    local kv_state
+    kv_state="$(_app_provision_kv_read "$app_name")"
+
+    local names changed=false
+    names="$(_app_provision_secret_names)"
+    local name
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        if ! _app_provision_valid_secret_name "$name"; then
+            echo "  ${ICON_ERROR:-[ ]} Invalid secret name in manifest: ${name}" >&2
+            return 1
+        fi
+        if ! printf '%s\n' "$kv_state" | grep -q "^${name}	"; then
+            local value
+            value="$(_app_provision_generate_secret)"
+            kv_state="$(printf '%s\n%s\t%s' "$kv_state" "$name" "$value")"
+            changed=true
+        fi
+    done <<< "$names"
+
+    if [ "$changed" = true ]; then
+        if ! printf '%s\n' "$kv_state" | _app_provision_kv_write "$app_name"; then
+            echo "  ${ICON_ERROR:-[ ]} Failed to write secrets to Vault KV" >&2
+            return 1
+        fi
+    fi
+
+    # 2. Render secrets into the per-app volume
+    local volume
+    volume="$(_app_provision_volume_name "$app_name")"
+    "${DOCKER_BIN:-docker}" volume create "$volume" >/dev/null 2>&1 || true
+
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        local value
+        value="$(printf '%s\n' "$kv_state" | grep "^${name}	" | head -1 | cut -f2-)"
+        if [ -z "$value" ]; then
+            echo "  ${ICON_ERROR:-[ ]} Secret ${name} missing after Vault sync" >&2
+            return 1
+        fi
+        if ! printf '%s\n' "$value" | _app_provision_render_secret "$volume" "${app_name}-${name}"; then
+            echo "  ${ICON_ERROR:-[ ]} Failed to render secret ${app_name}-${name}" >&2
+            return 1
+        fi
+    done <<< "$names"
+
+    # 3. Ensure postgres role + database if declared
+    if [ -n "${APP_PROVISION_POSTGRES_DATABASE:-}" ]; then
+        local database owner pw_secret password
+        database="${APP_PROVISION_POSTGRES_DATABASE}"
+        owner="${APP_PROVISION_POSTGRES_OWNER:-$database}"
+        pw_secret="${APP_PROVISION_POSTGRES_PASSWORD_SECRET:-db-password}"
+        password="$(printf '%s\n' "$kv_state" | grep "^${pw_secret}	" | head -1 | cut -f2-)"
+        if [ -z "$password" ]; then
+            echo "  ${ICON_ERROR:-[ ]} provision.postgres.password_secret '${pw_secret}' is not a declared secret" >&2
+            return 1
+        fi
+        if ! _app_provision_postgres "$database" "$owner" "$password" >/dev/null; then
+            echo "  ${ICON_ERROR:-[ ]} Postgres provisioning failed for ${app_name}" >&2
+            return 1
+        fi
+    fi
+
+    echo "  ${ICON_SUCCESS:-[x]} Provisioned (vault secrets, app volume$([ -n "${APP_PROVISION_POSTGRES_DATABASE:-}" ] && echo ", postgres"))"
+    return 0
+}
+
+# Print the app's provisioned secrets (developer convenience; local stack only).
+# Usage: _app_provision_show_secrets <app_name>
+_app_provision_show_secrets() {
+    local app_name="$1"
+
+    if [ -z "${APP_PROVISION_SECRETS_0:-}" ]; then
+        echo "No provisioned secrets declared for ${app_name}."
+        return 0
+    fi
+
+    _app_provision_ensure_vault || return 1
+
+    local kv_state
+    kv_state="$(_app_provision_kv_read "$app_name")"
+    if [ -z "$kv_state" ]; then
+        echo "No secrets found in Vault for ${app_name}. Run: ./aixcl app start ${app_name}"
+        return 1
+    fi
+
+    echo ""
+    echo "Secrets for ${app_name} (kv/apps/${app_name})"
+    echo "--------------------------------------------------"
+    local name
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        local value
+        value="$(printf '%s\n' "$kv_state" | grep "^${name}	" | head -1 | cut -f2-)"
+        printf "  %-20s %s\n" "$name" "${value:-<missing>}"
+    done <<< "$(_app_provision_secret_names)"
+    echo ""
+}
+
+export -f _app_provision _app_provision_required _app_provision_show_secrets
+export -f _app_provision_secret_names _app_provision_valid_ident _app_provision_valid_secret_name
+export -f _app_provision_generate_secret _app_provision_ensure_vault
+export -f _app_provision_kv_read _app_provision_kv_write
+export -f _app_provision_volume_name _app_provision_render_secret _app_provision_postgres

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -244,6 +244,3 @@ groups:
         annotations:
           summary: "Alertmanager is down"
           description: "Alertmanager is not responding for more than 2 minutes. Alert notifications may not be delivered."
-
-
-

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -83,7 +83,10 @@ scrape_configs:
           service: 'alertmanager'
 
   # Application services - discovered via file_sd_configs
-  # Apps write their targets to prometheus/app-targets/<app_name>.json
+  # Apps write their targets to /etc/prometheus/app-targets/<app_name>.json
+  # (mounted from host ./prometheus/file_sd/)
+  # Default scrape path is /metrics; apps with a different path declare
+  # prometheus.metrics_path in app.yaml (emitted as __metrics_path__ label).
   - job_name: 'aixcl-apps'
     file_sd_configs:
       - files:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -400,6 +400,7 @@ services:
     volumes:
       - ../prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ../prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ../prometheus/file_sd:/etc/prometheus/app-targets:ro
       - aixcl-prometheus:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1331 Fixes #1333 Fixes #1334 Fixes #1335 Fixes #1336 Addresses #1332

### Description of Changes

Adds the declarative app provisioning contract for "bring your own app" builders: apps declare what they need in a `provision:` block in `app.yaml`, and the platform creates it idempotently on every `app start`.

- `lib/core/app_provision.sh` (new): Vault KV seeding (`kv/apps/<name>`, generated 32-char alphanumeric secrets, never overwritten), per-app secrets volume rendering (`aixcl-app-<name>-secrets`, mode 0600, no secret ever in argv/env), postgres role + database creation with password sync. A freshly re-initialised stack heals itself on the next `app start`.
- Demarcation enforced: apps never hold Vault tokens, never mount the shared `aixcl-vault-secrets` volume (which exposed postgres/grafana/pgadmin admin credentials to any app), and never ship files into platform directories.
- `app.sh`: provision on start, new `app provision` / `app secrets` subcommands, implement manifest healthcheck `type: cmd` (previously accepted but unimplemented), stale-container removal on start, `rm -f` on stop to defeat restart policies, `ICON_*` output with ASCII fallbacks, scaffold template documents the contract.
- Prometheus: per-app `prometheus.metrics_path` manifest key emitted as a `__metrics_path__` file_sd label (no platform config edits per app); label-name mangling fixed (underscores preserved -- dashes are invalid in Prometheus label names); `prometheus/file_sd/` mounted into the container.
- `docs/developer/adding-apps.md`: provision contract reference, healthcheck types, metrics_path, dashboard copy behavior.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (shellcheck, bash -n, yamllint, compose config, check-paths, check-generated-files)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:cli, component:infrastructure
- [x] **Title Format**: no colons, ends with issue number

### Testing Notes

Validated end to end on a fork against a live stack (rootless podman, profile sys) with a real two-service app (FastAPI + redis + dedicated postgres database + Ollama moderation pipeline):

- `app start` provisions Vault secrets, per-app volume, and postgres role/database idempotently (re-run produces byte-identical secrets)
- `type: cmd` healthcheck (`redis-cli ping`) passes on start and status
- Prometheus discovers the app via file_sd with `__metrics_path__` override; target healthy
- Full app lifecycle survives stop/start/restart with persisted data

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1331, #1333, #1334, #1335, #1336
- Addresses #1332 (manifest depends_on remains parsed-but-unused; left open)
