### PR TITLE
Fix bootstrap containers shown as unhealthy after successful exit (#1377)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1522,23 +1522,36 @@ function status() {
 
     # Helper function to check both container status and health
     # Returns: 0=healthy, 1=unhealthy, 2=stopped
-    # health_check_type can be: "curl" (with URL), "pg_isready" (with username), "status_var" (with variable name), or empty (no health check)
+    # health_check_type can be: "curl" (with URL), "pg_isready" (with username),
+    #   "status_var" (with variable name), "one-shot" (exited-0 = complete/healthy),
+    #   or empty (running = healthy, no endpoint check)
     check_service_status() {
         local service_name="$1"
         local container_name="$2"
         local health_check_type="$3"
         local health_check_arg="$4"
 
-        # Check container status
+        # Check if container is currently running
         local container_running=false
         if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^${container_name}$"; then
             container_running=true
         fi
 
-        # Check health (only if container is running)
+        # For one-shot containers: check if the container exited successfully (exit code 0).
+        # docker ps only lists running containers, so exited containers need docker ps -a.
+        local container_complete=false
+        if [ "$health_check_type" = "one-shot" ] && [ "$container_running" = "false" ]; then
+            local _exit_code
+            _exit_code=$("${DOCKER_BIN:-docker}" inspect --format '{{.State.ExitCode}}' "$container_name" 2>/dev/null)
+            if [ "$_exit_code" = "0" ]; then
+                container_complete=true
+            fi
+        fi
+
+        # Check health (only if container is running and has an active health check type)
         local health_status=""
         local health_result=""
-        if [ "$container_running" = "true" ] && [ -n "$health_check_type" ]; then
+        if [ "$container_running" = "true" ] && [ -n "$health_check_type" ] && [ "$health_check_type" != "one-shot" ]; then
             case "$health_check_type" in
                 curl)
                     health_result=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 2 --max-time 3 "$health_check_arg" 2>/dev/null || echo "000")
