### PR TITLE
Align Vault image version and replace hardcoded podman calls (#1423)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -803,7 +803,7 @@ function start() {
                     --env "VAULT_TOKEN=${_vtoken}" \
                     -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-postgres.sh:/usr/local/bin/bootstrap-password-postgres.sh:ro" \
                     -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:1.18 /usr/local/bin/bootstrap-password-postgres.sh
+                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-postgres.sh
                 "$_bin" run -d --replace --name vault-agent-openwebui-bootstrap --restart unless-stopped \
                     --network host \
                     --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
@@ -813,7 +813,7 @@ function start() {
                     --env "VAULT_TOKEN=${_vtoken}" \
                     -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-openwebui.sh:/usr/local/bin/bootstrap-password-openwebui.sh:ro" \
                     -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:1.18 /usr/local/bin/bootstrap-password-openwebui.sh
+                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-openwebui.sh
                 "$_bin" run -d --replace --name vault-agent-pgadmin-bootstrap --restart unless-stopped \
                     --network host \
                     --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
@@ -823,7 +823,7 @@ function start() {
                     --env "VAULT_TOKEN=${_vtoken}" \
                     -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-pgadmin.sh:/usr/local/bin/bootstrap-password-pgadmin.sh:ro" \
                     -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:1.18 /usr/local/bin/bootstrap-password-pgadmin.sh
+                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-pgadmin.sh
                 "$_bin" run -d --replace --name vault-agent-grafana-bootstrap --restart unless-stopped \
                     --network host \
                     --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
@@ -833,7 +833,7 @@ function start() {
                     --env "VAULT_TOKEN=${_vtoken}" \
                     -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-grafana.sh:/usr/local/bin/bootstrap-password-grafana.sh:ro" \
                     -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:1.18 /usr/local/bin/bootstrap-password-grafana.sh
+                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-grafana.sh
                 # Start non-bootstrap vault agents via compose
                 run_compose up -d --no-deps \
                     vault-agent-postgres \
@@ -847,7 +847,7 @@ function start() {
                     local _pw
                     _pw=$("$_docker_bin" run --rm \
                         -v aixcl-vault-secrets:/s \
-                        docker.io/hashicorp/vault:1.18 \
+                        docker.io/hashicorp/vault:2.0.2 \
                         sh -c "cat /s/postgres-password 2>/dev/null" 2>/dev/null || true)
                     if [ -n "$_pw" ]; then
                         echo "Bootstrap secrets ready."

--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -174,17 +174,7 @@ load_vault_token() {
 # ---------------------------------------------------------------------------
 
 is_vault_running() {
-    local bin="${DOCKER_BIN:-}"
-    if [ -z "$bin" ]; then
-        if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
-            bin="podman"
-        elif command -v docker >/dev/null 2>&1; then
-            bin="docker"
-        else
-            return 1
-        fi
-    fi
-    "$bin" ps --format "{{.Names}}" | grep -q "^vault$"
+    ${DOCKER_BIN:-docker} ps --format "{{.Names}}" | grep -q "^vault$"
 }
 
 # Returns true if the Vault HTTP API is responding (even when sealed/uninitialized)
@@ -259,15 +249,7 @@ wait_for_vault() {
 # Wait for PostgreSQL container to accept connections before configuring Vault DB engine
 wait_for_postgres() {
     log_info "Waiting for PostgreSQL to be ready..."
-    local docker_bin=""
-    if command -v podman >/dev/null 2>&1; then
-        docker_bin="podman"
-    elif command -v docker >/dev/null 2>&1; then
-        docker_bin="docker"
-    else
-        log_warn "No container runtime found; skipping PostgreSQL readiness check"
-        return 0
-    fi
+    local docker_bin="${DOCKER_BIN:-docker}"
 
     local retries=60
     while [ $retries -gt 0 ]; do
@@ -519,12 +501,8 @@ init_bootstrap_passwords() {
             postgres_password=$(cat /run/secrets/postgres-password | tr -d '\n')
             log_info "Read existing PostgreSQL password from shared volume"
         fi
-        if [ -z "$postgres_password" ] && command -v podman >/dev/null 2>&1; then
-            postgres_password=$(podman exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
-            [ -n "$postgres_password" ] && log_info "Read existing PostgreSQL password from container"
-        fi
-        if [ -z "$postgres_password" ] && command -v docker >/dev/null 2>&1; then
-            postgres_password=$(docker exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+        if [ -z "$postgres_password" ]; then
+            postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
             [ -n "$postgres_password" ] && log_info "Read existing PostgreSQL password from container"
         fi
         [ -z "$postgres_password" ] && postgres_password=$(generate_password 32)
@@ -618,11 +596,8 @@ configure_postgres_connection() {
     # Always read the current password from Vault KV (authoritative) or the secrets volume
     postgres_password=$(curl -sf "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null | jq -r '.data.data.password // empty')
-    if [ -z "$postgres_password" ] && command -v podman >/dev/null 2>&1; then
-        postgres_password=$(podman exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
-    fi
-    if [ -z "$postgres_password" ] && command -v docker >/dev/null 2>&1; then
-        postgres_password=$(docker exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+    if [ -z "$postgres_password" ]; then
+        postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
     fi
     if [ -z "$postgres_password" ]; then
         log_error "Could not retrieve PostgreSQL password from Vault KV or container"

--- a/lib/aixcl/commands/vault-status.sh
+++ b/lib/aixcl/commands/vault-status.sh
@@ -41,25 +41,8 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 # Check if Vault container is running
 check_container() {
-    local container_runtime="unknown"
-    local is_running=false
-    
-    if command -v podman >/dev/null 2>&1; then
-        if podman ps --format "{{.Names}}" | grep -q "^vault$"; then
-            container_runtime="podman"
-            is_running=true
-        fi
-    fi
-    
-    if [ "$is_running" = false ] && command -v docker >/dev/null 2>&1; then
-        if docker ps --format "{{.Names}}" | grep -q "^vault$" 2>/dev/null; then
-            container_runtime="docker"
-            is_running=true
-        fi
-    fi
-    
-    if [ "$is_running" = true ]; then
-        echo -e "Container Status:     ${GREEN}Running${NC} ($container_runtime)"
+    if ${DOCKER_BIN:-docker} ps --format "{{.Names}}" 2>/dev/null | grep -q "^vault$"; then
+        echo -e "Container Status:     ${GREEN}Running${NC} (${DOCKER_BIN:-docker})"
         return 0
     else
         echo -e "Container Status:     ${RED}Not Running${NC}"
@@ -202,8 +185,8 @@ check_approle() {
 # Check Vault agents
 check_vault_agents() {
     local agents
-    agents=$(podman ps --format "{{.Names}}" 2>&1 | grep "vault-agent" || true)
-    
+    agents=$(${DOCKER_BIN:-docker} ps --format "{{.Names}}" 2>&1 | grep "vault-agent" || true)
+
     if [ -n "$agents" ]; then
         local count
         count=$(echo "$agents" | wc -l)

--- a/lib/aixcl/commands/vault-unseal.sh
+++ b/lib/aixcl/commands/vault-unseal.sh
@@ -73,7 +73,7 @@ main() {
 
     if is_vault_sealed; then
         log_error "Vault is still sealed after submitting 3 key shares"
-        log_error "  Check: podman logs vault | tail -20"
+        log_error "  Check: ${DOCKER_BIN:-docker} logs vault | tail -20"
         return 1
     fi
 

--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -173,13 +173,13 @@ function cmd_vault_rotate() {
     
     # Restart vault agents to trigger immediate rotation
     local agents
-    agents=$(podman ps --format "{{.Names}}" | grep "vault-agent" || true)
+    agents=$(${DOCKER_BIN:-docker} ps --format "{{.Names}}" | grep "vault-agent" || true)
     
     if [ -n "$agents" ]; then
         echo "Restarting Vault agents for immediate rotation..."
         while IFS= read -r agent; do
             echo "  Restarting $agent..."
-            podman restart "$agent" >/dev/null 2>&1 || true
+            ${DOCKER_BIN:-docker} restart "$agent" >/dev/null 2>&1 || true
         done <<< "$agents"
         echo "Agents restarted. Credentials will be updated within 30 seconds."
     else


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1423

### Description of Changes

Align the Vault container image version used in manual bootstrap container runs with the version declared in `services/docker-compose.yml`. Replace all direct `podman` calls in Vault-related scripts with the `${DOCKER_BIN:-docker}` abstraction so Docker-only hosts can run Vault commands correctly.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All modified scripts pass `bash -n` and `shellcheck`

### Testing Notes

- Updated `lib/aixcl/commands/stack.sh` lines 806, 816, 826, 836, 850: `docker.io/hashicorp/vault:1.18` -> `docker.io/hashicorp/vault:2.0.2`.
- Replaced direct `podman` calls in:
 - `lib/aixcl/commands/vault.sh` (agent restart logic)
 - `lib/aixcl/commands/vault-status.sh` (container and agent checks)
 - `lib/aixcl/commands/vault-init.sh` (runtime detection and postgres password reads)
 - `lib/aixcl/commands/vault-unseal.sh` (error log hint)
- Verified no `podman` or `docker` literal remains in these Vault scripts outside of `${DOCKER_BIN:-docker}`.
- Ran `bash -n` on all modified scripts: passed.
- Ran `shellcheck --severity=warning --exclude=SC1091` on all modified scripts: passed.
- Ran `bash scripts/checks/check-ai-elisions.sh --staged`: passed.
- Ran `bash scripts/checks/check-paths.sh`: passed.

### Verification

- [x] `./aixcl vault status` works with Docker as the container engine.
- [x] `./aixcl vault unseal` works with Docker as the container engine.
- [x] The Vault image tag is identical in `stack.sh` and `docker-compose.yml`.
- [x] `shellcheck` passes on modified Vault scripts.

### Related Issues
- Closes #1423

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
