### PR TITLE
Move dependency review to dedicated pull request workflow (#1358)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,15 +35,3 @@ jobs:
           SHELLCHECK_OPTS: --severity=warning --exclude=SC1091
         with:
           scandir: '.'
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v5
-        with:
-          fail-on-severity: high


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1358

### Description of Changes
Moves the Dependency Review job out of security.yml into a dedicated .github/workflows/dependency-review.yml triggered only on pull_request (main and dev). The previous job-level `if: github.event_name == 'pull_request'` guard rendered as a skipped job on every push and scheduled run, which surfaced in PR check lists (observed on #1356) and read as a bypassed check. actions/dependency-review-action requires a PR base/head pair, so pull_request is the only event where it can run.

No change to the check itself: same action version, same fail-on-severity: high gate.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] yamllint passes on both workflow files

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:infrastructure
- [x] **Title Format**: no colons, ends with (#1358)

### Testing Notes
- This PR itself exercises the new workflow: Dependency Review should appear once as a real (non-skipped) check on this PR
- Push runs of Security Checks will show only Shell Script Linting

### Verification
- [x] Dependency Review runs and passes on this PR
- [x] No skipped Dependency Review rows on subsequent push runs

### Related Issues
- Fixes #1358
