### PR TITLE
Fix app bash completion for registered external apps and remove subcommand (#1394)

### DIFF
--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -214,14 +214,9 @@ _aixcl_complete() {
             return 0
             ;;
         'status')
-            # If previous word was 'app', complete with available app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -229,16 +224,29 @@ _aixcl_complete() {
             fi
             ;;
         'build')
-            # If previous word was 'app', complete with available app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            ;;
+        'remove')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                local app_names
+                app_names="$(_aixcl_app_names)"
+                if [ -n "$app_names" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "models" ]]; then
+                local available_models
+                available_models=$(_get_ollama_models)
+                if [ -n "$available_models" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$available_models" -- "$cur")
                 fi
                 return 0
             fi
@@ -285,7 +293,7 @@ _aixcl_complete() {
             fi
             ;;
 
-        'add'|'remove')
+        'add')
             # If previous word was 'models', complete with available models
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "models" ]]; then
                 local available_models


### PR DESCRIPTION
## Summary

Fixes #1394

Bash completion for `./aixcl app <subcommand> <TAB>` did not surface externally registered apps for `status` and `build`, and `remove` had no handler at all.

- Replace inline `apps/*/` loops in `status` and `build` with `_aixcl_app_names`, which checks both `apps/*/` and the registry file
- Add `remove` case covering both `app remove` (app names) and `models remove` (model names) contexts
- Retire the old `'add'|'remove'` pattern that only handled the models context; fixes SC2221/SC2222 shadowing warnings from shellcheck

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (override: committed directly to dev per explicit instruction)
- [x] Commit messages follow conventional style
- [x] ShellCheck clean

### Testing Notes

Sourced `completion/aixcl.bash` in a live shell with `watcher` registered as an external app. Confirmed:
- `./aixcl app status <TAB>` completes with `watcher`
- `./aixcl app build <TAB>` completes with `watcher`
- `./aixcl app remove <TAB>` completes with `watcher`
- `./aixcl models remove <TAB>` still completes with Ollama model names

### Verification
- [x] Behavior works as expected
- [x] No regressions observed

### Related Issues
- Closes #1394
