### PR TITLE
Fix hardcoded ASCII icons in app build output (#1404)

### DIFF
--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -739,14 +739,14 @@ app_cmd_build() {
                     if "${DOCKER_BIN:-docker}" build -f "${abs_ctx}/${df}" \
                           -t "localhost/${svc_container}:latest" \
                           "$abs_ctx"; then
-                        echo "    [x] Built ${svc_name}"
+                        echo "    ${ICON_SUCCESS:-[x]} Built ${svc_name}"
                         built=$((built + 1))
                     else
-                        echo "    [ ] Build failed for ${svc_name}" >&2
+                        echo "    ${ICON_ERROR:-[ ]} Build failed for ${svc_name}" >&2
                         return 1
                     fi
                 else
-                    echo "  [ ] Build context missing: ${abs_ctx}" >&2
+                    echo "  ${ICON_ERROR:-[ ]} Build context missing: ${abs_ctx}" >&2
                 fi
             fi
         else


### PR DESCRIPTION
## Summary

Three output strings in `app_cmd_build` used hardcoded `[x]` / `[ ]` instead of `${ICON_SUCCESS:-[x]}` / `${ICON_ERROR:-[ ]}`. All other status lines in the file already use the variable form. This makes build success look like ASCII even on UTF-8 terminals.

## Agent checklist

- [x] Issue referenced: Fixes #1404
- [x] Branch from dev
- [x] ShellCheck passed
- [x] Elision guard clean

## Human verification

- [x] `./aixcl app build watcher` shows ✅ Built watcher-moderation

Fixes #1404
