### PR TITLE
Clear stale manifest variables between loads (#1341)

### DIFF
--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -111,6 +111,16 @@ _app_load_manifest() {
         return 1
     fi
 
+    # Clear variables from any previously loaded manifest so list entries
+    # that no longer exist (services, secrets, targets) do not leak into
+    # this load. APP_PARSER_YAML_TOOL is operator configuration, not
+    # manifest state, so it survives.
+    local stale_var
+    while IFS= read -r stale_var; do
+        [ "$stale_var" = "APP_PARSER_YAML_TOOL" ] && continue
+        unset "$stale_var"
+    done < <(compgen -v APP_ || true)
+
     eval "$exports"
     return 0
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1341

### Description of Changes
`_app_load_manifest` applied parser exports additively, so loading a second manifest in the same process kept stale `APP_*` list entries (services, secrets, targets) from the first. Because `_app_service_count` probes `APP_SERVICE_N_NAME` until unset, the stale variables also corrupted the service count and iteration, not just the environment.

This change unsets all `APP_*` variables immediately before applying a new manifest's exports. `APP_PARSER_YAML_TOOL` is excluded because it is operator configuration, not manifest state.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (shellcheck, bash -n, manual reproduction below)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:cli
- [x] **Title Format**: no colons, ends with issue number

**Note**: Commit is unsigned (agent has no TTY for GPG pinentry, per DEVELOPMENT.md scoping for working branches).

### Testing Notes
- `shellcheck --severity=warning --exclude=SC1091 lib/core/app_parser.sh` clean
- `bash -n` clean
- Reproduction: sourced the parser, loaded a 2-service manifest then a 1-service manifest in one bash process. Before the fix: `APP_SERVICE_1_NAME` and `APP_SERVICE_0_DEPENDS_ON_0` leaked and `_app_service_count` returned 2. After the fix: both unset, count returns 1, and reloading the first manifest restores count 2 with its dependencies intact.

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1341
