### PR TITLE
Surface compose diagnostics on app start failure (#1337)

### DIFF
--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -112,7 +112,10 @@ An array of service definitions used by the app command implementation. Each ser
 - `build`: Build context and Dockerfile path
 - `ports`: Exposed ports
 - `environment`: Environment variables
-- `depends_on`: Upstream platform services (e.g., `ollama`)
+- `depends_on`: Either another service in this manifest (started and
+  health-checked before the dependent) or an already-running platform
+  container (e.g., `ollama`). A name matching neither fails `app start`
+  before any service is started; dependency cycles also fail.
 - `healthcheck`: Readiness probe used by `app start` and `app status`:
   - `type: http` with `url` -- healthy on HTTP 200
   - `type: cmd` with `command` -- run inside the container, healthy on exit 0

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -38,7 +38,8 @@ Usage: ./aixcl app <action> [args]
 
 Actions:
   list                          Discover and list all registered apps
-  start   <name>                 Start an app's services from manifest
+  start   <name> [--verbose]     Start an app's services from manifest
+                                (--verbose shows full compose and build output)
   stop    <name>                 Stop an app's services
   restart <name>                 Restart an app's services
   status  <name>                 Show status of an app's services
@@ -93,7 +94,22 @@ _app_compose_cmd() {
         return 1
     fi
 
-    (cd "$app_dir" && "${cmd[@]}" "$@" 2>&1) | \
+    # Capture raw output: quiet (filtered) on success, but a failure must
+    # dump the unfiltered compose output -- the noise filter below must
+    # never hide the reason a command failed.
+    local out_file rc=0
+    out_file="$(mktemp /tmp/aixcl_compose_out.XXXXXX)" || return 1
+    (cd "$app_dir" && "${cmd[@]}" "$@" >"$out_file" 2>&1) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        cat "$out_file" >&2
+        rm -f "$out_file"
+        return "$rc"
+    fi
+    if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+        cat "$out_file"
+        rm -f "$out_file"
+        return 0
+    fi
     awk '
         /^[[:space:]]*-[ev][[:space:]]/ { next }
         /^[[:space:]]*--/ { next }
@@ -121,8 +137,9 @@ _app_compose_cmd() {
         /^ [x]/ { next }
         /^ [ ]/ { next }
         { print }
-    '
-    return ${PIPESTATUS[0]:-0}
+    ' < "$out_file"
+    rm -f "$out_file"
+    return 0
 }
 
 # Resolve whether a service has `built: true` in its manifest
@@ -365,7 +382,20 @@ app_cmd_list() {
 # Usage: app_cmd start <name>
 # Start all services for an app in manifest order with dependency waits
 app_cmd_start() {
-    local app_name="${1:-}"
+    local app_name="" arg
+    for arg in "$@"; do
+        case "$arg" in
+            --verbose|-v)
+                AIXCL_VERBOSE=1
+                export AIXCL_VERBOSE
+                ;;
+            *)
+                if [ -z "$app_name" ]; then
+                    app_name="$arg"
+                fi
+                ;;
+        esac
+    done
     if [ -z "$app_name" ]; then
         echo "Error: app name required." >&2
         _app_usage >&2
@@ -431,12 +461,16 @@ app_cmd_start() {
                 abs_ctx="${app_dir}/${build_ctx}"
                 if [ -d "$abs_ctx" ]; then
                     echo "  Building ${svc_name}..."
-                    local df
+                    local df build_out
                     df="$(_app_service_build_dockerfile "$i")"
-                    if "${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" -t "localhost/${svc_container}:latest" "$abs_ctx" >/dev/null 2>&1; then
+                    if build_out="$("${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" -t "localhost/${svc_container}:latest" "$abs_ctx" 2>&1)"; then
+                        if [ "${AIXCL_VERBOSE:-0}" = "1" ]; then
+                            printf '%s\n' "$build_out"
+                        fi
                         echo "    [x] ${svc_name} built"
                     else
                         echo "    [ ] ${svc_name} build failed (non-fatal; compose up may pull instead)" >&2
+                        printf '%s\n' "$build_out" >&2
                     fi
                 else
                     echo "  [ ] Build context not found: ${abs_ctx}" >&2
@@ -449,9 +483,10 @@ app_cmd_start() {
             "${DOCKER_BIN:-docker}" rm -f "$svc_container" >/dev/null 2>&1 || true
         fi
 
-        # Start the service silently, then print single status line
-        _app_compose_cmd "$app_name" up -d --no-deps "$svc_container" >/dev/null 2>&1 || {
-            echo "  [ ] ${svc_name}" >&2
+        # Quiet on success; _app_compose_cmd dumps the raw compose output
+        # to stderr on failure so the reason is visible
+        _app_compose_cmd "$app_name" up -d --no-deps "$svc_container" >/dev/null || {
+            echo "  [ ] ${svc_name} failed to start (compose output above)" >&2
             return 1
         }
 

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -199,6 +199,77 @@ _app_service_depends_on() {
     printf '%s\n' "${deps[@]}"
 }
 
+# Resolve manifest service start order honoring depends_on.
+# Prints one service index per line, dependencies before dependents.
+# A dependency naming another manifest service orders it earlier; one
+# naming an already-running container (platform service) is satisfied;
+# anything else fails loudly. Cycles fail loudly.
+# Usage: _app_resolve_start_order <svc_count>
+_app_resolve_start_order() {
+    local svc_count="$1"
+    local i j dep
+    local -a names svc_deps indeg done_flag
+
+    for ((i = 0; i < svc_count; i++)); do
+        names[i]="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
+        svc_deps[i]=""
+        indeg[i]=0
+        done_flag[i]=0
+    done
+
+    for ((i = 0; i < svc_count; i++)); do
+        while IFS= read -r dep; do
+            [ -z "$dep" ] && continue
+            local found=-1
+            for ((j = 0; j < svc_count; j++)); do
+                if [ "${names[j]}" = "$dep" ]; then
+                    found=$j
+                    break
+                fi
+            done
+            if [ "$found" -ge 0 ]; then
+                case " ${svc_deps[i]} " in
+                    *" ${found} "*) ;;  # duplicate entry, already counted
+                    *)
+                        svc_deps[i]="${svc_deps[i]} ${found}"
+                        indeg[i]=$((indeg[i] + 1))
+                        ;;
+                esac
+            elif _app_container_running "$dep"; then
+                : # platform dependency already running
+            else
+                echo "  ${ICON_ERROR:-[ ]} ${names[i]}: depends_on '${dep}' is not a manifest service and no running container has that name" >&2
+                echo "      Declare '${dep}' under services: or start it first." >&2
+                return 1
+            fi
+        done < <(_app_service_depends_on "$i")
+    done
+
+    # Kahn's algorithm; stable index order among ready services.
+    local emitted=0 progress
+    while [ "$emitted" -lt "$svc_count" ]; do
+        progress=0
+        for ((i = 0; i < svc_count; i++)); do
+            [ "${done_flag[i]}" = "1" ] && continue
+            [ "${indeg[i]}" -ne 0 ] && continue
+            echo "$i"
+            done_flag[i]=1
+            emitted=$((emitted + 1))
+            progress=1
+            for ((j = 0; j < svc_count; j++)); do
+                case " ${svc_deps[j]} " in
+                    *" ${i} "*) indeg[j]=$((indeg[j] - 1)) ;;
+                esac
+            done
+        done
+        if [ "$progress" -eq 0 ]; then
+            echo "  ${ICON_ERROR:-[ ]} Dependency cycle detected in manifest depends_on" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
 # Check if a URL responds healthy (same helper as ftso.sh)
 _app_http_ok() {
     local url="$1"
@@ -332,8 +403,16 @@ app_cmd_start() {
         return 1
     fi
 
+    # Honor manifest depends_on: dependencies start (and pass their
+    # health checks) before dependents; unresolvable deps fail here.
+    local start_order
+    if ! start_order="$(_app_resolve_start_order "$svc_count")"; then
+        echo "  ${ICON_ERROR:-[ ]} Cannot start ${app_name}: unresolvable service dependencies" >&2
+        return 1
+    fi
+
     local started=0
-    for i in $(seq 0 "$((svc_count - 1))"); do
+    for i in $start_order; do
         local svc_name svc_container health_type
         svc_name="$(eval "echo \${APP_SERVICE_${i}_NAME:-}" 2>/dev/null || true)"
         svc_container="$(_app_service_container_name $i)"

--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -111,6 +111,16 @@ _app_load_manifest() {
         return 1
     fi
 
+    # Clear variables from any previously loaded manifest so list entries
+    # that no longer exist (services, secrets, targets) do not leak into
+    # this load. APP_PARSER_YAML_TOOL is operator configuration, not
+    # manifest state, so it survives.
+    local stale_var
+    while IFS= read -r stale_var; do
+        [ "$stale_var" = "APP_PARSER_YAML_TOOL" ] && continue
+        unset "$stale_var"
+    done < <(compgen -v APP_ || true)
+
     eval "$exports"
     return 0
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1337

**Stacked on #1361** (which stacks on #1360) -- merge in order; this PR's diff then shows only its own commit.

### Description of Changes
A failing `compose up` printed only `[ ] <service>`: `_app_compose_cmd` piped everything through a noise filter and `app_cmd_start` additionally redirected to /dev/null. The build-on-start path hid docker build errors the same way. Developers had to re-run compose by hand to see why a start failed.

- `_app_compose_cmd` now captures raw output to a temp file. On failure it dumps the unfiltered output to stderr and preserves the exit code; the noise filter only ever applies to successful runs.
- `app start` keeps its quiet single-status-line output on success but no longer suppresses stderr, so failure diagnostics reach the user.
- Build-on-start captures `docker build` output and dumps it on failure.
- New `app start <name> --verbose` (or `-v`) shows full compose and build output; documented in `app help`.

Standalone `app build` already showed full output and is unchanged.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (shellcheck, bash -n, stubbed wrapper tests below)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:cli
- [x] **Title Format**: no colons, ends with issue number

**Note**: Commit is unsigned (agent has no TTY for GPG pinentry, per DEVELOPMENT.md scoping for working branches).

### Testing Notes
Wrapper exercised with a stubbed `docker` binary:

- failure (exit 125, error on stderr): raw output incl. the error line reaches stderr even with stdout suppressed; exit code preserved
- success: output filtered as before (noise lines dropped, real lines kept)
- AIXCL_VERBOSE=1 success: unfiltered passthrough

`shellcheck --severity=warning --exclude=SC1091` and `bash -n` clean.

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues
- Closes #1337
- Depends on #1361
