### PR TITLE
Release v1.1.32 (#1396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.32] - 2026-06-15
+
+### Summary
+
+Release v1.1.32 -- Bash completion extended to cover registered external apps for all app subcommands.
+
+### Added
+
+- [x] **External App Completion**: `_aixcl_app_names()` helper reads both built-in `apps/*/app.yaml` and `~/.config/aixcl/registry` (externally registered apps). All app subcommands (`start`, `stop`, `restart`, `status`, `build`, `remove`, `secrets`, `provision`, `unregister`) now complete registered external app names. Closes #1396.
+
+### Fixed
+
+- [x] **Completion for app remove**: `./aixcl app remove <TAB>` now suggests app names (both built-in and registered external). Previously the `remove` case had no completion handler, leaving both built-in and external apps invisible. Closes #1396.
+- [x] **Completion for app secrets/provision**: `./aixcl app secrets <TAB>` and `./aixcl app provision <TAB>` now suggest app names. Closes #1396.
+- [x] **Completion for app register/unregister**: `./aixcl app register <TAB>` now suggests directories; `./aixcl app unregister <TAB>` suggests registered app names. Closes #1396.
+
 ## [v1.1.31] - 2026-06-14
 
 ### Summary

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -43,8 +43,24 @@ _aixcl_complete() {
     # List of all possible commands (must stay in sync with lib/aixcl/dispatcher.sh)
     local commands="app stack service models engine utils vault help restart"
 
-    # Application service names are discovered dynamically from apps/*/app.yaml
-    
+    # Application names: built-in (apps/*/app.yaml) plus externally registered apps
+    _aixcl_app_names() {
+        local names=""
+        local d
+        for d in apps/*/; do
+            [ -f "${d}app.yaml" ] && names+=" $(basename "$d")"
+        done
+        local reg="${HOME}/.config/aixcl/registry"
+        if [ -f "$reg" ]; then
+            local line
+            while IFS='=' read -r line _; do
+                [[ "$line" == \#* ]] || [ -z "$line" ] && continue
+                names+=" $line"
+            done < "$reg"
+        fi
+        echo "$names"
+    }
+
     # Service categorization per AIXCL governance model (docs/architecture/governance/00_invariants.md)
     # Runtime Core (Strict): Always enabled, required for AIXCL to function
     # Note: OpenCode is a VS Code plugin, not a containerized service
@@ -102,12 +118,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -128,12 +140,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -148,12 +156,8 @@ _aixcl_complete() {
             fi
             # If previous word was 'app', complete with app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -210,14 +210,9 @@ _aixcl_complete() {
             return 0
             ;;
         'status')
-            # If previous word was 'app', complete with available app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -225,14 +220,55 @@ _aixcl_complete() {
             fi
             ;;
         'build')
-            # If previous word was 'app', complete with available app names
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
-                local app_names=""
-                for app_dir in apps/*/; do
-                    if [ -f "${app_dir}/app.yaml" ]; then
-                        app_names+=" $(basename "$app_dir")"
-                    fi
-                done
+                local app_names
+                app_names="$(_aixcl_app_names)"
+                if [ -n "$app_names" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            ;;
+        'remove')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                local app_names
+                app_names="$(_aixcl_app_names)"
+                if [ -n "$app_names" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "models" ]]; then
+                local available_models
+                available_models=$(_get_ollama_models)
+                if [ -n "$available_models" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$available_models" -- "$cur")
+                fi
+                return 0
+            fi
+            ;;
+        'secrets'|'provision')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                local app_names
+                app_names="$(_aixcl_app_names)"
+                if [ -n "$app_names" ]; then
+                    mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
+                fi
+                return 0
+            fi
+            ;;
+        'register')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                # Complete with directories for the local path argument
+                compopt -o dirnames 2>/dev/null
+                mapfile -t COMPREPLY < <(compgen -d -- "$cur")
+                return 0
+            fi
+            ;;
+        'unregister')
+            if (( cword >= 2 )) && [[ "${words[cword-2]}" == "app" ]]; then
+                local app_names
+                app_names="$(_aixcl_app_names)"
                 if [ -n "$app_names" ]; then
                     mapfile -t COMPREPLY < <(compgen -W "$app_names" -- "$cur")
                 fi
@@ -253,7 +289,7 @@ _aixcl_complete() {
             fi
             ;;
 
-        'add'|'remove')
+        'add')
             # If previous word was 'models', complete with available models
             if (( cword >= 2 )) && [[ "${words[cword-2]}" == "models" ]]; then
                 local available_models


### PR DESCRIPTION
## Summary

- Release v1.1.32: extend bash completion to cover all app subcommands for both built-in and externally registered apps
- Adds `_aixcl_app_names()` helper that reads `apps/*/app.yaml` and `~/.config/aixcl/registry`
- All app subcommands (`start`, `stop`, `restart`, `status`, `build`, `remove`, `secrets`, `provision`, `register`, `unregister`) now complete app names correctly
- Replaces all hardcoded `apps/*/` loops with the unified helper

## Agent checklist

- [x] Issue referenced: Fixes #1396
- [x] Branch named correctly: `issue-1396/release-v1-1-32-clean` from `main`
- [x] ShellCheck passed (no warnings)
- [x] Bash syntax check passed
- [x] Elision guard passed: `check-ai-elisions.sh --staged`
- [x] CHANGELOG updated for v1.1.32
- [x] No non-ASCII characters in CHANGELOG
- [x] PR targets `main` (release branch)

## Human verification

- [x] Completion works: `./aixcl app <TAB>` shows all registered apps
- [x] `./aixcl app remove <TAB>` suggests app names
- [x] `./aixcl app secrets <TAB>` suggests app names
- [x] CI checks green

Fixes #1396
