### PR TITLE
Release v1.1.31 (#1386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.31] - 2026-06-14
+
+### Summary
+
+Release v1.1.31 -- Fix for Loki container healthcheck failing on distroless image.
+
+### Fixed
+
+- [x] **Loki Container Healthcheck**: Removed broken `wget`-based healthcheck from the Loki service in `services/docker-compose.yml`. The Loki 3.7.2 image is distroless and contains no shell, wget, or curl. The healthcheck was permanently failing (exit 127), causing Loki to show as unhealthy in podman and as a warning in stack status despite serving requests normally. Stack status already performs an external curl check against `http://127.0.0.1:3100/ready` which correctly reflects Loki readiness. Closes #1384.
+
 ## [v1.1.30] - 2026-06-14
 
 ### Summary


### PR DESCRIPTION
## Summary
Fixes #1386

### Description of Changes
CHANGELOG.md updated with v1.1.31 entry. Single fix in this release:

- Removed broken wget healthcheck from Loki service (issue #1384, PR #1385). The Loki 3.7.2 distroless image has no shell, wget, or curl. The healthcheck was permanently failing, causing false unhealthy status. Stack status curl check against port 3100 already handles readiness correctly.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1386/release-v1-1-31 from dev)
- [x] Commit messages follow conventional style
- [x] check-ai-elisions.sh --staged passed
- [x] No non-ASCII punctuation in CHANGELOG

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:infrastructure
- [x] Title Format: no colons

### Verification
- [x] Release page published at https://github.com/xencon/aixcl/releases/tag/v1.1.31
- [x] Stack status shows all services healthy

### Related Issues
- Closes #1386
