### PR TITLE
Document cap_drop ALL crash-loop pattern for official images (#1342)

### DIFF
--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -215,6 +215,42 @@ The `docker-compose.yml` in the app directory must obey AIXCL invariants:
     com.aixcl.service: "my-app-service"
   ```
 
+### Hardened images and cap_drop: ALL
+
+Official images (redis, postgres, etc.) whose entrypoints `chown` their
+data directories as root crash-loop under `cap_drop: ALL` after the
+first boot.
+
+**Why it fails:** The entrypoint runs `find / chown` to fix ownership
+before dropping to the service user. This requires `DAC_OVERRIDE` or
+`DAC_READ_SEARCH`. Under `cap_drop: ALL` those capabilities are gone.
+The first boot succeeds because the data directory is freshly created
+with root ownership; every subsequent boot fails under `set -e` because
+`chown` returns EPERM. The container never starts, restart counts climb
+(one redis sidecar hit 6342 restarts before the pattern was identified).
+
+**Fix:** Run the container as the service user so the entrypoint skips
+the root-only ownership phase entirely:
+
+```yaml
+services:
+  redis:
+    image: redis:7
+    user: "999:999"   # redis default UID:GID in the official image
+    cap_drop:
+      - ALL
+```
+
+**How to find the UID:** Check the official image documentation or run:
+
+```bash
+docker run --rm --entrypoint id redis:7
+```
+
+**When cap_drop: ALL is safe without user:** Images that do not chown
+on startup (e.g. the Vault image, which starts as a non-root user by
+default) can use `cap_drop: ALL` without the `user:` override.
+
 ## CLI Commands
 
 | Command                          | Description                         |


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1342

Independent; based directly on dev.

### Description of Changes
Official images (redis, postgres, etc.) crash-loop under `cap_drop: ALL` after the first boot. The failure mode was observed in production (a redis sidecar hit 6342 restarts) but was not documented anywhere.

Added a "Hardened images and cap_drop: ALL" subsection to `docs/developer/adding-apps.md` covering:

- Why it fails: entrypoints chown data dirs as root, requiring `DAC_OVERRIDE`/`DAC_READ_SEARCH` which are absent under `cap_drop: ALL`; first boot succeeds, all subsequent boots fail under `set -e`
- The fix: `user: "UID:GID"` so the entrypoint skips the root-only phase
- How to find the UID for an image
- When `cap_drop: ALL` is safe without a `user:` override

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (check-paths.sh clean, ASCII check clean)

### PR Validation Requirements
- [x] **Assignee**: set at creation
- [x] **Component Label**: component:infrastructure
- [x] **Title Format**: no colons, ends with issue number

**Note**: Commit is unsigned (agent has no TTY for GPG pinentry, per DEVELOPMENT.md scoping for working branches).

### Testing Notes
- `bash scripts/checks/check-paths.sh` clean
- No non-ASCII characters in the modified file
- Elision check clean

### Verification
To verify this change is complete:

- [x] adding-apps.md explains the failure mode and the fix

### Related Issues
- Closes #1342
