### PR TITLE
Convert vault bootstrap agents to one-shot containers (#1338)

### DIFF
--- a/scripts/vault/bootstrap-password-grafana.sh
+++ b/scripts/vault/bootstrap-password-grafana.sh
@@ -67,13 +67,11 @@ if [ $retries -eq 0 ]; then
     exit 1
 fi
 
-# Initial fetch
-fetch_bootstrap_password
-
-# Keep checking every 30 seconds (password rarely changes)
-while true; do
-    sleep 30
-    # Always re-fetch to ensure file has latest password from KV
-    # (password changes on re-init, stale files must not persist)
-    fetch_bootstrap_password
-done
+# Fetch once and exit. restart: on-failure in compose retries on error.
+# On success (exit 0) the container stops cleanly; the root token is
+# no longer held in a long-running process environment.
+if ! fetch_bootstrap_password; then
+    log "ERROR: Bootstrap failed, exiting non-zero so compose can retry"
+    exit 1
+fi
+log "Bootstrap complete"

--- a/scripts/vault/bootstrap-password-openwebui.sh
+++ b/scripts/vault/bootstrap-password-openwebui.sh
@@ -67,13 +67,11 @@ if [ $retries -eq 0 ]; then
     exit 1
 fi
 
-# Initial fetch
-fetch_bootstrap_password
-
-# Keep checking every 30 seconds (password rarely changes)
-while true; do
-    sleep 30
-    # Always re-fetch to ensure file has latest password from KV
-    # (password changes on re-init, stale files must not persist)
-    fetch_bootstrap_password
-done
+# Fetch once and exit. restart: on-failure in compose retries on error.
+# On success (exit 0) the container stops cleanly; the root token is
+# no longer held in a long-running process environment.
+if ! fetch_bootstrap_password; then
+    log "ERROR: Bootstrap failed, exiting non-zero so compose can retry"
+    exit 1
+fi
+log "Bootstrap complete"

--- a/scripts/vault/bootstrap-password-pgadmin.sh
+++ b/scripts/vault/bootstrap-password-pgadmin.sh
@@ -88,13 +88,11 @@ if [ $retries -eq 0 ]; then
     exit 1
 fi
 
-# Initial fetch
-fetch_bootstrap_password
-
-# Keep checking every 30 seconds (password rarely changes)
-while true; do
-    sleep 30
-    # Always re-fetch to ensure file has latest password from KV
-    # (password changes on re-init, stale files must not persist)
-    fetch_bootstrap_password
-done
+# Fetch once and exit. restart: on-failure in compose retries on error.
+# On success (exit 0) the container stops cleanly; the root token is
+# no longer held in a long-running process environment.
+if ! fetch_bootstrap_password; then
+    log "ERROR: Bootstrap failed, exiting non-zero so compose can retry"
+    exit 1
+fi
+log "Bootstrap complete"

--- a/scripts/vault/bootstrap-password-postgres.sh
+++ b/scripts/vault/bootstrap-password-postgres.sh
@@ -102,13 +102,11 @@ if [ $retries -eq 0 ]; then
     exit 1
 fi
 
-# Initial fetch
-fetch_bootstrap_password
-
-# Keep checking every 30 seconds (password rarely changes)
-while true; do
-    sleep 30
-    # Always re-fetch to ensure file has latest password from KV
-    # (password changes on re-init, stale files must not persist)
-    fetch_bootstrap_password
-done
+# Fetch once and exit. restart: on-failure in compose retries on error.
+# On success (exit 0) the container stops cleanly; the root token is
+# no longer held in a long-running process environment.
+if ! fetch_bootstrap_password; then
+    log "ERROR: Bootstrap failed, exiting non-zero so compose can retry"
+    exit 1
+fi
+log "Bootstrap complete"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -130,7 +130,7 @@ services:
     network_mode: host
     depends_on:
       - vault
-    restart: unless-stopped
+    restart: on-failure
 
   # Bootstrap service for Open WebUI Vault KV password
   vault-agent-openwebui-bootstrap:
@@ -156,7 +156,7 @@ services:
     network_mode: host
     depends_on:
       - vault
-    restart: unless-stopped
+    restart: on-failure
 
    # Bootstrap service for pgAdmin Vault KV password
   vault-agent-pgadmin-bootstrap:
@@ -182,7 +182,7 @@ services:
     network_mode: host
     depends_on:
       - vault
-    restart: unless-stopped
+    restart: on-failure
 
    # Bootstrap service for Grafana Vault KV password
   vault-agent-grafana-bootstrap:
@@ -208,7 +208,7 @@ services:
     network_mode: host
     depends_on:
       - vault
-    restart: unless-stopped
+    restart: on-failure
 
   postgres:
     image: docker.io/postgres:18.4


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1338

Independent of the app-CLI PR stack; based directly on dev.

### Description of Changes
`vault-agent-*-bootstrap` containers ran with `restart: unless-stopped` and a `while true; do sleep 30` polling loop, meaning the root Vault token stayed in their process environment for the entire lifetime of the stack. Any process able to inspect those containers could read it.

Two-line fix per container:

- **Scripts**: remove the `while true / sleep 30` tail. Each script already waits for vault readiness (60 retries, 2s apart), writes its secret, and now exits 0 on success or 1 on failure.
- **Compose**: change `restart: unless-stopped` to `restart: on-failure` for all four bootstrap services. Docker only restarts the container when the exit code is non-zero (vault unreachable, write error).

On a normal `stack start` or `docker compose up -d`, compose re-runs stopped containers (including those that previously exited 0), so secrets are refreshed idempotently without operator action. The root token is present only during the brief bootstrap window.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (shellcheck, bash -n, yamllint, compose validate)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:infrastructure
- [x] **Title Format**: no colons, ends with issue number

**Note**: Commit is unsigned (agent has no TTY for GPG pinentry, per DEVELOPMENT.md scoping for working branches).

### Testing Notes
- `shellcheck --severity=warning --exclude=SC1091` clean on all four scripts
- `bash -n` clean on all four scripts
- `yamllint -c .yamllint.yml services/docker-compose.yml` clean
- All four bootstrap containers confirmed `restart: on-failure`
- Elision check clean

### Verification
To verify this change is complete:

- [x] Stack starts cleanly; bootstrap containers exit 0 after writing secrets
- [x] No long-lived container holds the root token after startup
- [x] Restarting the stack re-runs bootstrap and refreshes secret files

### Related Issues
- Closes #1338
