### PR TITLE
Fix prometheus file_sd target for externally registered apps (#1402)

### DIFF
--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -1189,7 +1189,8 @@ EOF
 # Generate Prometheus target JSON from manifest variables
 _app_generate_prometheus_targets() {
     local app_name="${1:-}"
-    local app_dir="${SCRIPT_DIR}/apps/${app_name}"
+    local app_dir
+    app_dir="$(_app_resolve_dir "$app_name" 2>/dev/null)" || app_dir="${SCRIPT_DIR}/apps/${app_name}"
     local platform_sd="${SCRIPT_DIR}/prometheus/file_sd"
 
     mkdir -p "$platform_sd"


### PR DESCRIPTION
## Summary

- `_app_generate_prometheus_targets` hardcoded `apps/${app_name}` as the app directory, which does not exist for apps registered via `./aixcl app register`
- The sibling function `_app_wire_grafana` already used `_app_resolve_dir` correctly; this PR applies the same one-line pattern to the prometheus function
- After the fix, `./aixcl app start <external-app>` writes the file_sd JSON and Prometheus begins scraping immediately (no platform restart required)

## Agent checklist

- [x] Issue referenced: Fixes #1402
- [x] Branch from dev: `issue-1402/fix-prometheus-target-external-apps`
- [x] ShellCheck passed (no warnings)
- [x] Elision guard passed
- [x] Change is minimal -- 2 lines (split declaration, use _app_resolve_dir)

## Human verification

- [x] `./aixcl app stop watcher && ./aixcl app start watcher` creates `prometheus/file_sd/watcher.json`
- [x] Prometheus target `localhost:9104` appears healthy in Prometheus targets UI
- [x] Grafana watcher dashboard shows live metrics

Fixes #1402
