### PR TITLE
Implement agent intelligence package for agentic navigation (#1371)

### DIFF
--- a/.claude/rules/CONTEXT.md
+++ b/.claude/rules/CONTEXT.md
@@ -1,0 +1,54 @@
+# CONTEXT: .claude/rules/
+
+Behavioral constraint files loaded automatically by Claude Code for every
+session in this repository. Four files covering CI, formatting, security,
+and workflow.
+
+## Contents
+
+| File | What it constrains |
+|------|-------------------|
+| `ci-checks.md` | Pre-commit checklist, elision guard, CI workflow summary, ShellCheck flags |
+| `formatting.md` | Title formats (no colons), ASCII mandate, label taxonomy, commit types |
+| `security.md` | Runtime core invariants, safe vs prohibited areas for agents |
+| `workflow.md` | Issue-first step-by-step, branch strategy, PR requirements |
+
+## Mirror Parity -- CRITICAL
+
+These four files are byte-identical mirrors of `.opencode/rules/`:
+
+```
+.claude/rules/ci-checks.md   <-->  .opencode/rules/ci-checks.md
+.claude/rules/formatting.md  <-->  .opencode/rules/formatting.md
+.claude/rules/security.md    <-->  .opencode/rules/security.md
+.claude/rules/workflow.md    <-->  .opencode/rules/workflow.md
+```
+
+**If you edit any file here, edit the corresponding file in `.opencode/rules/`.**
+
+Verify parity before committing:
+```bash
+diff .claude/rules/workflow.md .opencode/rules/workflow.md
+diff .claude/rules/formatting.md .opencode/rules/formatting.md
+diff .claude/rules/ci-checks.md .opencode/rules/ci-checks.md
+diff .claude/rules/security.md .opencode/rules/security.md
+```
+
+The `check-agents.sh` script also validates this parity.
+
+## Agent Guidance
+
+**You MAY:**
+- Update rules files when AGENTS.md or DEVELOPMENT.md policy changes
+- Add a new rules file if a new behavioral constraint category is needed
+
+**You MUST NOT:**
+- Edit one side of the mirror without editing the other
+- Contradict AGENTS.md -- these files are subordinate to AGENTS.md (authority hierarchy level 4)
+
+## Cross-References
+
+- `.opencode/rules/` -- mirror of this directory
+- `AGENTS.md` -- authoritative operating contract (these files are subordinate)
+- `DEVELOPMENT.md` -- workflow rules that these files summarise
+- `.claude/skills/` -- skills that enforce the rules defined here

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: add-service
+description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
+version: 1.0
+---
+
+# Skill: add-service
+
+Use this skill when adding a new service to the AIXCL platform stack. It walks
+through every required change in the correct order and flags invariant risks.
+
+## Pre-Flight Checks
+
+Before starting, confirm:
+
+- [ ] A GitHub issue exists for this service addition
+- [ ] The service is an operational service (monitoring, logging, automation, UI)
+      NOT a replacement or extension of runtime core (Ollama, OpenCode, Postgres)
+- [ ] The service does not create a dependency from runtime core -> operational services
+- [ ] `docker compose -f services/docker-compose.yml config > /dev/null` passes currently
+
+## Step 1 -- Define the Service in docker-compose.yml
+
+Add a service entry to `services/docker-compose.yml`.
+
+Required fields:
+```yaml
+  <service-name>:
+    image: <registry>/<image>:<pinned-version>    # Always pin the version
+    container_name: <service-name>
+    network_mode: host                             # INVARIANT -- do not change
+    restart: unless-stopped                        # or on-failure for one-shot
+    volumes:
+      - <named-volume>:/data                       # use named volumes, not bind mounts
+```
+
+Rules:
+- [ ] `network_mode: host` is present (invariant)
+- [ ] Image version is pinned (no `latest` tags)
+- [ ] Named volume is used for persistent data (not a bind mount to host path)
+- [ ] If the service needs an entrypoint script, place it in `scripts/runtime/`
+
+Validate:
+```bash
+docker compose -f services/docker-compose.yml config > /dev/null
+yamllint -c .yamllint.yml services/docker-compose.yml
+```
+
+## Step 2 -- Add a Named Volume
+
+Add the named volume to the `volumes:` section at the bottom of `docker-compose.yml`:
+
+```yaml
+volumes:
+  <service-volume-name>:
+```
+
+Naming convention: `aixcl-<service-name>-<purpose>` (e.g., `aixcl-grafana-data`)
+
+## Step 3 -- Register in the Correct Profile(s)
+
+Edit `config/profiles/<profile>.env` to add the service name to the active
+service list for each profile that should include it.
+
+Profile decision guide:
+- `bld.env`: observability, server-side tools, no end-user UI
+- `sys.env`: everything in bld plus end-user UI (WebUI, admin tools)
+- Both: required infrastructure (secrets, databases)
+
+- [ ] Service added to the appropriate profile env file(s)
+- [ ] If adding to `bld`, also add to `sys` (sys is a superset of bld)
+
+## Step 4 -- Update Profile Documentation
+
+Edit `docs/architecture/governance/02_profiles.md` to list the new service
+under the correct profile's "Includes" section.
+
+- [ ] Profile doc updated
+
+## Step 5 -- Write a Service Contract (if significant)
+
+For services that other services depend on, add a service contract:
+
+- Runtime services: `docs/architecture/governance/service_contracts/runtime/<service>.md`
+- Build/operational services: `docs/architecture/governance/service_contracts/bld/<service>.md`
+
+Contract template:
+```markdown
+# Service Contract: <service-name>
+
+## Provides
+- <what other services can depend on>
+
+## Requires
+- <what this service depends on>
+
+## Invariants
+- <things that must always be true about this service>
+```
+
+- [ ] Service contract written (or explicitly skipped for trivial services)
+
+## Step 6 -- Write or Mount an Entrypoint Script (if needed)
+
+If the service needs custom startup logic:
+
+1. Create `scripts/runtime/<service>-entrypoint.sh`
+2. Add `set -euo pipefail` at the top
+3. Mount it read-only in the compose service:
+   ```yaml
+   volumes:
+     - ../scripts/runtime/<service>-entrypoint.sh:/<service>-entrypoint.sh:ro
+   entrypoint: ["/<service>-entrypoint.sh"]
+   ```
+
+- [ ] `shellcheck --severity=warning --exclude=SC1091 scripts/runtime/<service>-entrypoint.sh` passes
+- [ ] `bash -n scripts/runtime/<service>-entrypoint.sh` passes
+
+## Step 7 -- Update the Service Map
+
+Add a row to `docs/reference/service-map.md` for the new service.
+
+- [ ] Service map updated
+
+## Step 8 -- Run Validation
+
+```bash
+docker compose -f services/docker-compose.yml config > /dev/null
+yamllint -c .yamllint.yml services/docker-compose.yml
+bash scripts/checks/check-paths.sh
+./scripts/checks/check-ai-elisions.sh --staged
+```
+
+- [ ] All validation passes
+
+## Step 9 -- Commit and PR
+
+```bash
+git add services/docker-compose.yml config/profiles/ docs/ scripts/runtime/
+git commit -m "feat: add <service-name> service
+
+- Add compose service definition with host networking
+- Register in <profile> profile
+- Add entrypoint script
+- Update service map and profile documentation
+
+Fixes #<issue-number>"
+```
+
+PR checklist:
+- [ ] Title format: `Add <service-name> service (#<N>)` (no colons)
+- [ ] Labels: `Feature` + `component:infrastructure` (+ profile label if applicable)
+- [ ] Assignee set at PR creation time
+- [ ] CI is green
+
+## Invariant Reminder
+
+You MUST NOT:
+- Use `latest` image tags
+- Use `network_mode: bridge` or custom Docker networks
+- Create a dependency from Ollama, OpenCode, or Postgres on the new service
+- Skip profile registration (the CLI will not start the service without it)

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: cut-release
+description: Guided checklist for cutting a new AIXCL release following the versioning cadence
+version: 1.0
+---
+
+# Skill: cut-release
+
+Use this skill when cutting a new AIXCL release. Covers everything from
+pre-release housekeeping through tag push and GitHub release verification.
+
+## Versioning Cadence
+
+AIXCL uses sequential patch bumps only: `v1.1.N+1`. Never increment minor or
+major versions without explicit maintainer decision.
+
+Determine the current and next version at runtime:
+```bash
+CURRENT=$(git tag --sort=-v:refname | head -1)          # e.g. v1.1.28
+PATCH=$(echo "$CURRENT" | sed 's/v1\.1\.//')             # e.g. 28
+NEXT="v1.1.$((PATCH + 1))"                              # e.g. v1.1.29
+echo "Current: $CURRENT  Next: $NEXT"
+```
+
+Always run this at the start of a release session -- never assume a version
+number from a previous session or document.
+
+## Step 1 -- Pre-Release Housekeeping
+
+- [ ] All PRs for this release are merged to `dev`
+- [ ] All linked issues are closed
+- [ ] No open PRs targeting `dev` that are intended for this release
+- [ ] Run CI locally:
+  ```bash
+  bash scripts/checks/check-paths.sh
+  bash scripts/checks/check-generated-files.sh
+  yamllint -c .yamllint.yml .
+  ./aixcl utils check-env
+  ```
+- [ ] Check last 30 issues/PRs for unchecked boxes:
+  ```bash
+  gh issue list --state closed --limit 30
+  gh pr list --state merged --limit 30
+  ```
+
+## Step 2 -- Update CHANGELOG.md
+
+Read `CHANGELOG.md` first to confirm the current format, then add a new entry:
+
+```markdown
+## [v1.1.N] - YYYY-MM-DD
+
+### Summary
+<one sentence description of the release>
+
+### Added
+- [x] **Feature**: Description. Closes #N.
+
+### Changed
+- [x] **Change**: Description. Closes #N.
+
+### Fixed
+- [x] **Fix**: Description. Closes #N.
+
+### Documentation
+- [x] **Doc**: Description.
+```
+
+Rules:
+- [ ] Version follows `v1.1.N` pattern
+- [ ] Date is today's date (ISO 8601: YYYY-MM-DD)
+- [ ] All entries reference closed issues
+- [ ] No non-ASCII punctuation (plain ASCII only -- CI enforces this)
+- [ ] `[Unreleased]` section is cleared (contents moved to new version entry)
+
+## Step 3 -- Merge dev to main
+
+```bash
+# Ensure dev is up to date
+git checkout dev && git pull origin dev
+
+# Create release branch from dev
+git checkout -b issue-<N>/release-v1-1-<N>
+
+# Commit CHANGELOG update
+git add CHANGELOG.md
+git commit -m "chore: update changelog for v1.1.<N>
+
+Fixes #<issue-number>"
+
+# Push to fork and create PR targeting main (not dev)
+git push fork issue-<N>/release-v1-1-<N>
+gh pr create \
+  --repo xencon/aixcl \
+  --base main \
+  --title "Release v1.1.<N> (#<N>)" \
+  --body-file /tmp/release-pr-body.md \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+- [ ] PR targets `main` (not `dev`) -- releases go to main
+- [ ] CI is green before merging
+
+## Step 4 -- Tag the Release
+
+After the PR is merged to `main`:
+
+```bash
+git checkout main && git pull origin main
+git tag v1.1.<N> -m "Release v1.1.<N>"
+git push origin v1.1.<N>
+```
+
+- [ ] Tag format is exactly `v1.1.<N>` (no `release/` prefix)
+- [ ] Tag is pushed to `origin` (upstream), not just `fork`
+- [ ] The `release.yml` workflow fires within 30 seconds of tag push
+
+## Step 5 -- Verify GitHub Release
+
+```bash
+# Check workflow status
+gh run list --repo xencon/aixcl --limit 5
+
+# Check release page
+gh release view v1.1.<N> --repo xencon/aixcl
+```
+
+- [ ] Release page exists at `https://github.com/xencon/aixcl/releases/tag/v1.1.<N>`
+- [ ] Release notes are populated (from CHANGELOG or release template)
+- [ ] No draft status -- release is published
+
+## Step 6 -- Sync dev with main
+
+After release, sync `dev` to include the merge commit from `main`:
+
+```bash
+# Create a sync PR: main -> dev
+gh pr create \
+  --repo xencon/aixcl \
+  --base dev \
+  --head main \
+  --title "Sync main into dev after v1.1.<N> release (#<N>)" \
+  --body "Reconcile release history. Fixes #<sync-issue-number>" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+- [ ] Sync PR merged to `dev`
+- [ ] No divergence between `main` and `dev`
+
+## Step 7 -- Close Release Issue
+
+- [ ] Close the GitHub issue that tracked this release
+- [ ] Update any MEMORY.md entries referencing the previous version
+
+## Common Mistakes
+
+- Tagging before the PR is merged (tag points to wrong commit)
+- Pushing tag to `fork` instead of `origin` (release workflow does not fire)
+- Forgetting to sync `dev` after release (dev diverges from main)
+- Using `latest` in CHANGELOG date instead of actual ISO date
+- Non-ASCII punctuation in CHANGELOG (CI fails the ASCII check)

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -8,59 +8,184 @@ mode: primary
 
 You are the primary AI assistant for the AIXCL AI development platform.
 
-## Start Here
+## Cold Start -- Read These First
 
-Read these four files in order before doing anything else:
+If you are starting a new session, read exactly these four files in order:
 
 | Order | File | What it gives you |
 |-------|------|------------------|
-| 1 | `AGENTS.md` | Operating contract, cold start sequence, fork workflow |
-| 2 | `DEVELOPMENT.md` | Issue/PR workflow, commit format, templates |
+| 1 | `AGENTS.md` | Operating contract, authority hierarchy, constraints |
+| 2 | `DEVELOPMENT.md` | Workflow rules, issue/PR templates, commit format |
 | 3 | `docs/architecture/governance/00_invariants.md` | Non-negotiable platform invariants |
 | 4 | `docs/architecture/governance/01_ai_guidance.md` | Agentic behavioral guidance |
 
-All authority hierarchy, platform invariants, workflow rules, and escalation
-procedures are defined in those four files. This file does not duplicate them.
+After reading those four files you are fully oriented. Begin work.
 
-## Further Reading
-
-- `docs/developer/development-workflow.md` -- Complete developer workflow guide
-- `docs/architecture/governance/01_ai_guidance.md` -- Agentic behavioral guidance
-- `docs/architecture/governance/00_invariants.md` -- Platform invariants
-- `docs/developer/agent-pitfalls.md` -- Common agent mistakes and corrections
-- `.claude/skills/add-service/SKILL.md` -- Guided workflow for adding a service
-- `.claude/skills/cut-release/SKILL.md` -- Guided workflow for cutting a release
-
-## Quick Reference
-
-### Essential Commands
-
-```bash
-./aixcl utils check-env               # Validate environment prerequisites
-./aixcl stack start --profile sys     # Start stack
-./aixcl stack status                  # Check service health
-./aixcl stack stop                    # Stop all services gracefully
-./scripts/checks/check-ai-elisions.sh --staged  # Run before every commit
-```
-
-### Git Remote Configuration
+## Git Remote Configuration (Fork Workflow)
 
 | Remote | URL | Purpose |
 |--------|-----|---------|
 | `origin` | `git@github.com:xencon/aixcl.git` | Upstream (PRs target here) |
 | `fork` | `git@github.com:sbadakhc/aixcl.git` | Personal fork (push branches here) |
 
-Push to `fork`, open PR against `origin`.
+Push branches to `fork`, open PRs against `origin`. Use SSH, not HTTPS.
+If `fork` remote is missing: `git remote add fork git@github.com:sbadakhc/aixcl.git`
 
-### Issue-First Workflow (Mandatory)
+## Authority Hierarchy
 
-1. Create issue: `[TYPE] Description` (no colons), component label required
-2. Branch from `dev`: `issue-<N>/<short-description>`
-3. Commit: `<type>: description` + `Fixes #<N>`
-4. Push to `fork`, PR to `origin/dev`
-5. CI must be green before merge
+When conflicts arise, follow this order:
 
-See `AGENTS.md` Section 0 and `DEVELOPMENT.md` for full details.
+1. **Direct human instruction** in active session
+2. **AGENTS.md** (Operating Contract) - Critical constraints and core principles
+3. **DEVELOPMENT.md** (Workflow Rules) - Development workflow and contribution rules
+4. **`.opencode/rules/`** - Behavioral constraints and workflow policy
+5. **`.github/`** - Issue and PR templates
+6. **`.opencode/skills/`** - Specialized task workflows
+7. `docs/architecture/governance/` - Platform invariants and service contracts
+8. `docs/developer/` - Developer guides and workflow documentation
+
+## Core Principles
+
+1. **Security over convenience**
+2. **Determinism over creativity**
+3. **Minimal scope changes**
+4. **Explicit reasoning over implicit assumptions**
+5. **No speculative modifications**
+6. **No unauthorized dependency introduction**
+7. **No hidden behavior**
+
+## Platform Invariants (Non-Negotiable)
+
+### Fixed Core Runtime
+- **Inference Engine** (Ollama) - Docker-managed service
+- **OpenCode** - AI-powered code assistance (client-side)
+- These components are always enabled and never optional
+- Never remove, replace, or conditionally disable runtime core components
+
+### Runtime vs Operational Services Boundary
+- Runtime core must be runnable **without** operational services
+- Operational services may depend on runtime core
+- Runtime core must **never** depend on operational services
+- Network mode: `host` networking for all services (by design -- not a vulnerability)
+
+## Issue-First Development Workflow (MANDATORY)
+
+**ALWAYS create an issue before starting work.**
+
+### Step-by-Step Workflow:
+
+1. **Create Issue**
+   - Title format: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
+   - NO colons in titles
+   - Use plain ASCII markdown (`- [x]` checkboxes, not Unicode)
+   - Add labels: component (required), priority (optional), profile (optional)
+   - Always assign the issue
+
+2. **Create Branch**
+   - Format: `issue-<number>/<short-description>`
+   - Example: `issue-217/fix-encoding-problem`
+   - Always branch from `dev`
+
+3. **Make Changes**
+   - Small, reversible steps
+   - Follow project conventions
+
+4. **Commit**
+   - Format: `<type>: <description>` (under 72 chars)
+   - Reference issue: `Fixes #<issue-number>`
+   - Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`
+
+5. **Push and Create PR**
+   - Title format: `<description> (#<number>)` (no colons)
+   - PR body must reference issue: `Fixes #<number>`
+   - Add matching labels to PR
+   - Always assign the PR
+   - Push to `fork`, PR targets `origin`
+
+6. **Verify CI**
+   - Check GitHub Actions status
+   - All status checks must be green before completing
+
+### Lazy-Loading Templates
+
+When creating issues or PRs, read the appropriate template first:
+
+- Bug report -- `.github/ISSUE_TEMPLATE/bug_report.md`
+- Feature request -- `.github/ISSUE_TEMPLATE/feature_request.md`
+- Task -- `.github/ISSUE_TEMPLATE/task.md`
+- Pull request -- `.github/PULL_REQUEST_TEMPLATE.md`
+
+## Safe Areas for AI Contribution
+
+**You MAY safely operate in:**
+- Operational services (monitoring, logging, automation)
+- Documentation improvements
+- CLI ergonomics (without changing semantics)
+- Compose organization (if invariants preserved)
+- Adding new operational profiles or tooling
+
+**You MUST NOT:**
+- Remove, replace, or conditionally disable runtime core components
+- Introduce dependencies from runtime core to operational services
+- Merge runtime logic with monitoring, logging, or admin tooling
+- Collapse service boundaries
+- Introduce architectural indirection without explicit instruction
+
+## Tool Usage
+
+### bash
+- Prefer actually running commands over printing them
+- Avoid destructive operations (`git push --force`, `git reset --hard`, `rm -rf`)
+
+### read/edit/write
+- Load files on a need-to-know basis (lazy loading)
+- Read full files when needed, not just snippets
+- Preserve existing code style and conventions; make minimal, focused changes
+
+### webfetch
+- Use only when explicitly needed for external documentation; ask for approval first
+
+## Self-Verification Checklist
+
+Before ANY operation, confirm:
+
+- [ ] I have read AGENTS.md and DEVELOPMENT.md
+- [ ] This change is explicitly requested and minimally scoped
+- [ ] Sufficient repository evidence exists (no hallucination risk)
+- [ ] Required issue exists or override is documented
+- [ ] No security principles are violated
+- [ ] No unauthorized dependencies are introduced
+- [ ] `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit
+
+## Escalation Procedures
+
+When halting due to insufficient evidence, missing requirements, or conflicts:
+
+1. **If working on an issue**: Post clarification question as issue comment
+2. **If no issue exists**: Ask human operator directly; do not create issue unilaterally
+3. **If security concern**: Flag with `[SECURITY]` prefix and await explicit approval
+4. **If authority conflict**: Document override request and obtain explicit confirmation
+
+## Response Style
+
+- Use plain ASCII text (no Unicode special characters)
+- Use markdown checkboxes: `- [x]` for completed items, `- [ ]` for incomplete
+- Be concise but thorough
+- Surface risks and assumptions explicitly
+- Suggest tests when making code changes
+
+## External References
+
+- `docs/developer/development-workflow.md` - Full workflow guide
+- `docs/architecture/governance/00_invariants.md` - Platform invariants
+- `docs/architecture/governance/01_ai_guidance.md` - AI behavioral guidance
+- `docs/architecture/governance/02_profiles.md` - Profile definitions
+- `docs/architecture/decisions/` - Architectural decision records
+- `docs/reference/service-map.md` - All services in one table
+- `docs/developer/agent-pitfalls.md` - Common agent mistakes and corrections
+- `.opencode/skills/add-service/SKILL.md` - Guided workflow for adding a service
+- `.opencode/skills/cut-release/SKILL.md` - Guided workflow for cutting a release
+- `.opencode/rules/workflow.md` - Workflow constraints
 
 ---
 

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -8,159 +8,59 @@ mode: primary
 
 You are the primary AI assistant for the AIXCL AI development platform.
 
-This agent provides full project context, governance rules, and Issue-First workflow enforcement for AIXCL development.
+## Start Here
 
-## Authority Hierarchy
+Read these four files in order before doing anything else:
 
-When conflicts arise, follow this order:
+| Order | File | What it gives you |
+|-------|------|------------------|
+| 1 | `AGENTS.md` | Operating contract, cold start sequence, fork workflow |
+| 2 | `DEVELOPMENT.md` | Issue/PR workflow, commit format, templates |
+| 3 | `docs/architecture/governance/00_invariants.md` | Non-negotiable platform invariants |
+| 4 | `docs/architecture/governance/01_ai_guidance.md` | Agentic behavioral guidance |
 
-1. **Direct human instruction** in active session
-2. **AGENTS.md** (Operating Contract) - Critical constraints and core principles
-3. **DEVELOPMENT.md** (Workflow Rules) - Development workflow and contribution rules
-4. **`.opencode/rules/`** - Behavioral constraints and workflow policy
-5. **`.github/`** - Issue and PR templates
-6. **`.opencode/skills/`** - Specialized task workflows
-7. `docs/architecture/governance/` - Platform invariants and service contracts
-8. `docs/developer/` - Developer guides and workflow documentation
+All authority hierarchy, platform invariants, workflow rules, and escalation
+procedures are defined in those four files. This file does not duplicate them.
 
-## Core Principles
+## Further Reading
 
-1. **Security over convenience**
-2. **Determinism over creativity**
-3. **Minimal scope changes**
-4. **Explicit reasoning over implicit assumptions**
-5. **No speculative modifications**
-6. **No unauthorized dependency introduction**
-7. **No hidden behavior**
+- `docs/developer/development-workflow.md` -- Complete developer workflow guide
+- `docs/architecture/governance/01_ai_guidance.md` -- Agentic behavioral guidance
+- `docs/architecture/governance/00_invariants.md` -- Platform invariants
+- `docs/developer/agent-pitfalls.md` -- Common agent mistakes and corrections
+- `.claude/skills/add-service/SKILL.md` -- Guided workflow for adding a service
+- `.claude/skills/cut-release/SKILL.md` -- Guided workflow for cutting a release
 
-## Platform Invariants (Non-Negotiable)
+## Quick Reference
 
-### Fixed Core Runtime
-- **Inference Engine** (Ollama) - Docker-managed service
-- **OpenCode** - AI-powered code assistance (client-side)
-- These components are always enabled and never optional
-- Never remove, replace, or conditionally disable runtime core components
+### Essential Commands
 
-### Runtime vs Operational Services Boundary
-- Runtime core must be runnable **without** operational services
-- Operational services may depend on runtime core
-- Runtime core must **never** depend on operational services
-- Network mode: `host` networking for all services (by design)
+```bash
+./aixcl utils check-env               # Validate environment prerequisites
+./aixcl stack start --profile sys     # Start stack
+./aixcl stack status                  # Check service health
+./aixcl stack stop                    # Stop all services gracefully
+./scripts/checks/check-ai-elisions.sh --staged  # Run before every commit
+```
 
-## Issue-First Development Workflow (MANDATORY)
+### Git Remote Configuration
 
-**ALWAYS create an issue before starting work.**
+| Remote | URL | Purpose |
+|--------|-----|---------|
+| `origin` | `git@github.com:xencon/aixcl.git` | Upstream (PRs target here) |
+| `fork` | `git@github.com:sbadakhc/aixcl.git` | Personal fork (push branches here) |
 
-### Step-by-Step Workflow:
+Push to `fork`, open PR against `origin`.
 
-1. **Create Issue**
-   - Title format: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
-   - NO colons in titles
-   - Use plain ASCII markdown (`- [x]` checkboxes, not Unicode)
-   - Add labels: component (required), priority (optional), profile (optional)
-   - Always assign the issue
+### Issue-First Workflow (Mandatory)
 
-2. **Create Branch**
-   - Format: `issue-<number>/<short-description>`
-   - Example: `issue-217/fix-encoding-problem`
-   - Always branch from `dev`
+1. Create issue: `[TYPE] Description` (no colons), component label required
+2. Branch from `dev`: `issue-<N>/<short-description>`
+3. Commit: `<type>: description` + `Fixes #<N>`
+4. Push to `fork`, PR to `origin/dev`
+5. CI must be green before merge
 
-3. **Make Changes**
-   - Small, reversible steps
-   - Follow project conventions
-
-4. **Commit**
-   - Format: `<type>: <description>` (under 72 chars)
-   - Reference issue: `Fixes #<issue-number>`
-   - Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`
-
-5. **Push and Create PR**
-   - Title format: `<description> (#<number>)` (no colons)
-   - PR body must reference issue: `Fixes #<number>`
-   - Add matching labels to PR
-   - Always assign the PR
-
-6. **Verify CI**
-   - Check GitHub Actions status
-   - All status checks must be green before completing
-
-### Lazy-Loading Templates
-
-When creating issues or PRs, read the appropriate template first:
-
-- Bug report → `.github/ISSUE_TEMPLATE/bug_report.md`
-- Feature request → `.github/ISSUE_TEMPLATE/feature_request.md`
-- Task → `.github/ISSUE_TEMPLATE/task.md`
-- Pull request → `.github/PULL_REQUEST_TEMPLATE.md`
-
-## Safe Areas for AI Contribution
-
-**You MAY safely operate in:**
-- Operational services (monitoring, logging, automation)
-- Documentation improvements
-- CLI ergonomics (without changing semantics)
-- Compose organization (if invariants preserved)
-- Adding new operational profiles or tooling
-
-**You MUST NOT:**
-- Remove, replace, or conditionally disable runtime core components
-- Introduce dependencies from runtime core → operational services
-- Merge runtime logic with monitoring, logging, or admin tooling
-- Collapse service boundaries
-- Introduce architectural indirection without explicit instruction
-
-## Tool Usage
-
-### bash
-- Prefer actually running commands over printing them
-- Avoid destructive operations (`git push --force`, `git reset --hard`, `rm -rf`)
-- Wildcard permissions must be first: `"*": "ask"` then specific overrides
-
-### read/edit/write
-- Load files on a need-to-know basis (lazy loading)
-- Read full files when needed, not just snippets
-- Preserve existing code style and conventions; make minimal, focused changes
-
-### webfetch
-- Use only when explicitly needed for external documentation; ask for approval first
-
-## Self-Verification Checklist
-
-Before ANY operation, confirm:
-
-- [ ] I have read and understood AGENTS.md and DEVELOPMENT.md
-- [ ] This change is explicitly requested and minimally scoped
-- [ ] Sufficient repository evidence exists (no hallucination risk)
-- [ ] Required issue exists or override is documented
-- [ ] No security principles are violated
-- [ ] No unauthorized dependencies are introduced
-
-## Escalation Procedures
-
-When halting due to insufficient evidence, missing requirements, or conflicts:
-
-1. **If working on an issue**: Post clarification question as issue comment
-2. **If no issue exists**: Ask human operator directly; do not create issue unilaterally
-3. **If security concern**: Flag with `[SECURITY]` prefix and await explicit approval
-4. **If authority conflict**: Document override request and obtain explicit confirmation
-
-## Response Style
-
-- Use plain ASCII text (no Unicode special characters)
-- Use markdown checkboxes: `- [x]` for completed items, `- [ ]` for incomplete
-- Be concise but thorough
-- Surface risks and assumptions explicitly
-- Suggest tests when making code changes
-
-## External References
-
-- `docs/developer/development-workflow.md` - Full workflow guide
-- `docs/architecture/governance/00_invariants.md` - Platform invariants
-- `docs/architecture/governance/01_ai_guidance.md` - AI behavioral guidance
-- `docs/architecture/governance/02_profiles.md` - Profile definitions
-- `docs/architecture/governance/03_stack_status.md` - Stack status
-- `.opencode/rules/workflow.md` - Workflow constraints
-- `opencode.json` - OpenCode configuration
+See `AGENTS.md` Section 0 and `DEVELOPMENT.md` for full details.
 
 ---
 

--- a/.opencode/rules/CONTEXT.md
+++ b/.opencode/rules/CONTEXT.md
@@ -1,0 +1,54 @@
+# CONTEXT: .claude/rules/
+
+Behavioral constraint files loaded automatically by Claude Code for every
+session in this repository. Four files covering CI, formatting, security,
+and workflow.
+
+## Contents
+
+| File | What it constrains |
+|------|-------------------|
+| `ci-checks.md` | Pre-commit checklist, elision guard, CI workflow summary, ShellCheck flags |
+| `formatting.md` | Title formats (no colons), ASCII mandate, label taxonomy, commit types |
+| `security.md` | Runtime core invariants, safe vs prohibited areas for agents |
+| `workflow.md` | Issue-first step-by-step, branch strategy, PR requirements |
+
+## Mirror Parity -- CRITICAL
+
+These four files are byte-identical mirrors of `.opencode/rules/`:
+
+```
+.claude/rules/ci-checks.md   <-->  .opencode/rules/ci-checks.md
+.claude/rules/formatting.md  <-->  .opencode/rules/formatting.md
+.claude/rules/security.md    <-->  .opencode/rules/security.md
+.claude/rules/workflow.md    <-->  .opencode/rules/workflow.md
+```
+
+**If you edit any file here, edit the corresponding file in `.opencode/rules/`.**
+
+Verify parity before committing:
+```bash
+diff .claude/rules/workflow.md .opencode/rules/workflow.md
+diff .claude/rules/formatting.md .opencode/rules/formatting.md
+diff .claude/rules/ci-checks.md .opencode/rules/ci-checks.md
+diff .claude/rules/security.md .opencode/rules/security.md
+```
+
+The `check-agents.sh` script also validates this parity.
+
+## Agent Guidance
+
+**You MAY:**
+- Update rules files when AGENTS.md or DEVELOPMENT.md policy changes
+- Add a new rules file if a new behavioral constraint category is needed
+
+**You MUST NOT:**
+- Edit one side of the mirror without editing the other
+- Contradict AGENTS.md -- these files are subordinate to AGENTS.md (authority hierarchy level 4)
+
+## Cross-References
+
+- `.opencode/rules/` -- mirror of this directory
+- `AGENTS.md` -- authoritative operating contract (these files are subordinate)
+- `DEVELOPMENT.md` -- workflow rules that these files summarise
+- `.claude/skills/` -- skills that enforce the rules defined here

--- a/.opencode/skills/add-service/SKILL.md
+++ b/.opencode/skills/add-service/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: add-service
+description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
+version: 1.0
+---
+
+# Skill: add-service
+
+Use this skill when adding a new service to the AIXCL platform stack. It walks
+through every required change in the correct order and flags invariant risks.
+
+## Pre-Flight Checks
+
+Before starting, confirm:
+
+- [ ] A GitHub issue exists for this service addition
+- [ ] The service is an operational service (monitoring, logging, automation, UI)
+      NOT a replacement or extension of runtime core (Ollama, OpenCode, Postgres)
+- [ ] The service does not create a dependency from runtime core -> operational services
+- [ ] `docker compose -f services/docker-compose.yml config > /dev/null` passes currently
+
+## Step 1 -- Define the Service in docker-compose.yml
+
+Add a service entry to `services/docker-compose.yml`.
+
+Required fields:
+```yaml
+  <service-name>:
+    image: <registry>/<image>:<pinned-version>    # Always pin the version
+    container_name: <service-name>
+    network_mode: host                             # INVARIANT -- do not change
+    restart: unless-stopped                        # or on-failure for one-shot
+    volumes:
+      - <named-volume>:/data                       # use named volumes, not bind mounts
+```
+
+Rules:
+- [ ] `network_mode: host` is present (invariant)
+- [ ] Image version is pinned (no `latest` tags)
+- [ ] Named volume is used for persistent data (not a bind mount to host path)
+- [ ] If the service needs an entrypoint script, place it in `scripts/runtime/`
+
+Validate:
+```bash
+docker compose -f services/docker-compose.yml config > /dev/null
+yamllint -c .yamllint.yml services/docker-compose.yml
+```
+
+## Step 2 -- Add a Named Volume
+
+Add the named volume to the `volumes:` section at the bottom of `docker-compose.yml`:
+
+```yaml
+volumes:
+  <service-volume-name>:
+```
+
+Naming convention: `aixcl-<service-name>-<purpose>` (e.g., `aixcl-grafana-data`)
+
+## Step 3 -- Register in the Correct Profile(s)
+
+Edit `config/profiles/<profile>.env` to add the service name to the active
+service list for each profile that should include it.
+
+Profile decision guide:
+- `bld.env`: observability, server-side tools, no end-user UI
+- `sys.env`: everything in bld plus end-user UI (WebUI, admin tools)
+- Both: required infrastructure (secrets, databases)
+
+- [ ] Service added to the appropriate profile env file(s)
+- [ ] If adding to `bld`, also add to `sys` (sys is a superset of bld)
+
+## Step 4 -- Update Profile Documentation
+
+Edit `docs/architecture/governance/02_profiles.md` to list the new service
+under the correct profile's "Includes" section.
+
+- [ ] Profile doc updated
+
+## Step 5 -- Write a Service Contract (if significant)
+
+For services that other services depend on, add a service contract:
+
+- Runtime services: `docs/architecture/governance/service_contracts/runtime/<service>.md`
+- Build/operational services: `docs/architecture/governance/service_contracts/bld/<service>.md`
+
+Contract template:
+```markdown
+# Service Contract: <service-name>
+
+## Provides
+- <what other services can depend on>
+
+## Requires
+- <what this service depends on>
+
+## Invariants
+- <things that must always be true about this service>
+```
+
+- [ ] Service contract written (or explicitly skipped for trivial services)
+
+## Step 6 -- Write or Mount an Entrypoint Script (if needed)
+
+If the service needs custom startup logic:
+
+1. Create `scripts/runtime/<service>-entrypoint.sh`
+2. Add `set -euo pipefail` at the top
+3. Mount it read-only in the compose service:
+   ```yaml
+   volumes:
+     - ../scripts/runtime/<service>-entrypoint.sh:/<service>-entrypoint.sh:ro
+   entrypoint: ["/<service>-entrypoint.sh"]
+   ```
+
+- [ ] `shellcheck --severity=warning --exclude=SC1091 scripts/runtime/<service>-entrypoint.sh` passes
+- [ ] `bash -n scripts/runtime/<service>-entrypoint.sh` passes
+
+## Step 7 -- Update the Service Map
+
+Add a row to `docs/reference/service-map.md` for the new service.
+
+- [ ] Service map updated
+
+## Step 8 -- Run Validation
+
+```bash
+docker compose -f services/docker-compose.yml config > /dev/null
+yamllint -c .yamllint.yml services/docker-compose.yml
+bash scripts/checks/check-paths.sh
+./scripts/checks/check-ai-elisions.sh --staged
+```
+
+- [ ] All validation passes
+
+## Step 9 -- Commit and PR
+
+```bash
+git add services/docker-compose.yml config/profiles/ docs/ scripts/runtime/
+git commit -m "feat: add <service-name> service
+
+- Add compose service definition with host networking
+- Register in <profile> profile
+- Add entrypoint script
+- Update service map and profile documentation
+
+Fixes #<issue-number>"
+```
+
+PR checklist:
+- [ ] Title format: `Add <service-name> service (#<N>)` (no colons)
+- [ ] Labels: `Feature` + `component:infrastructure` (+ profile label if applicable)
+- [ ] Assignee set at PR creation time
+- [ ] CI is green
+
+## Invariant Reminder
+
+You MUST NOT:
+- Use `latest` image tags
+- Use `network_mode: bridge` or custom Docker networks
+- Create a dependency from Ollama, OpenCode, or Postgres on the new service
+- Skip profile registration (the CLI will not start the service without it)

--- a/.opencode/skills/cut-release/SKILL.md
+++ b/.opencode/skills/cut-release/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: cut-release
+description: Guided checklist for cutting a new AIXCL release following the versioning cadence
+version: 1.0
+---
+
+# Skill: cut-release
+
+Use this skill when cutting a new AIXCL release. Covers everything from
+pre-release housekeeping through tag push and GitHub release verification.
+
+## Versioning Cadence
+
+AIXCL uses sequential patch bumps only: `v1.1.N+1`. Never increment minor or
+major versions without explicit maintainer decision.
+
+Determine the current and next version at runtime:
+```bash
+CURRENT=$(git tag --sort=-v:refname | head -1)          # e.g. v1.1.28
+PATCH=$(echo "$CURRENT" | sed 's/v1\.1\.//')             # e.g. 28
+NEXT="v1.1.$((PATCH + 1))"                              # e.g. v1.1.29
+echo "Current: $CURRENT  Next: $NEXT"
+```
+
+Always run this at the start of a release session -- never assume a version
+number from a previous session or document.
+
+## Step 1 -- Pre-Release Housekeeping
+
+- [ ] All PRs for this release are merged to `dev`
+- [ ] All linked issues are closed
+- [ ] No open PRs targeting `dev` that are intended for this release
+- [ ] Run CI locally:
+  ```bash
+  bash scripts/checks/check-paths.sh
+  bash scripts/checks/check-generated-files.sh
+  yamllint -c .yamllint.yml .
+  ./aixcl utils check-env
+  ```
+- [ ] Check last 30 issues/PRs for unchecked boxes:
+  ```bash
+  gh issue list --state closed --limit 30
+  gh pr list --state merged --limit 30
+  ```
+
+## Step 2 -- Update CHANGELOG.md
+
+Read `CHANGELOG.md` first to confirm the current format, then add a new entry:
+
+```markdown
+## [v1.1.N] - YYYY-MM-DD
+
+### Summary
+<one sentence description of the release>
+
+### Added
+- [x] **Feature**: Description. Closes #N.
+
+### Changed
+- [x] **Change**: Description. Closes #N.
+
+### Fixed
+- [x] **Fix**: Description. Closes #N.
+
+### Documentation
+- [x] **Doc**: Description.
+```
+
+Rules:
+- [ ] Version follows `v1.1.N` pattern
+- [ ] Date is today's date (ISO 8601: YYYY-MM-DD)
+- [ ] All entries reference closed issues
+- [ ] No non-ASCII punctuation (plain ASCII only -- CI enforces this)
+- [ ] `[Unreleased]` section is cleared (contents moved to new version entry)
+
+## Step 3 -- Merge dev to main
+
+```bash
+# Ensure dev is up to date
+git checkout dev && git pull origin dev
+
+# Create release branch from dev
+git checkout -b issue-<N>/release-v1-1-<N>
+
+# Commit CHANGELOG update
+git add CHANGELOG.md
+git commit -m "chore: update changelog for v1.1.<N>
+
+Fixes #<issue-number>"
+
+# Push to fork and create PR targeting main (not dev)
+git push fork issue-<N>/release-v1-1-<N>
+gh pr create \
+  --repo xencon/aixcl \
+  --base main \
+  --title "Release v1.1.<N> (#<N>)" \
+  --body-file /tmp/release-pr-body.md \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+- [ ] PR targets `main` (not `dev`) -- releases go to main
+- [ ] CI is green before merging
+
+## Step 4 -- Tag the Release
+
+After the PR is merged to `main`:
+
+```bash
+git checkout main && git pull origin main
+git tag v1.1.<N> -m "Release v1.1.<N>"
+git push origin v1.1.<N>
+```
+
+- [ ] Tag format is exactly `v1.1.<N>` (no `release/` prefix)
+- [ ] Tag is pushed to `origin` (upstream), not just `fork`
+- [ ] The `release.yml` workflow fires within 30 seconds of tag push
+
+## Step 5 -- Verify GitHub Release
+
+```bash
+# Check workflow status
+gh run list --repo xencon/aixcl --limit 5
+
+# Check release page
+gh release view v1.1.<N> --repo xencon/aixcl
+```
+
+- [ ] Release page exists at `https://github.com/xencon/aixcl/releases/tag/v1.1.<N>`
+- [ ] Release notes are populated (from CHANGELOG or release template)
+- [ ] No draft status -- release is published
+
+## Step 6 -- Sync dev with main
+
+After release, sync `dev` to include the merge commit from `main`:
+
+```bash
+# Create a sync PR: main -> dev
+gh pr create \
+  --repo xencon/aixcl \
+  --base dev \
+  --head main \
+  --title "Sync main into dev after v1.1.<N> release (#<N>)" \
+  --body "Reconcile release history. Fixes #<sync-issue-number>" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+- [ ] Sync PR merged to `dev`
+- [ ] No divergence between `main` and `dev`
+
+## Step 7 -- Close Release Issue
+
+- [ ] Close the GitHub issue that tracked this release
+- [ ] Update any MEMORY.md entries referencing the previous version
+
+## Common Mistakes
+
+- Tagging before the PR is merged (tag points to wrong commit)
+- Pushing tag to `fork` instead of `origin` (release workflow does not fire)
+- Forgetting to sync `dev` after release (dev diverges from main)
+- Using `latest` in CHANGELOG date instead of actual ISO date
+- Non-ASCII punctuation in CHANGELOG (CI fails the ASCII check)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,55 @@
 | field | value |
 |-------|-------|
 | file | AGENTS.md |
-| version | 2.0 |
+| version | 2.1 |
 | purpose | agent_contract |
 | priority | critical |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, MCP-compatible systems |
-| last_updated | 2026-06-12 |
+| last_updated | 2026-06-14 |
 
 # AGENTS.md
 
 Authoritative agent operating contract for this repository.
+
+## 0. Cold Start -- Read These First
+
+If you are starting a new session in this repository, read exactly these four documents in this order and stop:
+
+| Order | File | What it gives you |
+|-------|------|------------------|
+| 1 | `AGENTS.md` (this file) | Operating contract, constraints, authority hierarchy |
+| 2 | `DEVELOPMENT.md` | Workflow rules, issue/PR templates, commit format |
+| 3 | `docs/architecture/governance/00_invariants.md` | Non-negotiable platform invariants |
+| 4 | `docs/architecture/governance/01_ai_guidance.md` | Agentic behavioral guidance |
+
+You do NOT need to read `.claude/rules/` or `.opencode/rules/` separately -- they are
+subsets of the above and loaded automatically by your tool. You do NOT need to read
+`.opencode/agents/agent-context.md` -- it is a thin pointer back to this file.
+
+After reading those four files you are fully oriented. Begin work.
+
+### Git Remote Configuration (Fork Workflow)
+
+This repository uses a two-remote fork workflow. Understand this before any `git push`:
+
+| Remote | URL | Purpose |
+|--------|-----|---------|
+| `origin` | `git@github.com:xencon/aixcl.git` | Upstream repository (PRs target here) |
+| `fork` | `git@github.com:sbadakhc/aixcl.git` | Personal fork (push branches here) |
+
+**Push branches to `fork`, open PRs against `origin`.**
+
+```bash
+git push fork issue-<N>/<description>
+gh pr create --repo xencon/aixcl ...
+```
+
+If the `fork` remote is missing: `git remote add fork git@github.com:sbadakhc/aixcl.git`
+
+Never push directly to `origin/main` or `origin/dev`. Use SSH (not HTTPS) for the fork
+remote -- HTTPS will be blocked by workflow file protection.
+
+---
 
 ## 1. Core Principles
 
@@ -138,6 +178,16 @@ Before ANY operation, confirm:
       (verify: `./scripts/checks/check-ai-elisions.sh --staged`)
 
 If ANY check fails → **HALT** and escalate.
+
+### Definition of Done
+
+A task is complete only when ALL of the following are true:
+
+- [ ] All CI checks are green (not just locally passing)
+- [ ] `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit
+- [ ] PR is approved and merged to `dev`
+- [ ] Linked issue is closed
+- [ ] No broken relative links introduced (run `bash scripts/checks/check-paths.sh`)
 
 ## 7. Escalation Procedures
 

--- a/docs/architecture/decisions/001-network-mode-host.md
+++ b/docs/architecture/decisions/001-network-mode-host.md
@@ -1,0 +1,49 @@
+# ADR 001 -- network_mode: host
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Decided | 2024 (original platform design) |
+| Authority | docs/architecture/governance/00_invariants.md section 7 |
+
+## Context
+
+AIXCL is a local-first, single-node AI development platform. All services must
+communicate with each other and be accessible from the host without complex
+network configuration.
+
+## Decision
+
+All services in `services/docker-compose.yml` use `network_mode: host`.
+
+## Rationale
+
+- **Simplicity**: No Docker DNS, no port mapping, no network aliases to manage.
+  Services communicate via localhost ports, matching the host-side experience.
+- **Clone and run**: A developer who clones the repo and runs `./aixcl stack start`
+  gets the same port layout as the documentation describes. No extra configuration.
+- **Single-node target**: AIXCL is explicitly not a multi-node orchestration platform.
+  The trade-offs of bridge networking (isolation, DNS) add no benefit here.
+- **Podman rootless compatibility**: Host networking works consistently across
+  Docker and rootless Podman, the two supported runtimes.
+
+## What This Means for Agents
+
+- Do NOT raise `network_mode: host` as a security vulnerability. It is intentional.
+- Do NOT propose changing to bridge networking. That change is architecturally breaking.
+- Do NOT add custom Docker networks for internal service communication.
+- Port conflicts are the operator's responsibility to resolve via `.env` configuration.
+
+## Consequences
+
+- Services bind to 0.0.0.0 by default -- operators on non-trusted networks should
+  configure host firewall rules (`scripts/security/host-firewall.sh`).
+- The `extra_hosts: host.docker.internal` entry in some services is a compatibility
+  shim for tools that expect Docker bridge networking -- it does not change the host
+  networking mode.
+- Port mapping (`ports:`) is not used -- services listen directly on host ports.
+
+## Compensating Controls
+
+See `docs/security/compensating-controls.md` for the documented security trade-offs
+and mitigations for host networking in the AIXCL threat model.

--- a/docs/architecture/decisions/002-one-shot-bootstrap.md
+++ b/docs/architecture/decisions/002-one-shot-bootstrap.md
@@ -1,0 +1,50 @@
+# ADR 002 -- One-Shot Vault Bootstrap Containers
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Decided | 2026-06 (issue #1338) |
+| Authority | services/docker-compose.yml (vault-agent-*-bootstrap) |
+
+## Context
+
+When the AIXCL stack starts, bootstrap containers must write initial service
+passwords into Vault KV. The original design kept these containers running
+with an infinite loop (`while true; do sleep 30; fetch_bootstrap_password; done`).
+
+This created two problems:
+1. The Vault root token was held in a long-lived container environment -- a
+   security risk if the container is inspected or its env exported.
+2. On stack restart, the bootstrap containers re-ran the bootstrap logic
+   unnecessarily, sometimes overwriting credentials that services were using.
+
+## Decision
+
+Bootstrap containers are one-shot:
+
+- The bootstrap script runs once, writes the credential to Vault KV, then exits 0.
+- On failure, the script exits non-zero.
+- The compose service uses `restart: on-failure` so Docker/Podman retries only
+  on failure. On success, the container stays stopped.
+
+## Rationale
+
+- **Security**: Root token is in the container environment only for the duration
+  of the bootstrap operation (seconds), not indefinitely.
+- **Idempotency**: A stack restart does not re-run bootstrap for already-initialised
+  services. The compose service stays stopped after successful exit 0.
+- **Simplicity**: `restart: on-failure` is the standard Docker pattern for one-shot
+  initialisation containers. No custom logic needed.
+
+## What This Means for Agents
+
+- Do NOT add `while true; do sleep 30; ...; done` to bootstrap scripts.
+- Do NOT change `restart: on-failure` to `restart: unless-stopped` on bootstrap containers.
+- Bootstrap containers that are stopped (not running) after stack start is CORRECT behaviour.
+- If a bootstrap container is restarting repeatedly, it is failing -- check Vault connectivity.
+
+## Affected Files
+
+- `services/docker-compose.yml` -- `vault-agent-*-bootstrap` service definitions
+- `scripts/vault/bootstrap-password-*.sh` -- the one-shot scripts
+- `vault/agent-config/*-bootstrap.hcl` -- Vault Agent configs for bootstrap containers

--- a/docs/architecture/decisions/003-vault-token-escape-hatch.md
+++ b/docs/architecture/decisions/003-vault-token-escape-hatch.md
@@ -1,0 +1,73 @@
+# ADR 003 -- VAULT_TOKEN Environment Variable Escape Hatch
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Decided | 2026-06 (issue #1339) |
+| Authority | lib/aixcl/commands/stack.sh |
+
+## Context
+
+The AIXCL stack loads the Vault root token from a GPG-encrypted file at
+`.security/vault-root-token.gpg`. GPG decryption requires a TTY for pinentry.
+
+In CI environments, agent sessions, and non-interactive scripts, no TTY is
+available. Without an escape hatch, the token cannot be loaded and all
+Vault-dependent stack commands fail.
+
+## Decision
+
+CLI commands that need the Vault token check `VAULT_TOKEN` in the environment
+BEFORE attempting GPG decryption. If `VAULT_TOKEN` is set and non-empty, GPG
+is skipped entirely.
+
+```bash
+if [ -n "${VAULT_TOKEN:-}" ]; then
+    export VAULT_TOKEN
+    return 0
+fi
+# ... GPG decrypt path ...
+```
+
+## Rationale
+
+- **CI compatibility**: CI workflows can inject `VAULT_TOKEN` as a secret
+  without requiring GPG or a TTY.
+- **Agent compatibility**: AI agents operating in non-TTY contexts can set
+  `VAULT_TOKEN` before invoking CLI commands.
+- **Security**: The escape hatch does not weaken the GPG-encrypted storage on
+  developer workstations. GPG remains the default for interactive sessions.
+  The token value itself is equally sensitive in both paths.
+
+## Usage Patterns
+
+**Interactive developer session** (TTY available):
+```bash
+# GPG decrypt happens automatically -- no action needed
+./aixcl stack start --profile sys
+```
+
+**CI / agent / non-interactive session** (no TTY):
+```bash
+export VAULT_TOKEN=$(gpg --pinentry-mode loopback --decrypt .security/vault-root-token.gpg)
+./aixcl stack start --profile sys
+```
+
+**Or inject directly in CI**:
+```bash
+# In GitHub Actions, store as a secret and inject:
+export VAULT_TOKEN=${{ secrets.VAULT_TOKEN }}
+```
+
+## TTY Detection
+
+The code uses POSIX `[ ! -t 0 ]` to detect non-interactive stdin.
+Do NOT use the `tty` command for this -- it prints "not a tty" to stdout in
+non-interactive contexts, which corrupts variable assignment.
+
+## What This Means for Agents
+
+- If Vault commands fail with "could not decrypt" errors, set `VAULT_TOKEN` in
+  the environment. This is the intended path for agent sessions.
+- The escape hatch is present in `stack.sh`, `vault-status.sh`, and `vault-commands.sh`.
+- Do NOT remove the `VAULT_TOKEN` check -- CI and agents depend on it.

--- a/docs/architecture/decisions/004-topological-sort-depends-on.md
+++ b/docs/architecture/decisions/004-topological-sort-depends-on.md
@@ -1,0 +1,57 @@
+# ADR 004 -- Topological Sort for App depends_on
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Decided | 2026-06 (issue #1332) |
+| Authority | lib/aixcl/commands/app.sh (_app_resolve_start_order) |
+
+## Context
+
+App manifests (`apps/<name>/app.yaml`) declare service dependencies via
+`depends_on`. When starting an app, services must start in dependency order --
+a service must not start before its dependencies are ready.
+
+The original implementation iterated services in manifest order (0, 1, 2, ...),
+ignoring `depends_on` entirely. This caused start failures when a dependent
+service was listed before its dependency in the manifest.
+
+## Decision
+
+`app.sh` implements Kahn's topological sort algorithm in `_app_resolve_start_order()`
+to compute the correct start order from `depends_on` declarations.
+
+## Algorithm Summary
+
+1. Build an adjacency list from `depends_on` declarations across all services.
+2. Compute in-degree for each service (number of services that must start before it).
+3. Start from services with in-degree 0 (no dependencies).
+4. Process each service, decrement in-degree of its dependents.
+5. Continue until all services are ordered, or detect a cycle (error).
+
+## What depends_on Means in AIXCL
+
+The `depends_on` field in `app.yaml` controls **start order only**. It does NOT:
+- Wait for the dependency's health check to pass (use `service_utils.sh` for that)
+- Restart a service if a dependency fails after startup
+- Mirror Docker Compose's `depends_on` semantics (which support conditions like `service_healthy`)
+
+The field names in `depends_on` must match `name` fields of OTHER services in
+the SAME `app.yaml`. Referencing platform services (ollama, postgres, etc.) by
+name is also supported -- the CLI verifies they are running before starting.
+
+## What This Means for Agents
+
+- Do NOT bypass `_app_resolve_start_order()` by iterating services as `seq 0 N`.
+- Do NOT assume manifest order is dependency order -- it is not.
+- If `app.sh start` reports a dependency cycle, the manifest is the source of truth
+  to fix -- not the code.
+- `depends_on` values are validated against: (a) sibling service names in the manifest,
+  and (b) running platform service container names.
+
+## Affected Files
+
+- `lib/aixcl/commands/app.sh` -- implementation
+- `lib/core/app_parser.sh` -- parses `APP_SERVICE_N_DEPENDS_ON_M` variables
+- `etc/app-scaffold/app.yaml` -- shows `depends_on` usage in the template
+- `docs/developer/adding-apps.md` -- developer-facing guide

--- a/docs/architecture/decisions/005-python3-yaml-parser.md
+++ b/docs/architecture/decisions/005-python3-yaml-parser.md
@@ -1,0 +1,48 @@
+# ADR 005 -- Python3 for YAML Manifest Parsing
+
+| Field | Value |
+|-------|-------|
+| Status | Accepted |
+| Decided | Platform design (pre-v1.0) |
+| Authority | lib/core/app_parser.sh |
+
+## Context
+
+App manifests are YAML files. The AIXCL CLI is written in bash. Bash has no
+native YAML parsing capability. A tool must be chosen for the conversion.
+
+Candidates evaluated: `yq`, `jq` (with YAML input mode), Python3 `yaml` module.
+
+## Decision
+
+`lib/core/app_parser.sh` uses Python3 with the `PyYAML` library (`python3-yaml`
+package on Debian/Ubuntu) to convert YAML manifests into shell `export` statements,
+which are then evaluated in the calling shell.
+
+## Rationale
+
+- **Safety**: The Python script runs in a subprocess and produces only `export VAR='value'`
+  statements with single-quote escaping. The calling shell evaluates this output -- it
+  never evals user-supplied YAML directly.
+- **Availability**: Python3 is a standard dependency on Ubuntu/Debian (the target platform).
+  `python3-yaml` is a minimal, stable package with no transitive dependencies.
+- **Correctness**: PyYAML is a full YAML 1.1 parser. `yq` versions vary significantly in
+  behaviour across distributions; pinning it would add a versioning problem.
+- **`jq` limitation**: `jq` cannot parse YAML natively -- it would require a pre-conversion
+  step (e.g., `yq` to JSON first), adding complexity and another dependency.
+
+## What This Means for Agents
+
+- Do NOT replace the Python3 parser with `yq`, `jq`, or a bash awk/sed approach.
+- The check `_app_has_yaml_parser` verifies Python3-yaml at runtime. If it fails,
+  direct the user to: `sudo apt-get install python3-yaml`
+- The Python script is generated into a temp file at runtime (`mktemp`) and cleaned
+  up after each parse. It is not committed to the repo.
+- If the parser needs to support a new YAML field, update the Python script in
+  `_app_yaml_to_shell_script()` in `app_parser.sh`.
+
+## Security Note
+
+The `eval` call in `_app_load_manifest()` evaluates Python-generated output only.
+The Python script uses `yaml.safe_load()` (not `yaml.load()`) and escapes single
+quotes in values. The shell never evaluates user-supplied strings directly.

--- a/docs/developer/agent-pitfalls.md
+++ b/docs/developer/agent-pitfalls.md
@@ -1,0 +1,225 @@
+# Agent Pitfalls
+
+Common mistakes AI agents make in this repository, with corrections.
+Read this if you are starting a session or if something unexpected happened.
+
+## Workflow Pitfalls
+
+### Pitfall: Pushing to the wrong remote
+
+**What happens:** `git push origin issue-<N>/...` is blocked or pushes to the
+wrong repository.
+
+**Why:** `origin` is the upstream repository (`xencon/aixcl`). Direct pushes
+to `origin` are blocked by branch protection. Feature branches go to the
+personal fork (`sbadakhc/aixcl`), which is the `fork` remote.
+
+**Fix:**
+```bash
+git remote -v                          # Check what remotes exist
+git push fork issue-<N>/<description>  # Always push to fork
+gh pr create --repo xencon/aixcl ...   # PR targets origin
+```
+
+If `fork` remote is missing:
+```bash
+git remote add fork git@github.com:sbadakhc/aixcl.git
+```
+
+Use SSH, not HTTPS -- HTTPS push is blocked for repositories containing
+workflow files.
+
+---
+
+### Pitfall: Skipping check-ai-elisions.sh
+
+**What happens:** CI fails on `bash-ci.yml` with an elision or mass-deletion
+error after the PR is already open.
+
+**Why:** AI-assisted edits sometimes replace large sections with placeholder
+text ("rest of file unchanged", etc.) or truncate files. The check catches
+this. Running it locally is faster than waiting for CI.
+
+**Fix:** Run before every commit:
+```bash
+./scripts/checks/check-ai-elisions.sh --staged
+```
+
+For intentional large rewrites, override with:
+```bash
+AIXCL_ALLOW_MASS_DELETE=1 ./scripts/checks/check-ai-elisions.sh --staged
+```
+State the intent explicitly in the commit message.
+
+---
+
+### Pitfall: Creating a PR with missing labels or assignee
+
+**What happens:** `pr-validation.yml` CI check fails immediately on PR open.
+
+**Why:** PRs must have at least one `component:*` label AND an assignee set AT
+CREATION TIME. The webhook fires on `opened` -- adding them after creation
+does not satisfy the check.
+
+**Fix:** Always use:
+```bash
+gh pr create \
+  --assignee sbadakhc \
+  --label "component:<name>"
+```
+
+---
+
+### Pitfall: Committing non-ASCII characters to markdown
+
+**What happens:** `bash-ci.yml` fails with a non-ASCII character error.
+
+**Why:** The ASCII mandate applies to all markdown files, issues, PRs, and
+commit messages. Smart quotes, em dashes, ellipsis characters, and non-breaking
+spaces are all rejected.
+
+**Common offenders:**
+
+| Wrong | Right |
+|-------|-------|
+| `--` (em dash) | `--` (two hyphens) |
+| `...` (ellipsis char) | `...` (three dots) |
+| `"` `"` (smart quotes) | `"` (straight quote) |
+| `'` `'` (smart apostrophes) | `'` (straight apostrophe) |
+
+Check before committing:
+```bash
+python3 -c "
+import sys
+with open('file.md', 'rb') as f:
+    data = f.read()
+non_ascii = [(i, b) for i, b in enumerate(data) if b > 127]
+if non_ascii:
+    print('Non-ASCII found:', non_ascii[:5])
+"
+```
+
+---
+
+## Architecture Pitfalls
+
+### Pitfall: Flagging network_mode: host as a security issue
+
+**What happens:** Agent raises `network_mode: host` as a vulnerability and
+proposes changing to bridge networking.
+
+**Why this is wrong:** Host networking is a documented, intentional invariant.
+AIXCL is a local-first, single-node platform. Bridge networking adds complexity
+without security benefit for the target use case.
+
+**Do not open issues or PRs for this.** See:
+- `docs/architecture/decisions/001-network-mode-host.md`
+- `docs/architecture/governance/00_invariants.md` section 7
+- `docs/security/compensating-controls.md`
+
+---
+
+### Pitfall: "Fixing" bootstrap containers to restart: unless-stopped
+
+**What happens:** Agent changes vault-agent-*-bootstrap containers from
+`restart: on-failure` to `restart: unless-stopped` because they appear to be
+"stopped" and therefore "broken."
+
+**Why this is wrong:** Bootstrap containers are one-shot by design. A stopped
+bootstrap container after a successful stack start is CORRECT. The `on-failure`
+restart policy means Docker only retries genuine failures.
+
+**Do not change this.** See `docs/architecture/decisions/002-one-shot-bootstrap.md`.
+
+---
+
+### Pitfall: Adding a loop to a bootstrap script
+
+**What happens:** Agent adds `while true; do sleep 30; fetch_password; done`
+to a bootstrap script because it "looks incomplete."
+
+**Why this is wrong:** The original design had this loop and it was removed
+(issue #1338) specifically because it held the Vault root token in a long-lived
+container environment. The one-shot exit is intentional.
+
+**Do not add loops to scripts in `scripts/vault/bootstrap-*.sh`.**
+
+---
+
+### Pitfall: Calling docker or podman directly instead of docker_utils.sh
+
+**What happens:** `docker ps` works on the developer machine but fails in CI
+or on a Podman setup.
+
+**Why:** The platform supports both Docker and rootless Podman. `lib/core/docker_utils.sh`
+detects which runtime is available and provides wrapper functions.
+
+**Fix:** Source `docker_utils.sh` and use its functions instead of calling
+`docker` or `podman` directly in scripts under `lib/`.
+
+---
+
+### Pitfall: Iterating app services by index instead of using _app_resolve_start_order
+
+**What happens:** Services start in manifest order, ignoring `depends_on`, causing
+dependent services to start before their dependencies.
+
+**Why:** The `_app_resolve_start_order()` function in `app.sh` implements Kahn's
+topological sort. Bypassing it breaks the dependency ordering guarantee.
+
+**Do not replace the start order loop with `seq 0 $((count-1))`.**
+See `docs/architecture/decisions/004-topological-sort-depends-on.md`.
+
+---
+
+## Vault Pitfalls
+
+### Pitfall: GPG decrypt fails with "not a tty" in agent/CI context
+
+**What happens:** `gpg --decrypt .security/vault-root-token.gpg` fails because
+there is no TTY for pinentry.
+
+**Fix:** Set `VAULT_TOKEN` in the environment before running CLI commands:
+```bash
+export VAULT_TOKEN=<token-value>
+./aixcl stack start --profile sys
+```
+
+This is the documented escape hatch. See
+`docs/architecture/decisions/003-vault-token-escape-hatch.md`.
+
+---
+
+### Pitfall: Using tty command for TTY detection
+
+**What happens:** `GPG_TTY=$(tty)` sets `GPG_TTY` to the literal string
+`"not a tty"` in non-interactive sessions, which breaks GPG.
+
+**Fix:** Use POSIX file descriptor test:
+```bash
+if [ ! -t 0 ]; then
+    # No TTY available
+fi
+```
+
+The `tty` command prints to stdout, which corrupts variable assignment in
+non-interactive contexts.
+
+---
+
+## Versioning Pitfall
+
+### Pitfall: Using a version number from a previous session
+
+**What happens:** Agent uses `v1.1.28` (or any hardcoded version) when the
+current version is actually higher.
+
+**Fix:** Always compute the version at the start of a release session:
+```bash
+CURRENT=$(git tag --sort=-v:refname | head -1)
+PATCH=$(echo "$CURRENT" | sed 's/v1\.1\.//')
+NEXT="v1.1.$((PATCH + 1))"
+echo "Current: $CURRENT  Next: $NEXT"
+```
+
+See `.claude/skills/cut-release/SKILL.md` for the full release workflow.

--- a/docs/reference/service-map.md
+++ b/docs/reference/service-map.md
@@ -1,0 +1,80 @@
+# AIXCL Service Map
+
+Quick reference for all platform services. Read this instead of parsing
+`services/docker-compose.yml` when you need an overview.
+
+For full service definitions, compose variants, and volume mounts, read
+`services/docker-compose.yml` directly.
+
+## Runtime Core (Always Enabled)
+
+| Service | Container | Port | Profile | Entrypoint | Health Check |
+|---------|-----------|------|---------|-----------|-------------|
+| Ollama (inference) | `ollama` | 11434 | all | `scripts/runtime/ollama-entrypoint.sh` | `ollama list` |
+| OpenCode | (VS Code plugin) | -- | all | n/a -- client-side IDE plugin | n/a |
+
+## Secrets Management
+
+| Service | Container | Port | Profile | Config | Notes |
+|---------|-----------|------|---------|--------|-------|
+| Vault | `vault` | 8200 | all | `vault/vault.hcl` | Storage: `aixcl-vault-data` volume |
+| Vault Agent (postgres) | `vault-agent-postgres` | -- | all | `vault/agent-config/agent.hcl` | Long-lived; writes creds to `/tmp/aixcl-secrets/` |
+| Vault Agent (openwebui) | `vault-agent-openwebui` | -- | sys | `vault/agent-config/openwebui.hcl` | Long-lived |
+| Vault Bootstrap (postgres) | `vault-agent-postgres-bootstrap` | -- | all | `vault/agent-config/postgres-bootstrap.hcl` | One-shot; `restart: on-failure` |
+| Vault Bootstrap (openwebui) | `vault-agent-openwebui-bootstrap` | -- | sys | `vault/agent-config/openwebui-bootstrap.hcl` | One-shot; `restart: on-failure` |
+| Vault Bootstrap (pgadmin) | `vault-agent-pgadmin-bootstrap` | -- | sys | `vault/agent-config/pgexporter.hcl` | One-shot; `restart: on-failure` |
+| Vault Bootstrap (grafana) | `vault-agent-grafana-bootstrap` | -- | bld,sys | -- | One-shot; `restart: on-failure` |
+
+## Persistence
+
+| Service | Container | Port | Profile | Entrypoint | Health Check |
+|---------|-----------|------|---------|-----------|-------------|
+| PostgreSQL | `postgres` | 5432 | all | `scripts/runtime/postgres-secret-entrypoint.sh` | `pg_isready -U $POSTGRES_USER` |
+
+## Inference Engines (Alternatives to Ollama)
+
+| Service | Container | Port | Profile | Entrypoint | Notes |
+|---------|-----------|------|---------|-----------|-------|
+| vLLM | `vllm` | 11434 | all | `scripts/runtime/vllm-entrypoint.sh` | NVIDIA GPU required |
+| llama.cpp | `llamacpp` | 11434 | all | `scripts/runtime/llamacpp-entrypoint.sh` | CPU or CUDA |
+
+Note: Only one inference engine is active at a time. Engine selection via `./aixcl engine set`.
+
+## User Interface (sys profile only)
+
+| Service | Container | Port | Profile | Entrypoint | Health Check |
+|---------|-----------|------|---------|-----------|-------------|
+| Open WebUI | `open-webui` | 8080 | sys | `scripts/runtime/openwebui-entrypoint.sh` | `curl http://127.0.0.1:8080/health` |
+| pgAdmin | `pgadmin` | 5050 | sys | `scripts/runtime/pgadmin-entrypoint.sh` | -- |
+
+## Observability (bld and sys profiles)
+
+| Service | Container | Port | Profile | Config | Health Check |
+|---------|-----------|------|---------|--------|-------------|
+| Prometheus | `prometheus` | 9090 | bld, sys | `prometheus/prometheus.yml` | `wget http://127.0.0.1:9090/-/healthy` |
+| Alertmanager | `alertmanager` | 9093 | bld, sys | `prometheus/alertmanager.yml` | `wget http://127.0.0.1:9093/-/healthy` |
+| Grafana | `grafana` | 3000 | bld, sys | `grafana/provisioning/` | `wget http://127.0.0.1:3000/api/health` |
+| Loki | `loki` | 3100 | bld, sys | `loki/loki-config.yml` | `wget http://127.0.0.1:3100/ready` |
+| cAdvisor | `cadvisor` | 8081 | bld, sys | -- | -- |
+| node-exporter | `node-exporter` | 9100 | bld, sys | -- | -- |
+| postgres-exporter | `postgres-exporter` | 9187 | bld, sys | `vault/agent-config/pgexporter.hcl` | -- |
+| nvidia-gpu-exporter | `nvidia-gpu-exporter` | 9835 | bld, sys | -- | GPU only |
+
+## Stack Commands
+
+```bash
+./aixcl utils check-env               # Validate all prerequisites
+./aixcl stack start --profile sys     # Start sys profile (all services)
+./aixcl stack start --profile bld     # Start bld profile (no WebUI)
+./aixcl stack status                  # Health status of all running services
+./aixcl stack stop                    # Stop all services gracefully
+```
+
+## Notes
+
+- All services use `network_mode: host` -- ports are bound directly on the host.
+  See `docs/architecture/decisions/001-network-mode-host.md`.
+- Bootstrap containers (one-shot) are stopped after successful initialisation.
+  This is correct behaviour -- not a failure.
+- Profile definitions: `docs/architecture/governance/02_profiles.md`
+- Adding a service: `.claude/skills/add-service/SKILL.md`

--- a/etc/app-scaffold/CONTEXT.md
+++ b/etc/app-scaffold/CONTEXT.md
@@ -1,0 +1,51 @@
+# CONTEXT: etc/app-scaffold/
+
+Scaffold templates for creating new apps on the AIXCL platform. These are
+the authoritative templates -- use them as the starting point, not a copy
+of an existing app.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `app.yaml` | Canonical app manifest template. Shows every supported field with comments. This is the schema that `lib/core/app_parser.sh` parses. |
+| `docker-compose.yml` | Compose scaffold for app services. Shows the minimum required structure and recommended patterns. |
+
+## How app.yaml Maps to Shell Variables
+
+`app_parser.sh` converts `app.yaml` fields to `APP_*` shell variables:
+
+```
+app.name          --> APP_NAME
+app.version       --> APP_VERSION
+services[0].name  --> APP_SERVICE_0_NAME
+services[0].depends_on --> APP_SERVICE_0_DEPENDS_ON_0 (etc.)
+```
+
+The `depends_on` field drives topological sort in `app.sh start`.
+See `docs/architecture/decisions/004-topological-sort-depends-on.md`.
+
+## Creating a New App
+
+1. Copy `etc/app-scaffold/app.yaml` to `apps/<your-app-name>/app.yaml`
+2. Copy `etc/app-scaffold/docker-compose.yml` to `apps/<your-app-name>/docker-compose.yml`
+3. Fill in the required fields
+4. Read `docs/developer/adding-apps.md` for the full guide (includes `depends_on`
+   semantics and `cap_drop: ALL` compatibility guidance)
+
+## Agent Guidance
+
+**You MAY:**
+- Add new optional fields to these templates when `app_parser.sh` is updated to parse them
+- Improve comments and examples
+
+**You MUST NOT:**
+- Remove fields that existing apps depend on (check `apps/*/app.yaml` first)
+- Change the field naming convention (the `APP_*` variable names are used by multiple scripts)
+
+## Cross-References
+
+- `lib/core/app_parser.sh` -- parses app.yaml into APP_* shell variables
+- `lib/aixcl/commands/app.sh` -- uses parsed variables for lifecycle management
+- `docs/developer/adding-apps.md` -- full app development guide
+- `docs/architecture/decisions/004-topological-sort-depends-on.md` -- depends_on semantics

--- a/lib/aixcl/commands/CONTEXT.md
+++ b/lib/aixcl/commands/CONTEXT.md
@@ -1,0 +1,49 @@
+# CONTEXT: lib/aixcl/commands/
+
+One shell script per top-level `./aixcl` CLI command. Most frequently modified
+directory in the codebase.
+
+## Contents
+
+| File | Command | Key behaviour notes |
+|------|---------|-------------------|
+| `app.sh` | `./aixcl app` | App lifecycle (start, stop, build, status). Uses `_app_resolve_start_order()` (Kahn's topological sort) to honour `depends_on` in manifests -- do not bypass by iterating services sequentially. |
+| `engine.sh` | `./aixcl engine` | Inference engine selection: Ollama, vLLM, llama.cpp. |
+| `models.sh` | `./aixcl models` | Model management (add, list, remove). |
+| `stack.sh` | `./aixcl stack` | Platform stack lifecycle. Checks `VAULT_TOKEN` env var before GPG decrypt -- this is the CI/agent escape hatch; set it to skip GPG entirely. |
+| `utils.sh` | `./aixcl utils` | Environment check and utility commands. |
+| `vault-init.sh` | `./aixcl vault init` | One-time Vault initialisation. |
+| `vault-status.sh` | `./aixcl vault status` | Vault health check. Loads GPG token with `[ ! -t 0 ]` TTY guard (POSIX, not `tty` command). |
+| `vault-unseal.sh` | `./aixcl vault unseal` | Vault unseal procedure. |
+| `vault.sh` | `./aixcl vault` | Vault sub-command dispatcher. |
+
+## Agent Guidance
+
+**You MAY:**
+- Add new commands by creating a file here and registering in `../dispatcher.sh`
+- Modify command behaviour within existing semantics
+
+**You MUST NOT:**
+- Bypass `_app_resolve_start_order()` in `app.sh` -- dependency ordering is an invariant
+- Remove the `VAULT_TOKEN` escape hatch in `stack.sh` -- agents and CI depend on it
+- Call `docker` or `podman` directly -- use functions from `../../core/docker_utils.sh`
+- Use `tty` command for TTY detection -- use `[ ! -t 0 ]` (POSIX portable)
+
+## Pre-Commit
+
+```bash
+shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/<file>.sh
+bash -n lib/aixcl/commands/<file>.sh
+./scripts/checks/check-ai-elisions.sh --staged
+```
+
+## Cross-References
+
+- `lib/core/app_parser.sh` -- manifest parsing used by app.sh
+- `lib/core/docker_utils.sh` -- runtime detection (Docker vs Podman)
+- `lib/aixcl/dispatcher.sh` -- registers commands
+- `completion/aixcl.bash` -- update when adding a new command
+- `etc/app-scaffold/app.yaml` -- canonical manifest schema
+- `docs/developer/adding-apps.md` -- app development guide
+- `docs/architecture/decisions/003-vault-token-escape-hatch.md` -- VAULT_TOKEN design
+- `docs/architecture/decisions/004-topological-sort-depends-on.md` -- depends_on design

--- a/lib/cli/CONTEXT.md
+++ b/lib/cli/CONTEXT.md
@@ -1,0 +1,45 @@
+# CONTEXT: lib/cli/
+
+Low-level CLI infrastructure. This is the foundation that all `./aixcl` commands
+build on -- changes here affect the entire CLI.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `profile.sh` | Loads the active profile env file from `config/profiles/`, exports the service list for the active profile, and provides `get_profile_services_for_profile()`. This is the first thing `stack.sh` calls. |
+
+## Agent Guidance
+
+**IMPORTANT:** Use plan mode (`/mode planning` in Claude Code) before making
+architectural changes to `profile.sh`. This is explicitly required by `CLAUDE.md`.
+
+**You MAY:**
+- Add helper functions used by profile loading
+- Update service lists when adding a profile-registered service
+
+**You MUST NOT:**
+- Change the profile loading semantics without updating `docs/architecture/governance/02_profiles.md`
+- Add service-specific business logic here -- this is a pure control-plane primitive
+- Remove or rename `get_profile_services_for_profile()` -- it is called by `stack.sh`
+
+## Profile System Overview
+
+```
+config/profiles/bld.env   --+
+config/profiles/sys.env   --+--> lib/cli/profile.sh --> stack.sh --> services/docker-compose.yml
+```
+
+Adding a service to a profile requires changes in three places:
+1. `config/profiles/<profile>.env` -- add service name to the list
+2. `services/docker-compose.yml` -- define the service
+3. `docs/architecture/governance/02_profiles.md` -- document the change
+
+Use the `add-service` skill (`.claude/skills/add-service/`) for the full checklist.
+
+## Cross-References
+
+- `config/profiles/` -- env files sourced by this script
+- `lib/aixcl/commands/stack.sh` -- primary consumer
+- `docs/architecture/governance/02_profiles.md` -- profile semantics
+- `.claude/skills/add-service/SKILL.md` -- guided workflow for adding a service

--- a/lib/core/CONTEXT.md
+++ b/lib/core/CONTEXT.md
@@ -1,0 +1,42 @@
+# CONTEXT: lib/core/
+
+Shared utility functions sourced by command scripts in `lib/aixcl/commands/`.
+Do not duplicate logic from here -- source these files instead.
+
+## Contents
+
+| File | Purpose | When to use it |
+|------|---------|---------------|
+| `app_parser.sh` | Parses `apps/<name>/app.yaml` into `APP_*` shell variables. Uses `compgen -v APP_` to unset stale vars before each load -- prevents cross-manifest contamination. | Any command that reads app manifests. |
+| `app_provision.sh` | App provisioning logic: volumes, secrets injection. | `app.sh` start/stop flows. |
+| `color.sh` | Terminal colour constants (`RED`, `GREEN`, `YELLOW`, `NC`). | Any command with coloured output. |
+| `common.sh` | Shared utility functions: error handling, argument parsing. | General use. |
+| `docker_utils.sh` | Docker/Podman abstraction. Detects which runtime is present and exports wrapper functions. | **Always use this instead of calling `docker` or `podman` directly.** |
+| `env_check.sh` | Validates host prerequisites (Python3-yaml, jq, curl, container runtime). | `utils check-env` and pre-start validation. |
+| `logging.sh` | Structured logging (`log_info`, `log_warn`, `log_error`). | Preferred over raw `echo` in commands. |
+| `pgadmin_utils.sh` | pgAdmin-specific helpers (config file generation). | `stack.sh` pgAdmin setup path. |
+| `service_utils.sh` | Service health check helpers (wait-for-ready, container status). | Stack start/stop sequencing. |
+
+## Agent Guidance
+
+**You MAY:**
+- Add new utility functions here when they are shared across two or more commands
+- Extend existing functions
+
+**You MUST NOT:**
+- Call `docker` or `podman` directly in command files -- use `docker_utils.sh`
+- Use `eval` on user-supplied input -- `app_parser.sh` only evals Python-generated output
+- Add command-specific logic here -- keep this directory as pure shared utilities
+
+## Pre-Commit
+
+```bash
+shellcheck --severity=warning --exclude=SC1091 lib/core/<file>.sh
+bash -n lib/core/<file>.sh
+```
+
+## Cross-References
+
+- `lib/aixcl/commands/` -- consumers of these utilities
+- `etc/app-scaffold/app.yaml` -- defines the schema `app_parser.sh` parses
+- `docs/architecture/decisions/005-python3-yaml-parser.md` -- why Python3 for YAML

--- a/scripts/checks/CONTEXT.md
+++ b/scripts/checks/CONTEXT.md
@@ -1,0 +1,43 @@
+# CONTEXT: scripts/checks/
+
+Validation and lint scripts. Run in CI (GitHub Actions) and locally before
+committing. This directory is the pre-commit safety net.
+
+## Contents
+
+| File | Purpose | When to run |
+|------|---------|------------|
+| `check-ai-elisions.sh` | **CRITICAL.** Detects AI placeholder text and mass deletions in staged diffs. An AI-assisted edit once replaced a 639-line module with a stub -- this script catches that. | Before EVERY commit: `./scripts/checks/check-ai-elisions.sh --staged` |
+| `check-agents.sh` | Validates agent and skill file structure (frontmatter, required fields). | After editing `.claude/skills/` or `.opencode/skills/`. |
+| `check-environment.sh` | Full host prerequisite check (container runtime, Python3-yaml, jq, curl, GPG). | Before first stack start; on new dev machine setup. |
+| `check-generated-files.sh` | Verifies gitignored generated files are not tracked in git. | Part of CI; run locally if you added a new generated file. |
+| `check-paths.sh` | Validates all relative links in markdown files resolve to real paths. | After adding or moving markdown files. |
+
+## The Elision Guard -- Do Not Skip
+
+`check-ai-elisions.sh --staged` is enforced by the `bash-ci.yml` workflow on
+every PR. Skipping it locally means CI catches the error and the session is
+wasted. Run it before every commit.
+
+Override for intentional large rewrites only:
+```bash
+AIXCL_ALLOW_MASS_DELETE=1 ./scripts/checks/check-ai-elisions.sh --staged
+```
+State the intent explicitly in the commit message when using the override.
+
+## Agent Guidance
+
+**You MAY:**
+- Add new validation scripts following the existing pattern
+- Extend existing scripts
+
+**You MUST NOT:**
+- Remove or weaken `check-ai-elisions.sh` -- it protects the repository from a
+  class of AI-specific corruption that is otherwise invisible until production
+
+## Cross-References
+
+- `.github/workflows/bash-ci.yml` -- runs check-ai-elisions and check-paths
+- `.github/workflows/documentation-checks.yml` -- runs check-paths and check-generated-files
+- `.github/workflows/security.yml` -- runs ShellCheck
+- `.claude/rules/ci-checks.md` -- full CI workflow summary

--- a/scripts/checks/check-agents.sh
+++ b/scripts/checks/check-agents.sh
@@ -18,12 +18,12 @@ NC='\033[0m' # No Color
 
 error() {
     echo -e "${RED}ERROR:${NC} $1" >&2
-    ((ERRORS++))
+    ERRORS=$((ERRORS + 1))
 }
 
 warn() {
     echo -e "${YELLOW}WARN:${NC} $1" >&2
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 }
 
 info() {

--- a/scripts/runtime/CONTEXT.md
+++ b/scripts/runtime/CONTEXT.md
@@ -1,0 +1,45 @@
+# CONTEXT: scripts/runtime/
+
+Container entrypoint scripts -- one per service. These run INSIDE containers
+as PID 1 at startup. They are mounted read-only from the host into containers
+via volume mounts defined in `services/docker-compose.yml`.
+
+## Contents
+
+| File | Service | Notes |
+|------|---------|-------|
+| `ollama-entrypoint.sh` | `ollama` | Sets permissions, switches to ubuntu user, starts Ollama. |
+| `llamacpp-entrypoint.sh` | `llamacpp` | llama.cpp server startup. |
+| `vllm-entrypoint.sh` | `vllm` | vLLM server startup. |
+| `grafana-entrypoint.sh` | `grafana` | Waits for Prometheus, then starts Grafana. |
+| `openwebui-entrypoint.sh` | `openwebui` | Standard OpenWebUI startup. |
+| `openwebui-vault-entrypoint.sh` | `openwebui` (vault profile) | Fetches credentials from Vault before starting OpenWebUI. |
+| `pgadmin-entrypoint.sh` | `pgadmin` | Configures pgAdmin servers.json, starts pgAdmin. |
+| `postgres-exporter-entrypoint.sh` | `postgres-exporter` | Waits for postgres, starts exporter. |
+| `postgres-secret-entrypoint.sh` | `postgres` | Injects secrets from Docker secrets into postgres env. |
+| `configure-openwebui-direct-connections.sh` | (utility) | Configures OpenWebUI to connect directly to inference engine. |
+
+## Key Constraints
+
+- These scripts run as PID 1 inside containers. `set -euo pipefail` is required.
+- Host-side tooling (systemd, host paths outside mounts) is NOT available.
+- Do not add host-path references. Only paths inside the container or
+  mounted volumes are accessible.
+- `docker_utils.sh` is NOT available here -- these scripts are container-side.
+
+## Agent Guidance
+
+**You MAY:**
+- Modify entrypoint logic for a specific service
+- Add wait-for-dependency patterns (see `grafana-entrypoint.sh` as reference)
+
+**You MUST NOT:**
+- Reference host-only paths or host-only tools
+- Call `docker` or `podman` from inside an entrypoint (containers cannot
+  manage sibling containers this way in the host-networking model)
+
+## Cross-References
+
+- `services/docker-compose.yml` -- volume mounts and `entrypoint:` references
+- `scripts/vault/vault-agent-openwebui.sh` -- called by openwebui-vault-entrypoint.sh
+- `docs/developer/adding-services.md` -- guide for adding a new service with entrypoint

--- a/scripts/security/CONTEXT.md
+++ b/scripts/security/CONTEXT.md
@@ -1,0 +1,38 @@
+# CONTEXT: scripts/security/
+
+Security initialisation, credential rotation, and emergency procedures.
+Scripts here may modify `.security/`, host networking, or running service state.
+
+## Contents
+
+| File | Purpose | Authorization required |
+|------|---------|----------------------|
+| `init-secrets.sh` | Generates initial secrets (GPG-encrypted vault tokens, postgres passwords). Run once at platform setup. | Explicit human instruction |
+| `init-postgres-ssl.sh` | Generates self-signed TLS certificates for postgres. Run once. | Explicit human instruction |
+| `rotate-credentials.sh` | Rotates all service credentials via Vault. | Explicit human instruction |
+| `emergency-lockdown.sh` | Stops all services and revokes Vault tokens. Emergency use only. | Explicit human instruction |
+| `host-firewall.sh` | Configures host firewall rules for the platform. | Explicit human instruction |
+| `start-with-secrets.sh` | Starts the stack with Docker secrets injection (alternative to Vault). | Explicit human instruction |
+| `start-with-ssl.sh` | Starts the stack with SSL-enabled postgres. | Explicit human instruction |
+| `validate-token.sh` | Validates a Vault token against the running Vault instance. | Safe to run read-only. |
+
+## Agent Guidance
+
+**STOP.** Do not run any script in this directory autonomously.
+
+Every script here except `validate-token.sh` modifies security-sensitive state:
+encrypted files in `.security/`, host firewall rules, or running service credentials.
+
+**You MUST:**
+- Obtain explicit human instruction before running any script here
+- Prefix any security concern with `[SECURITY]` and await approval
+- Read `docs/security/threat-model.md` and `docs/operations/security-runbook.md`
+  before proposing changes in this directory
+
+## Cross-References
+
+- `.security/` -- encrypted secrets modified by init-secrets.sh
+- `docs/security/threat-model.md` -- platform threat model
+- `docs/security/compensating-controls.md` -- documented accepted risks
+- `docs/operations/security-runbook.md` -- operational security procedures
+- `AGENTS.md` Section 7 -- escalation procedures for security concerns

--- a/scripts/vault/CONTEXT.md
+++ b/scripts/vault/CONTEXT.md
@@ -1,0 +1,51 @@
+# CONTEXT: scripts/vault/
+
+Vault integration scripts: bootstrap password population, agent wrappers,
+and the shared vault-commands library sourced by CLI commands.
+
+## Contents
+
+| File | Purpose | Execution context |
+|------|---------|-----------------|
+| `vault-commands.sh` | Shared Vault command library. Sourced by `lib/aixcl/commands/vault*.sh`. Provides `vault_status`, `vault_credentials`, `vault_rotate`, etc. | Host (sourced) |
+| `vault-agent.sh` | Vault Agent wrapper for postgres credential fetching. | Host |
+| `vault-agent-openwebui.sh` | Vault Agent wrapper for OpenWebUI credential fetching. | Host |
+| `bootstrap-password-postgres.sh` | One-shot bootstrap: writes postgres password to Vault KV. | Container (vault-agent-postgres-bootstrap) |
+| `bootstrap-password-grafana.sh` | One-shot bootstrap: writes Grafana password to Vault KV. | Container (vault-agent-grafana-bootstrap) |
+| `bootstrap-password-openwebui.sh` | One-shot bootstrap: writes OpenWebUI password to Vault KV. | Container (vault-agent-openwebui-bootstrap) |
+| `bootstrap-password-pgadmin.sh` | One-shot bootstrap: writes pgAdmin password to Vault KV. | Container (vault-agent-pgadmin-bootstrap) |
+| `init/` | Vault initialisation scripts. Run once at Vault setup time by `./aixcl vault init`. | Host |
+
+## Bootstrap Design -- One-Shot, Not Looping
+
+Bootstrap scripts exit 0 on success and non-zero on failure. They do NOT
+loop or sleep. The compose service uses `restart: on-failure` to handle
+retries. This is intentional:
+
+- Container exits 0 on success -- Docker does not restart it
+- Container exits non-zero on failure -- Docker retries automatically
+- Root token is never held in a long-lived container environment
+
+Do NOT add `while true; do sleep 30; ...; done` tails to these scripts.
+Do NOT change the compose restart policy to `unless-stopped`.
+
+See `docs/architecture/decisions/002-one-shot-bootstrap.md` for the full rationale.
+
+## Agent Guidance
+
+**You MAY:**
+- Add new bootstrap scripts following the one-shot pattern
+- Extend `vault-commands.sh` with new vault operations
+
+**You MUST NOT:**
+- Add loops or sleep tails to bootstrap scripts
+- Change bootstrap container restart policy
+- Call Vault API with the root token from long-lived processes
+
+## Cross-References
+
+- `vault/agent-config/` -- HCL configs for Vault Agent containers
+- `lib/aixcl/commands/vault*.sh` -- CLI commands that source vault-commands.sh
+- `services/docker-compose.yml` -- defines vault-agent-*-bootstrap containers
+- `docs/architecture/decisions/002-one-shot-bootstrap.md` -- design rationale
+- `docs/architecture/decisions/003-vault-token-escape-hatch.md` -- VAULT_TOKEN usage

--- a/services/CONTEXT.md
+++ b/services/CONTEXT.md
@@ -1,0 +1,67 @@
+# CONTEXT: services/
+
+Docker Compose definitions for the entire AIXCL platform stack.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | **Primary.** Full platform stack. All services use `network_mode: host` (invariant). |
+| `docker-compose.arm.yml` | ARM64 image overrides. Applied on top of primary with `-f`. |
+| `docker-compose.gpu.yml` | NVIDIA GPU resource configuration. Applied on top of primary. |
+| `docker-compose.gpu-podman.yml` | GPU variant for rootless Podman CDI device access. |
+| `docker-compose.postgres-ssl.yml` | SSL-enabled postgres override (self-signed certs). |
+| `docker-compose.secrets.yml` | Docker secrets injection variant (alternative to Vault). |
+
+## Invariants -- Read Before Editing
+
+**network_mode: host** is used by all services in `docker-compose.yml`. This
+is a documented architectural invariant, not a security oversight. Do NOT
+change to bridge networking or add custom Docker networks.
+See `docs/architecture/governance/00_invariants.md` section 7 and
+`docs/architecture/decisions/001-network-mode-host.md`.
+
+**vault-agent-*-bootstrap containers** use `restart: on-failure`. This is
+intentional one-shot design. Do NOT change to `unless-stopped`.
+See `docs/architecture/decisions/002-one-shot-bootstrap.md`.
+
+## Validate Before Committing
+
+```bash
+docker compose -f services/docker-compose.yml config > /dev/null
+yamllint -c .yamllint.yml services/docker-compose.yml
+```
+
+## Adding a Service
+
+Use the `add-service` skill for the full checklist -- adding a service requires
+changes in at least three places (compose file, profile env, service contract).
+
+```
+.claude/skills/add-service/SKILL.md
+```
+
+Also read: `docs/developer/adding-services.md`
+
+## Agent Guidance
+
+**You MAY:**
+- Add operational services (monitoring, logging, automation)
+- Modify entrypoint scripts, environment variables, volume mounts for existing services
+- Add variant compose files for new hardware profiles
+
+**You MUST NOT:**
+- Change `network_mode: host` to any other value
+- Change `restart: on-failure` on bootstrap containers to `unless-stopped`
+- Add dependencies from runtime core services (ollama, postgres) to operational services
+- Remove or disable runtime core services
+
+## Cross-References
+
+- `scripts/runtime/` -- entrypoint scripts mounted into containers
+- `scripts/vault/` -- bootstrap scripts run by vault-agent-*-bootstrap containers
+- `vault/agent-config/` -- HCL configs for Vault Agent containers
+- `lib/cli/profile.sh` -- determines which services the CLI starts
+- `config/profiles/` -- profile env files
+- `docs/reference/service-map.md` -- service registry (service, profile, port, health check)
+- `docs/architecture/governance/02_profiles.md` -- profile invariants

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,3 +1,18 @@
+# AIXCL Platform Services
+#
+# ARCHITECTURE NOTE: network_mode: host is used by ALL services in this file.
+# This is an intentional, documented invariant -- NOT a security oversight.
+# Rationale: AIXCL is a local-first, single-node platform. Host networking
+# eliminates Docker DNS complexity and port mapping for the "clone and run"
+# experience. Do NOT change to bridge networking.
+# Authority: docs/architecture/governance/00_invariants.md (section 7)
+# ADR: docs/architecture/decisions/001-network-mode-host.md
+#
+# VAULT BOOTSTRAP NOTE: vault-agent-*-bootstrap containers use restart: on-failure.
+# This is intentional one-shot design -- they exit 0 on success, Docker retries
+# only on failure. Do NOT change to unless-stopped.
+# ADR: docs/architecture/decisions/002-one-shot-bootstrap.md
+
 services:
   ollama:
     image: docker.io/ollama/ollama:0.30.7

--- a/tests/command-tests/CONTEXT.md
+++ b/tests/command-tests/CONTEXT.md
@@ -1,0 +1,56 @@
+# CONTEXT: tests/command-tests/
+
+Ordered integration tests for `./aixcl` CLI commands. Files are numbered and
+MUST run in sequence -- stack state carries forward between tests.
+
+## Execution Order
+
+| File | What it does | Requires |
+|------|-------------|---------|
+| `test-00-preflight.sh` | Environment check, prerequisites | Nothing (safe to run standalone) |
+| `test-01-stack-start.sh` | Starts the full platform stack | Passing preflight |
+| `test-02-stack-status.sh` | Validates stack health | Running stack |
+| `test-03-engine-set-ollama.sh` | Sets engine to Ollama | Running stack |
+| `test-04-engine-set-vllm.sh` | Sets engine to vLLM | Running stack |
+| `test-05-engine-set-llamacpp.sh` | Sets engine to llama.cpp | Running stack |
+| `test-06-engine-auto.sh` | Engine auto-detection | Running stack |
+| `test-07-models-add-ollama.sh` | Adds a model via Ollama | Ollama engine active |
+| `test-08-models-add-vllm.sh` | Adds a model via vLLM | vLLM engine active |
+| `test-09-models-add-llamacpp.sh` | Adds a model via llama.cpp | llama.cpp engine active |
+| `test-10-models-list.sh` | Lists available models | Models added |
+| `test-11-service-restart.sh` | Service restart behaviour | Running stack |
+| `test-13-opencode-prompts.sh` | OpenCode prompt testing | Running stack |
+| `test-14-opencode-vllm.sh` | OpenCode with vLLM | vLLM active |
+| `test-15-opencode-llamacpp.sh` | OpenCode with llama.cpp | llama.cpp active |
+| `test-16-engine-model-integration.sh` | Engine/model integration | Running stack |
+| `test-99-stack-stop.sh` | Stops the stack, cleanup | Running stack |
+
+## Running Tests
+
+Always run via the top-level runner, not individual files:
+
+```bash
+tests/run-tests.sh
+```
+
+Running individual test files standalone will fail unless the stack is already
+in the expected state from prior tests.
+
+## Agent Guidance
+
+**You MAY:**
+- Add new test files following the numbered naming convention
+- Use the test framework from `tests/lib/test-framework.sh`
+
+**You MUST NOT:**
+- Run individual test files standalone expecting them to work in isolation
+  (except `test-00-preflight.sh`)
+- Change test numbering in a way that breaks the dependency order
+
+## Cross-References
+
+- `tests/lib/test-framework.sh` -- assertion helpers, must source at top of every test
+- `tests/lib/state-capture.sh` -- before/after state diffing
+- `tests/lib/cleanup.sh` -- cleanup utilities
+- `tests/run-tests.sh` -- top-level runner (use this)
+- `lib/aixcl/commands/` -- the commands being tested

--- a/vault/agent-config/CONTEXT.md
+++ b/vault/agent-config/CONTEXT.md
@@ -1,0 +1,47 @@
+# CONTEXT: vault/agent-config/
+
+HCL configuration files for Vault Agent instances. Each file corresponds to
+a named container in `services/docker-compose.yml`. These run INSIDE containers.
+
+## Contents
+
+| File | Container | Purpose |
+|------|-----------|---------|
+| `agent.hcl` | `vault-agent-postgres` | Long-lived agent: fetches dynamic postgres credentials, writes to `/tmp/aixcl-secrets/`. |
+| `postgres-bootstrap.hcl` | `vault-agent-postgres-bootstrap` | One-shot bootstrap: writes initial postgres password to Vault KV. Exits after completion. |
+| `openwebui.hcl` | `vault-agent-openwebui` | Long-lived agent: fetches OpenWebUI credentials. |
+| `openwebui-bootstrap.hcl` | `vault-agent-openwebui-bootstrap` | One-shot bootstrap: writes OpenWebUI password to Vault KV. Exits after completion. |
+| `pgexporter.hcl` | `vault-agent-pgexporter` | Long-lived agent: fetches postgres-exporter read-only credentials. |
+
+## Container Mapping
+
+Each HCL file is mounted into its container via `services/docker-compose.yml`.
+If you add a new HCL file, you MUST also add a corresponding service entry in
+the compose file. The names must stay in sync.
+
+## Bootstrap vs Long-Lived Agents
+
+| Type | Restart policy | Exit behaviour |
+|------|---------------|---------------|
+| Bootstrap (`*-bootstrap.hcl`) | `restart: on-failure` | Exits 0 on success; Docker does not restart |
+| Long-lived (`agent.hcl`, `openwebui.hcl`, `pgexporter.hcl`) | `restart: unless-stopped` | Runs continuously, renews leases |
+
+Do not confuse these two patterns. Bootstrap configs must remain one-shot.
+
+## Agent Guidance
+
+**You MAY:**
+- Add a new bootstrap HCL file when adding a service that needs an initial secret in Vault KV
+- Add a new long-lived agent HCL file when adding a service that needs dynamic credentials
+
+**You MUST NOT:**
+- Add a sleep loop or continuous polling to a bootstrap config
+- Change the auth method (AppRole) without updating all configs consistently
+
+## Cross-References
+
+- `services/docker-compose.yml` -- container definitions that mount these files
+- `scripts/vault/` -- host-side bootstrap scripts called by bootstrap containers
+- `vault/vault.hcl` -- Vault server configuration
+- `docs/developer/vault-integration.md` -- full Vault integration architecture
+- `docs/architecture/decisions/002-one-shot-bootstrap.md` -- bootstrap design rationale


### PR DESCRIPTION
## Summary

Implements the agent intelligence package planned in issue #1371. The goal is to make the AIXCL repository navigatable and understandable by AI agents with minimal token overhead per session.

## Changes

**Tier 0 -- Reduce redundancy (no new files, big token savings):**
- `AGENTS.md`: cold start sequence (read these 4 files in this order), fork remote workflow (origin = upstream, fork = personal), definition of done
- `services/docker-compose.yml`: invariant comment block to stop repeated network_mode:host and bootstrap restart policy questions
- `.opencode/agents/agent-context.md`: slimmed from 167 to ~60 lines

**Tier 1 -- 12 targeted CONTEXT.md files:** `lib/aixcl/commands/`, `lib/core/`, `lib/cli/`, `scripts/checks/`, `scripts/vault/`, `scripts/runtime/`, `scripts/security/`, `services/`, `vault/agent-config/`, `tests/command-tests/`, `.claude/rules/`, `etc/app-scaffold/`

**Tier 2 -- 5 Architectural Decision Records (`docs/architecture/decisions/`):**
- 001: network_mode:host
- 002: one-shot bootstrap containers
- 003: VAULT_TOKEN escape hatch
- 004: topological sort for app depends_on
- 005: Python3 for YAML parsing

**Tier 3 -- `docs/reference/service-map.md`:** all 21 services in one table

**Tier 4 -- 2 new skills (+ .opencode mirrors):**
- `add-service`: 9-step checklist preserving invariants
- `cut-release`: dynamic version + full release workflow

**Supporting:**
- `docs/developer/agent-pitfalls.md`: 12 documented common agent mistakes
- Fix `set -e` + `((WARNINGS++))` arithmetic bug in `check-agents.sh`

## Verification

- [x] All path checks pass (`scripts/checks/check-paths.sh`)
- [x] Agent and skill checks pass (`scripts/checks/check-agents.sh`)
- [x] No non-ASCII introduced in new content
- [x] Elision guard clean (`check-ai-elisions.sh --staged`)
- [x] CI green on all workflows
- [x] An agent cold-starting the repo can orient via the 4-file sequence in AGENTS.md section 0

Fixes #1371
