### PR TITLE
Fix Loki container healthcheck wget not found in distroless image (#1384)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -588,11 +588,6 @@ services:
     command: -config.file=/etc/loki/loki-config.yml
     network_mode: host
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3100/ready"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
 
 volumes:
   aixcl-ollama-data:


### PR DESCRIPTION
## Summary
Fixes #1384

### Description of Changes
Removes the broken healthcheck from the Loki service in services/docker-compose.yml.

The Loki 3.7.2 image is distroless: no shell (/bin/sh), no wget, no curl. The healthcheck was using "CMD wget" which exits 127 (not found) on every attempt, causing Loki to show as unhealthy in podman and as warning in stack status -- despite Loki correctly serving log queries throughout.

The stack status command already performs an external readiness check via curl against http://127.0.0.1:3100/ready, which correctly reflects Loki's actual health. The container-level healthcheck is redundant and unworkable for this image.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (issue-1384/fix-loki-healthcheck from dev)
- [x] Commit messages follow conventional style
- [x] docker compose config validated clean
- [x] check-ai-elisions.sh --staged passed

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:observability
- [x] Title Format: no colons

### Testing Notes
Confirmed on running stack:
- podman exec loki wget exits 127 (not found)
- podman exec loki curl exits 127 (not found)
- curl http://127.0.0.1:3100/ready returns HTTP 200 / "ready" from host
- container health FailingStreak: 9 before fix
- After fix, container will run without a health check; podman ps shows no health column, and stack status curl check reports healthy

### Verification
- [x] Behavior works as expected (stack status shows Loki healthy after container restart)
- [x] No regressions observed
- [x] No additional tests required -- this removes broken config, not code

### Related Issues
- Closes #1384
