### PR TITLE
Honor manifest depends_on ordering in app start (#1332)

### DIFF
--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -112,7 +112,10 @@ An array of service definitions used by the app command implementation. Each ser
 - `build`: Build context and Dockerfile path
 - `ports`: Exposed ports
 - `environment`: Environment variables
-- `depends_on`: Upstream platform services (e.g., `ollama`)
+- `depends_on`: Either another service in this manifest (started and
+  health-checked before the dependent) or an already-running platform
+  container (e.g., `ollama`). A name matching neither fails `app start`
+  before any service is started; dependency cycles also fail.
 - `healthcheck`: Readiness probe used by `app start` and `app status`:
   - `type: http` with `url` -- healthy on HTTP 200
   - `type: cmd` with `command` -- run inside the container, healthy on exit 0

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -199,6 +199,77 @@ _app_service_depends_on() {
     printf '%s\n' "${deps[@]}"
 }
 
+# Resolve manifest service start order honoring depends_on.
+# Prints one service index per line, dependencies before dependents.
+# A dependency naming another manifest service orders it earlier; one
+# naming an already-running container (platform service) is satisfied;
+# anything else fails loudly. Cycles fail loudly.
+# Usage: _app_resolve_start_order <svc_count>
+_app_resolve_start_order() {
+    local svc_count="$1"
+    local i j dep
+    local -a names svc_deps indeg done_flag
+
+    for ((i = 0; i < svc_count; i++)); do
+        names[i]="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
+        svc_deps[i]=""
+        indeg[i]=0
+        done_flag[i]=0
+    done
+
+    for ((i = 0; i < svc_count; i++)); do
+        while IFS= read -r dep; do
+            [ -z "$dep" ] && continue
+            local found=-1
+            for ((j = 0; j < svc_count; j++)); do
+                if [ "${names[j]}" = "$dep" ]; then
+                    found=$j
+                    break
+                fi
+            done
+            if [ "$found" -ge 0 ]; then
+                case " ${svc_deps[i]} " in
+                    *" ${found} "*) ;;  # duplicate entry, already counted
+                    *)
+                        svc_deps[i]="${svc_deps[i]} ${found}"
+                        indeg[i]=$((indeg[i] + 1))
+                        ;;
+                esac
+            elif _app_container_running "$dep"; then
+                : # platform dependency already running
+            else
+                echo "  ${ICON_ERROR:-[ ]} ${names[i]}: depends_on '${dep}' is not a manifest service and no running container has that name" >&2
+                echo "      Declare '${dep}' under services: or start it first." >&2
+                return 1
+            fi
+        done < <(_app_service_depends_on "$i")
+    done
+
+    # Kahn's algorithm; stable index order among ready services.
+    local emitted=0 progress
+    while [ "$emitted" -lt "$svc_count" ]; do
+        progress=0
+        for ((i = 0; i < svc_count; i++)); do
+            [ "${done_flag[i]}" = "1" ] && continue
+            [ "${indeg[i]}" -ne 0 ] && continue
+            echo "$i"
+            done_flag[i]=1
+            emitted=$((emitted + 1))
+            progress=1
+            for ((j = 0; j < svc_count; j++)); do
+                case " ${svc_deps[j]} " in
+                    *" ${i} "*) indeg[j]=$((indeg[j] - 1)) ;;
+                esac
+            done
+        done
+        if [ "$progress" -eq 0 ]; then
+            echo "  ${ICON_ERROR:-[ ]} Dependency cycle detected in manifest depends_on" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
 # Check if a URL responds healthy (same helper as ftso.sh)
 _app_http_ok() {
     local url="$1"
@@ -332,8 +403,16 @@ app_cmd_start() {
         return 1
     fi
 
+    # Honor manifest depends_on: dependencies start (and pass their
+    # health checks) before dependents; unresolvable deps fail here.
+    local start_order
+    if ! start_order="$(_app_resolve_start_order "$svc_count")"; then
+        echo "  ${ICON_ERROR:-[ ]} Cannot start ${app_name}: unresolvable service dependencies" >&2
+        return 1
+    fi
+
     local started=0
-    for i in $(seq 0 "$((svc_count - 1))"); do
+    for i in $start_order; do
         local svc_name svc_container health_type
         svc_name="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
         svc_container="$(_app_service_container_name $i)"

--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -111,6 +111,16 @@ _app_load_manifest() {
         return 1
     fi
 
+    # Clear variables from any previously loaded manifest so list entries
+    # that no longer exist (services, secrets, targets) do not leak into
+    # this load. APP_PARSER_YAML_TOOL is operator configuration, not
+    # manifest state, so it survives.
+    local stale_var
+    while IFS= read -r stale_var; do
+        [ "$stale_var" = "APP_PARSER_YAML_TOOL" ] && continue
+        unset "$stale_var"
+    done < <(compgen -v APP_ || true)
+
     eval "$exports"
     return 0
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1332

**Stacked on #1360** -- merge #1360 first; this PR's diff will then show only its own commit.

### Description of Changes
`app start` ran `compose up -d --no-deps` per service in manifest order. Manifest `depends_on` was parsed into `APP_SERVICE_*_DEPENDS_ON_*` but never honored, so a dependency not also listed under `services:` silently never started (observed: a vault bootstrap sidecar never ran and its app crash-looped). `docs/developer/adding-apps.md` documented the field as supported, so developers were being promised behavior the code ignored.

- New `_app_resolve_start_order`: topological sort (Kahn's algorithm) of manifest services. Dependencies start first, and the existing per-service health-check wait means each dependency is healthy before its dependent starts.
- A dependency naming an already-running container (platform service, e.g. `ollama`) is satisfied as-is.
- A dependency matching neither fails loudly before any service starts, with guidance. Cycles fail loudly.
- `adding-apps.md` updated to state the actual semantics.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (shellcheck, bash -n, resolver test matrix below)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:cli
- [x] **Title Format**: no colons, ends with issue number

**Note**: Commit is unsigned (agent has no TTY for GPG pinentry, per DEVELOPMENT.md scoping for working branches).

### Testing Notes
Resolver exercised in isolation with stubbed container checks; all pass:

- `a depends_on b` with independent `c` -> order `b c a`
- chain `a->b->c` -> order `c b a`
- dep on running platform container (`ollama`) -> satisfied, natural order
- dep on unknown name -> fails before start with actionable message
- cycle `a->b->a` -> fails with cycle error

`shellcheck --severity=warning --exclude=SC1091` and `bash -n` clean.

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1332
- Depends on #1360
