### PR TITLE
Replace hardcoded username with placeholder in release skill examples (#1422)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -95,7 +95,7 @@ gh pr create \
   --base main \
   --title "Release v1.1.<N> (#<N>)" \
   --body-file /tmp/release-pr-body.md \
-  --assignee sbadakhc \
+  --assignee <assignee> \
   --label "Task,component:infrastructure,Maintenance"
 ```
 
@@ -142,7 +142,7 @@ gh pr create \
   --head main \
   --title "Sync main into dev after v1.1.<N> release (#<N>)" \
   --body "Reconcile release history. Fixes #<sync-issue-number>" \
-  --assignee sbadakhc \
+  --assignee <assignee> \
   --label "Task,component:infrastructure,Maintenance"
 ```
 

--- a/.opencode/skills/cut-release/SKILL.md
+++ b/.opencode/skills/cut-release/SKILL.md
@@ -95,7 +95,7 @@ gh pr create \
   --base main \
   --title "Release v1.1.<N> (#<N>)" \
   --body-file /tmp/release-pr-body.md \
-  --assignee sbadakhc \
+  --assignee <assignee> \
   --label "Task,component:infrastructure,Maintenance"
 ```
 
@@ -142,7 +142,7 @@ gh pr create \
   --head main \
   --title "Sync main into dev after v1.1.<N> release (#<N>)" \
   --body "Reconcile release history. Fixes #<sync-issue-number>" \
-  --assignee sbadakhc \
+  --assignee <assignee> \
   --label "Task,component:infrastructure,Maintenance"
 ```
 


### PR DESCRIPTION
Fixes #1422

## Summary

Replace the hardcoded `sbadakhc` username in the `cut-release` skill examples with the generic `\u003cassignee\u003e` placeholder, per DEVELOPMENT.md Section 11.

## Changes

- [x] `.opencode/skills/cut-release/SKILL.md` lines 98 and 145: `--assignee sbadakhc` -> `--assignee \u003cassignee\u003e`
- [x] `.claude/skills/cut-release/SKILL.md` lines 98 and 145: same replacement
- [x] Historical `CHANGELOG.md` entries left unchanged.

## Testing Notes

- Ran `bash scripts/checks/check-agents.sh` — passed (mirror parity preserved).
- Ran `bash scripts/checks/check-paths.sh` — passed.

## Verification

- [x] Both skill mirrors remain byte-identical
- [x] No broken relative links
- [x] CI documentation-checks workflow passes

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
