### PR TITLE
Add app register command for external app repos (#1390)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -43,7 +43,23 @@ _aixcl_complete() {
     # List of all possible commands (must stay in sync with lib/aixcl/dispatcher.sh)
     local commands="app stack service models engine utils vault help restart"
 
-    # Application service names are discovered dynamically from apps/*/app.yaml
+    # Application names: built-in (apps/*/app.yaml) plus externally registered apps
+    _aixcl_app_names() {
+        local names=""
+        local d
+        for d in apps/*/; do
+            [ -f "${d}app.yaml" ] && names+=" $(basename "$d")"
+        done
+        local reg="${HOME}/.config/aixcl/registry"
+        if [ -f "$reg" ]; then
+            local line
+            while IFS='=' read -r line _; do
+                [[ "$line" == \#* ]] || [ -z "$line" ] && continue
+                names+=" $line"
+            done < "$reg"
+        fi
+        echo "$names"
+    }
     
     # Service categorization per AIXCL governance model (docs/architecture/governance/00_invariants.md)
     # Runtime Core (Strict): Always enabled, required for AIXCL to function
@@ -102,12 +118,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -128,12 +140,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -148,12 +156,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -205,7 +209,7 @@ _aixcl_complete() {
             return 0
             ;;
         'app')
-            local app_actions="list start stop restart status build remove scaffold install help"
+            local app_actions="list register unregister start stop restart status build remove scaffold install help"
             mapfile -t COMPREPLY < <(compgen -W "$app_actions" -- "$cur")
             return 0
             ;;
@@ -239,6 +243,24 @@ _aixcl_complete() {
                 return 0
             fi
             ;;
+        'register')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                # Complete with directories for the local path argument
+                compopt -o dirnames 2>/dev/null
+                mapfile -t COMPREPLY < <(compgen -d -- "$cur")
+                return 0
+            fi
+            ;;
+        'unregister')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                local app_names
+                app_names="$(_aixcl_app_names)"
+                if [ -n "$app_names" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            ;;
         'install'|'scaffold')
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
                 # No completions: user must type the URL or name
@@ -248,7 +270,7 @@ _aixcl_complete() {
             ;;
         'help')
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                mapfile -t COMPREPLY < <(compgen -W "list start stop restart status build remove scaffold install" -- "$cur")
+                mapfile -t COMPREPLY < <(compgen -W "list register unregister start stop restart status build remove scaffold install" -- "$cur")
                 return 0
             fi
             ;;

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -254,11 +254,44 @@ docker run --rm --entrypoint id redis:7
 on startup (e.g. the Vault image, which starts as a non-root user by
 default) can use `cap_drop: ALL` without the `user:` override.
 
+## External App Repos
+
+Apps do not need to live inside the platform tree. If your app source is in its
+own repository, register it with the platform using its local path:
+
+```bash
+# Clone your app repo somewhere convenient
+git clone git@github.com:you/my-app.git ~/src/my-app
+
+# Register it with the platform (reads app.name from app.yaml)
+./aixcl app register ~/src/my-app
+
+# Use it like any built-in app
+./aixcl app start my-app
+./aixcl app status my-app
+./aixcl app stop my-app
+
+# Remove the registration (does not touch files or running containers)
+./aixcl app unregister my-app
+```
+
+The registry is stored at `~/.config/aixcl/registry` as a plain text file.
+It is machine-local and not committed to the platform repo.
+
+`./aixcl app list` shows both built-in apps and registered external apps,
+with the external path displayed for registered entries.
+
+Tab completion works for `register` (directory paths) and for all app-name
+arguments (`start`, `stop`, `status`, `build`, `unregister`) across both
+built-in and registered apps.
+
 ## CLI Commands
 
 | Command                          | Description                         |
 |----------------------------------|-------------------------------------|
-| `./aixcl app list`               | List installed applications         |
+| `./aixcl app list`               | List all apps (built-in and registered) |
+| `./aixcl app register <path>`    | Register an external app by local path |
+| `./aixcl app unregister <name>`  | Remove a registered external app    |
 | `./aixcl app start <app>`        | Start an application                |
 | `./aixcl app stop <app>`         | Stop an application                 |
 | `./aixcl app restart <app>`      | Restart an application              |
@@ -266,7 +299,7 @@ default) can use `cap_drop: ALL` without the `user:` override.
 | `./aixcl app build <app>`        | Build/rebuild application image     |
 | `./aixcl app provision <app>`    | Provision declared platform resources |
 | `./aixcl app secrets <app>`      | Show provisioned secrets (local dev) |
-| `./aixcl app scaffold <name>`    | Create scaffolding for a new app    |
+| `./aixcl app scaffold <name>`    | Create scaffolding for a new built-in app |
 | `./aixcl app install <url>`      | Install from a git URL              |
 
 ## Prometheus Integration

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -37,25 +37,29 @@ _app_usage() {
 Usage: ./aixcl app <action> [args]
 
 Actions:
-  list                          Discover and list all registered apps
-  start   <name> [--verbose]     Start an app's services from manifest
+  list                          Discover and list all apps (built-in and registered)
+  register <path>               Register an external app repo by local path
+  unregister <name>             Remove a registered external app
+  start   <name> [--verbose]    Start an app's services from manifest
                                 (--verbose shows full compose and build output)
-  stop    <name>                 Stop an app's services
-  restart <name>                 Restart an app's services
-  status  <name>                 Show status of an app's services
-  build   <name>                 Build containers for an app (built: true)
-  provision <name>               Provision declared vault secrets and postgres
-  secrets <name>                 Show an app's provisioned secrets (local dev)
-  remove  <name>                 Stop, rm containers, and prune images
-  scaffold <name>                Generate a new app skeleton from template
+  stop    <name>                Stop an app's services
+  restart <name>                Restart an app's services
+  status  <name>                Show status of an app's services
+  build   <name>                Build containers for an app (built: true)
+  provision <name>              Provision declared vault secrets and postgres
+  secrets <name>                Show an app's provisioned secrets (local dev)
+  remove  <name>                Stop, rm containers, and prune images
+  scaffold <name>               Generate a new app skeleton from template
   install <git-url> [--name <n>] [--branch <b>]
                                 Clone a builder repo as submodule and scaffold
 
 Examples:
+  ./aixcl app register ~/src/my-org/my-app
   ./aixcl app list
-  ./aixcl app start ftso
-  ./aixcl app stop  ftso
-  ./aixcl app build ftso
+  ./aixcl app start my-app
+  ./aixcl app stop  my-app
+  ./aixcl app build my-app
+  ./aixcl app unregister my-app
   ./aixcl app scaffold my-app
   ./aixcl app install git@github.com:user/my-app.git --name my-app
 EOF
@@ -73,7 +77,11 @@ _app_ensure_compose() {
 _app_compose_cmd() {
     local app_name="${1:-}"
     shift
-    local app_dir="${SCRIPT_DIR}/apps/${app_name}"
+    local app_dir
+    if ! app_dir="$(_app_resolve_dir "$app_name")"; then
+        echo "${ICON_ERROR:-[ ]} App not found: ${app_name}" >&2
+        return 1
+    fi
     local compose_file="${app_dir}/docker-compose.yml"
 
     if [ ! -f "$compose_file" ]; then
@@ -363,10 +371,10 @@ app_cmd_list() {
     local apps
     apps="$(_app_discover 2>/dev/null)"
     if [ -z "$apps" ]; then
-        echo "No applications registered."
+        echo "No applications found."
         echo ""
-        echo "Use './aixcl app scaffold <name>' to create a new app,"
-        echo "or './aixcl app install <git-url>' to import an existing one."
+        echo "Use './aixcl app register <path>' to register an external app,"
+        echo "or './aixcl app scaffold <name>' to create a new built-in app."
         return 0
     fi
 
@@ -374,18 +382,24 @@ app_cmd_list() {
     echo "Registered Applications"
     echo "======================"
     echo ""
+    local reg_file
+    reg_file="$(_app_registry_file)"
     while IFS= read -r app_name; do
-        if [ -z "$app_name" ]; then
-            continue
-        fi
-        local version=""
+        [ -z "$app_name" ] && continue
+        local version="" location=""
         if _app_load_manifest "$app_name" 2>/dev/null; then
             version="${APP_VERSION:-}"
         fi
+        # Show path for registered external apps
+        local app_dir
+        app_dir="$(_app_resolve_dir "$app_name" 2>/dev/null || true)"
+        if [ -f "$reg_file" ] && grep -q "^${app_name}=" "$reg_file" 2>/dev/null; then
+            location=" [external: ${app_dir}]"
+        fi
         if [ -n "$version" ]; then
-            printf "  - %-20s (version: %s)\n" "$app_name" "$version"
+            printf "  - %-20s (version: %s)%s\n" "$app_name" "$version" "$location"
         else
-            printf "  - %-20s\n" "$app_name"
+            printf "  - %-20s%s\n" "$app_name" "$location"
         fi
     done <<< "${apps}"
     echo ""
@@ -422,7 +436,9 @@ app_cmd_start() {
         return 1
     fi
 
-    if ! _app_validate_manifest "apps/${app_name}/app.yaml"; then
+    local _start_app_dir
+    _start_app_dir="$(_app_resolve_dir "$app_name")"
+    if ! _app_validate_manifest "${_start_app_dir}/app.yaml"; then
         return 1
     fi
 
@@ -706,6 +722,8 @@ app_cmd_build() {
     local svc_count
     svc_count="$(_app_service_count)"
     local built=0
+    local _build_app_dir
+    _build_app_dir="$(_app_resolve_dir "$app_name")"
     for i in $(seq 0 "$((svc_count - 1))"); do
         if _app_service_needs_build "$i"; then
             local svc_name svc_container build_ctx df
@@ -714,9 +732,8 @@ app_cmd_build() {
             build_ctx="$(_app_service_build_context "$i")"
             df="$(_app_service_build_dockerfile "$i")"
             if [ -n "$build_ctx" ]; then
-                local app_dir="${SCRIPT_DIR}/apps/${app_name}"
                 local abs_ctx
-                abs_ctx="${app_dir}/${build_ctx}"
+                abs_ctx="${_build_app_dir}/${build_ctx}"
                 if [ -d "$abs_ctx" ]; then
                     echo "  Building ${svc_name}..."
                     if "${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" \
@@ -1251,7 +1268,8 @@ EOF
 # Copy Grafana dashboards from app into platform provisioning
 _app_wire_grafana() {
     local app_name="${1:-}"
-    local app_dir="${SCRIPT_DIR}/apps/${app_name}"
+    local app_dir
+    app_dir="$(_app_resolve_dir "$app_name" 2>/dev/null)" || app_dir="${SCRIPT_DIR}/apps/${app_name}"
     local platform_dash="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/${app_name}"
 
     if [ -d "${app_dir}/grafana/dashboards" ]; then
@@ -1260,6 +1278,86 @@ _app_wire_grafana() {
         mkdir -p "$platform_dash"
         cp -f "${app_dir}"/grafana/dashboards/*.json "$platform_dash/" 2>/dev/null || true
     fi
+}
+
+# Usage: app_cmd_register <path>
+# Registers an external app repo by its local path.
+# Reads app.name from the manifest and writes to ~/.config/aixcl/registry.
+app_cmd_register() {
+    local raw_path="${1:-}"
+    if [ -z "$raw_path" ]; then
+        echo "Error: path required. Usage: ./aixcl app register <path>" >&2
+        return 1
+    fi
+
+    _app_ensure_parser
+
+    local app_path
+    app_path="$(cd "$raw_path" 2>/dev/null && pwd)" || {
+        echo "${ICON_ERROR:-[ ]} Path not found: ${raw_path}" >&2
+        return 1
+    }
+
+    local manifest="${app_path}/app.yaml"
+    if [ ! -f "$manifest" ]; then
+        echo "${ICON_ERROR:-[ ]} No app.yaml found at: ${app_path}" >&2
+        return 1
+    fi
+
+    if ! _app_load_manifest_from_path "$manifest"; then
+        echo "${ICON_ERROR:-[ ]} Failed to parse app.yaml at: ${app_path}" >&2
+        return 1
+    fi
+
+    local app_name="${APP_NAME:-}"
+    if [ -z "$app_name" ]; then
+        echo "${ICON_ERROR:-[ ]} app.name not set in manifest at: ${app_path}" >&2
+        return 1
+    fi
+
+    local reg_file
+    reg_file="$(_app_registry_file)"
+    mkdir -p "$(dirname "$reg_file")"
+
+    # Remove any existing entry for this name before writing new one
+    if [ -f "$reg_file" ]; then
+        grep -v "^${app_name}=" "$reg_file" > "${reg_file}.tmp" \
+            && mv "${reg_file}.tmp" "$reg_file" \
+            || rm -f "${reg_file}.tmp"
+    fi
+
+    printf '%s=%s\n' "$app_name" "$app_path" >> "$reg_file"
+    echo "${ICON_SUCCESS:-[x]} Registered '${app_name}'"
+    echo "    Path:     ${app_path}"
+    echo "    Registry: ${reg_file}"
+    echo ""
+    echo "    Run './aixcl app start ${app_name}' to start the app."
+}
+
+# Usage: app_cmd_unregister <name>
+# Removes a registered external app from ~/.config/aixcl/registry.
+# Does not stop running containers or delete any files.
+app_cmd_unregister() {
+    local app_name="${1:-}"
+    if [ -z "$app_name" ]; then
+        echo "Error: app name required. Usage: ./aixcl app unregister <name>" >&2
+        return 1
+    fi
+
+    local reg_file
+    reg_file="$(_app_registry_file)"
+
+    if [ ! -f "$reg_file" ] || ! grep -q "^${app_name}=" "$reg_file" 2>/dev/null; then
+        echo "${ICON_ERROR:-[ ]} '${app_name}' is not a registered external app." >&2
+        return 1
+    fi
+
+    grep -v "^${app_name}=" "$reg_file" > "${reg_file}.tmp" \
+        && mv "${reg_file}.tmp" "$reg_file" \
+        || rm -f "${reg_file}.tmp"
+
+    echo "${ICON_SUCCESS:-[x]} Unregistered '${app_name}'"
+    echo "    Note: running containers and source files are not affected."
 }
 
 # -- Dispatcher entry point -----------------------------------------------------
@@ -1278,6 +1376,12 @@ app_cmd() {
     case "$subcommand" in
         list)
             app_cmd_list "$@"
+            ;;
+        register)
+            app_cmd_register "$@"
+            ;;
+        unregister)
+            app_cmd_unregister "$@"
             ;;
         start)
             app_cmd_start "$@"

--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -80,14 +80,79 @@ _app_yaml_parser_file() {
 
 # Load manifest variables into current shell environment
 # Sets: APP_NAME, APP_VERSION, APP_DESCRIPTION, APP_SERVICE_0_NAME, etc.
-_app_load_manifest() {
-    local app_name="$1"
-    local manifest="apps/${app_name}/app.yaml"
+# Returns path to the registry file (~/.config/aixcl/registry).
+# Format: one entry per line as  name=/absolute/path
+_app_registry_file() {
+    echo "${HOME}/.config/aixcl/registry"
+}
 
+# Resolve the directory for a named app.
+# Checks built-in apps/ first, then the registry.
+# Prints the absolute path and returns 0 on success, 1 if not found.
+_app_resolve_dir() {
+    local app_name="$1"
+    local builtin_dir="${SCRIPT_DIR}/apps/${app_name}"
+    if [ -d "$builtin_dir" ] && [ -f "${builtin_dir}/app.yaml" ]; then
+        echo "$builtin_dir"
+        return 0
+    fi
+    local reg_file
+    reg_file="$(_app_registry_file)"
+    if [ -f "$reg_file" ]; then
+        local reg_path
+        reg_path=$(grep "^${app_name}=" "$reg_file" 2>/dev/null | head -1 | cut -d= -f2-)
+        if [ -n "$reg_path" ] && [ -d "$reg_path" ] && [ -f "${reg_path}/app.yaml" ]; then
+            echo "$reg_path"
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# Parse a manifest at an absolute path, loading variables into the shell.
+# Used by app_cmd_register to extract the app name before registration.
+_app_load_manifest_from_path() {
+    local manifest="$1"
     if [ ! -f "$manifest" ]; then
         echo "[ ] Error: Manifest not found: ${manifest}" >&2
         return 1
     fi
+    if ! _app_has_yaml_parser; then
+        echo "[ ] Error: python3-yaml not installed. Run: sudo apt-get install python3-yaml" >&2
+        return 1
+    fi
+    local parser_file
+    parser_file="$(_app_yaml_parser_file)"
+    if [ -z "$parser_file" ] || [ ! -f "$parser_file" ]; then
+        echo "[ ] Error: Failed to create temporary parser file" >&2
+        return 1
+    fi
+    local exports
+    exports="$(${_APP_PARSER_YAML_TOOL} "$parser_file" "$manifest" 2>/dev/null)"
+    local py_exit=$?
+    rm -f "$parser_file"
+    if [ $py_exit -ne 0 ] || [ -z "$exports" ]; then
+        echo "[ ] Error: Failed to parse manifest: ${manifest}" >&2
+        return 1
+    fi
+    local stale_var
+    while IFS= read -r stale_var; do
+        [ "$stale_var" = "APP_PARSER_YAML_TOOL" ] && continue
+        unset "$stale_var"
+    done < <(compgen -v APP_ || true)
+    eval "$exports"
+    return 0
+}
+
+_app_load_manifest() {
+    local app_name="$1"
+    local app_dir
+    if ! app_dir="$(_app_resolve_dir "$app_name")"; then
+        echo "[ ] Error: App not found: ${app_name}" >&2
+        echo "[ ]   Check apps/ directory or run './aixcl app register <path>'" >&2
+        return 1
+    fi
+    local manifest="${app_dir}/app.yaml"
 
     if ! _app_has_yaml_parser; then
         echo "[ ] Error: python3-yaml not installed. Run: sudo apt-get install python3-yaml" >&2
@@ -125,20 +190,33 @@ _app_load_manifest() {
     return 0
 }
 
-# Discover all apps with valid manifests
+# Discover all apps with valid manifests (built-in and registered).
 _app_discover() {
     local found=0
-    for app_dir in apps/*/; do
-        if [ ! -d "$app_dir" ]; then
-            continue
-        fi
-        local name
+    # Built-in apps under apps/
+    local app_dir name
+    for app_dir in "${SCRIPT_DIR}/apps/"/*/; do
+        [ -d "$app_dir" ] || continue
         name="$(basename "$app_dir")"
-        if [ -f "${app_dir}app.yaml" ]; then
+        if [ -f "${app_dir}/app.yaml" ]; then
             echo "$name"
             found=$((found + 1))
         fi
     done
+    # Registered external apps
+    local reg_file
+    reg_file="$(_app_registry_file)"
+    if [ -f "$reg_file" ]; then
+        local reg_name reg_path
+        while IFS='=' read -r reg_name reg_path; do
+            [ -z "$reg_name" ] && continue
+            [[ "$reg_name" == \#* ]] && continue
+            if [ -f "${reg_path}/app.yaml" ]; then
+                echo "$reg_name"
+                found=$((found + 1))
+            fi
+        done < "$reg_file"
+    fi
     if [ $found -eq 0 ]; then
         return 1
     fi
@@ -187,4 +265,5 @@ _app_service_count() {
 
 # Export functions for app.sh
 export -f _app_has_yaml_parser _app_yaml_to_shell_script _app_yaml_parser_file
+export -f _app_registry_file _app_resolve_dir _app_load_manifest_from_path
 export -f _app_load_manifest _app_discover _app_validate_manifest _app_service_count


### PR DESCRIPTION
## Summary
Fixes #1390

### Description of Changes
Adds `./aixcl app register <path>` and `./aixcl app unregister <name>` so apps living in external repositories can be managed by the platform without copying source into the platform tree.

**How it works:**

- Registry at `~/.config/aixcl/registry` (key=value, machine-local, not committed)
- `_app_resolve_dir <name>` in `app_parser.sh` checks `apps/<name>/` first, then the registry
- All existing commands (start, stop, status, build, remove) route through `_app_resolve_dir` transparently -- external apps are indistinguishable from built-in ones
- `app_cmd_register` reads `app.name` from the manifest, writes the registry entry
- `app_cmd_unregister` removes the entry; does not touch files or containers
- `app_cmd_list` shows built-in and registered apps; external entries show their path
- `_app_load_manifest_from_path` added for parsing a manifest at a direct path (used by register before the app is in the registry)

**Completion:**

- `register` gets directory path completion
- `unregister`, `start`, `stop`, `status`, `build`, `remove` complete names from both `apps/` and the registry via `_aixcl_app_names` helper

**Docs:**

- New "External App Repos" section in `docs/developer/adding-apps.md` with full workflow example
- CLI Commands table updated with register/unregister entries

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch named correctly (issue-1390/app-register-external-repos from dev)
- [x] Commit message follows conventional style
- [x] `bash -n` clean on all modified shell files
- [x] `shellcheck --severity=warning --exclude=SC1091` clean
- [x] `check-ai-elisions.sh --staged` passed
- [x] Built-in apps in `apps/` unaffected -- `_app_resolve_dir` checks there first

### PR Validation Requirements
- [x] Assignee: sbadakhc
- [x] Component Label: component:cli
- [x] Title Format: no colons

### Testing Notes
After merge, verify with the watcher app:
```bash
./aixcl app register ~/src/github.com/sbadakhc/aixcl/apps/watcher
./aixcl app list
./aixcl app start watcher
./aixcl app unregister watcher
```

### Verification
- [x] `./aixcl app register <path>` registers and confirms
- [x] `./aixcl app list` shows registered app with path
- [x] `./aixcl app start <name>` works for registered app
- [x] Tab completion works for name arguments and register path
- [x] `./aixcl app unregister <name>` removes entry cleanly
- [x] Built-in apps still work unchanged

### Related Issues
- Closes #1390
