### PR TITLE
Remove stale volume references from docker-compose.secrets.yml (#1427)

### DIFF
--- a/services/docker-compose.secrets.yml
+++ b/services/docker-compose.secrets.yml
@@ -103,13 +103,9 @@ volumes:
   # Ensure volumes from main compose are available
   aixcl-pgdata:
     external: true
-  aixcl-open-webui:
-    external: true
   aixcl-open-webui-data:
     external: true
   aixcl-grafana:
     external: true
   aixcl-pgadmin-storage:
-    external: true
-  aixcl-pgadmin:
     external: true


### PR DESCRIPTION
Fixes #1427

## Summary

Remove two stale volume references from `services/docker-compose.secrets.yml` that no longer exist in the main compose file.

## Changes

- [x] Removed `aixcl-open-webui` (renamed to `aixcl-open-webui-main` in main compose).
- [x] Removed `aixcl-pgadmin` (split into `aixcl-pgadmin-main`, `aixcl-pgadmin-config`, `aixcl-pgadmin-storage`).

| Volume in secrets.yml | Status in main compose |
|-----------------------|------------------------|
| `aixcl-open-webui` | Not declared — renamed to `aixcl-open-webui-main` |
| `aixcl-pgadmin` | Not declared — split into multiple volumes |

## Testing Notes

- Ran `docker compose -f services/docker-compose.yml -f services/docker-compose.secrets.yml config` — validated successfully.
- Ran `yamllint -c .yamllint.yml services/docker-compose.secrets.yml` — passed.

## Verification

- [x] Secrets overlay validates against main compose
- [x] No broken relative links
- [x] CI documentation-checks workflow passes

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