@@ -1573,8 +1586,13 @@ function status() {
         local display_status="${ICON_ERROR:-❌}"
         local is_healthy=false
 
-        if [ "$container_running" = "true" ]; then
-            if [ -z "$health_check_type" ]; then
+        if [ "$container_complete" = "true" ]; then
+            # One-shot container that exited successfully -- job is done
+            display_status="${ICON_SUCCESS:-✅}"
+            health_status=" (complete)"
+            is_healthy=true
+        elif [ "$container_running" = "true" ]; then
+            if [ -z "$health_check_type" ] || [ "$health_check_type" = "one-shot" ]; then
                 display_status="${ICON_SUCCESS:-✅}"
                 is_healthy=true
             else
@@ -1739,10 +1757,11 @@ function status() {
     # Vault Agents (sidecars -- no HTTP endpoints, check container running only)
     check_operational_service "Vault Agent (PostgreSQL)" "vault-agent-postgres" "vault-agent-postgres" "" ""
     check_operational_service "Vault Agent (Open WebUI)" "vault-agent-openwebui" "vault-agent-openwebui" "" ""
-    check_operational_service "Vault Agent Bootstrap (PostgreSQL)" "vault-agent-postgres-bootstrap" "vault-agent-postgres-bootstrap" "" ""
-    check_operational_service "Vault Agent Bootstrap (Open WebUI)" "vault-agent-openwebui-bootstrap" "vault-agent-openwebui-bootstrap" "" ""
-    check_operational_service "Vault Agent Bootstrap (pgAdmin)" "vault-agent-pgadmin-bootstrap" "vault-agent-pgadmin-bootstrap" "" ""
-    check_operational_service "Vault Agent Bootstrap (Grafana)" "vault-agent-grafana-bootstrap" "vault-agent-grafana-bootstrap" "" ""
+    # Bootstrap agents are one-shot: they exit 0 on success. "one-shot" treats exit 0 as healthy.
+    check_operational_service "Vault Agent Bootstrap (PostgreSQL)" "vault-agent-postgres-bootstrap" "vault-agent-postgres-bootstrap" "one-shot" ""
+    check_operational_service "Vault Agent Bootstrap (Open WebUI)" "vault-agent-openwebui-bootstrap" "vault-agent-openwebui-bootstrap" "one-shot" ""
+    check_operational_service "Vault Agent Bootstrap (pgAdmin)" "vault-agent-pgadmin-bootstrap" "vault-agent-pgadmin-bootstrap" "one-shot" ""
+    check_operational_service "Vault Agent Bootstrap (Grafana)" "vault-agent-grafana-bootstrap" "vault-agent-grafana-bootstrap" "one-shot" ""
 
     # Health Summary section
     echo ""

--- a/tests/command-tests/test-02-stack-status.sh
+++ b/tests/command-tests/test-02-stack-status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Test 02: Stack Status
-# Tests stack status command
+# Tests stack status command output and correctness.
+# Regression tests for: https://github.com/xencon/aixcl/issues/1377
 
 set -e
 
@@ -9,11 +10,62 @@ source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
 
 log_test_start "test-02-stack-status"
 
-# Test: Stack status command works
+# Test: Stack status command exits cleanly
 assert_command_success "${SCRIPT_DIR}/aixcl stack status" "Stack status command succeeds"
 
-# Test: Status shows running services (if stack is running)
-# This may show stopped services if previous test cleaned up
-log_info "Note: Status may show stopped services if stack was cleaned up"
+# Capture output for content assertions
+STATUS_OUTPUT=$("${SCRIPT_DIR}/aixcl" stack status 2>&1)
 
-log_test_pass "Stack status command works"
+# Test: Overall summary line is present
+if echo "$STATUS_OUTPUT" | grep -qE "^Services: [0-9]+/[0-9]+ healthy"; then
+    log_test_pass "Services summary line present"
+else
+    log_test_fail "Services summary line missing from stack status output"
+    exit 1
+fi
+
+# Test: If the stack is running, bootstrap containers must show as healthy
+# (regression for issue #1377 -- bootstrap containers showed as red despite exit 0)
+if echo "$STATUS_OUTPUT" | grep -q "Status: Running"; then
+    log_info "Stack is running -- asserting bootstrap container health"
+
+    for bootstrap in \
+        "Vault Agent Bootstrap (PostgreSQL)" \
+        "Vault Agent Bootstrap (Open WebUI)" \
+        "Vault Agent Bootstrap (pgAdmin)" \
+        "Vault Agent Bootstrap (Grafana)"; do
+
+        # Each bootstrap line must start with a success indicator (✅ or [x] fallback)
+        if echo "$STATUS_OUTPUT" | grep -F "$bootstrap" | grep -qE "^[[:space:]]*(✅|\[x\])"; then
+            log_test_pass "Bootstrap healthy: $bootstrap"
+        else
+            bootstrap_line=$(echo "$STATUS_OUTPUT" | grep -F "$bootstrap" || echo "(not found)")
+            log_test_fail "Bootstrap container not showing healthy: $bootstrap -- got: $bootstrap_line"
+            exit 1
+        fi
+    done
+
+    # The complete annotation must be present for at least one bootstrap container
+    if echo "$STATUS_OUTPUT" | grep -q "(complete)"; then
+        log_test_pass "Bootstrap containers show (complete) annotation"
+    else
+        log_test_fail "No bootstrap container shows (complete) -- one-shot status not working"
+        exit 1
+    fi
+
+    # Total healthy count must equal total service count (no red services on a healthy stack)
+    healthy_line=$(echo "$STATUS_OUTPUT" | grep -E "^Services: [0-9]+/[0-9]+ healthy")
+    healthy_count=$(echo "$healthy_line" | grep -oE "^Services: [0-9]+" | grep -oE "[0-9]+")
+    total_count=$(echo "$healthy_line" | grep -oE "/[0-9]+" | tr -d '/')
+
+    if [ "$healthy_count" = "$total_count" ]; then
+        log_test_pass "All services healthy: $healthy_count/$total_count"
+    else
+        log_test_fail "Healthy count mismatch: $healthy_count/$total_count -- some services unhealthy"
+        exit 1
+    fi
+else
+    log_info "Stack is not running -- skipping running-stack assertions"
+fi
+
+log_test_pass "Stack status tests passed"


### PR DESCRIPTION
## Summary

- Adds `one-shot` health_check_type to `check_service_status()`: containers that have exited with code 0 are shown as healthy with a `(complete)` annotation instead of red
- Updates the four `vault-agent-*-bootstrap` status calls to use `one-shot` so a completed bootstrap job is correctly reflected in the `Services: N/N healthy` count
- Extends `test-02-stack-status.sh` with real assertions: each bootstrap container must show healthy, the `(complete)` annotation must be present, and total healthy must equal total services

## Test plan

- [x] `bash tests/command-tests/test-02-stack-status.sh` passes against a running stack
- [x] `./aixcl stack status` shows `19/19 healthy` and `✅ All services healthy` after a clean start
- [x] Each `Vault Agent Bootstrap` entry shows `✅ ... (complete)`
- [x] A bootstrap container that exited non-zero still shows `❌`

Fixes #1377
