### PR TITLE
Replace Unicode checkmark with ASCII in bash-ci.yml output (#1424)

### DIFF
--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -46,7 +46,7 @@ jobs:
             echo "You can use: sed -i 's/\\r$//' <file>"
             exit 1
           else
-            echo "✓ No CRLF files found - all line endings are Unix style (LF)"
+            echo "[OK] No CRLF files found - all line endings are Unix style (LF)"
           fi
 
   check-ascii-markdown:


### PR DESCRIPTION
Fixes #1424

## Summary

Replace the Unicode checkmark `✓` in `.github/workflows/bash-ci.yml` with the ASCII equivalent `[OK]`.

## Changes

- [x] Line 49: `echo "✓ No CRLF files found..."` -> `echo "[OK] No CRLF files found..."`
- [x] Verified no other Unicode characters exist in workflow files.

## Testing Notes

- Ran `yamllint -c .yamllint.yml .github/workflows/bash-ci.yml` — only pre-existing line-length warning remains.

## Verification

- [x] No Unicode checkmarks remain in `.github/workflows/bash-ci.yml`
- [x] CI output remains readable
- [x] `bash scripts/checks/check-ai-elisions.sh --staged` passes

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
