### PR TITLE
Remove duplicate wait_for_api definition in test framework (#1418)

### DIFF
--- a/tests/lib/test-framework.sh
+++ b/tests/lib/test-framework.sh
@@ -306,24 +306,7 @@ wait_for_api() {
     local url="$1"
     local max_wait="${2:-60}"
     local waited=0
-    
-    log_info "Waiting for API: $url (max ${max_wait}s)"
-    while [[ $waited -lt $max_wait ]]; do
-        if curl -sf "$url" --max-time 5 > /dev/null 2>&1; then
-            log_success "API ready: $url (after ${waited}s)"
-            return 0
-        fi
-        ((waited++))
-    done
-    log_error "Timeout waiting for API: $url"
-    return 1
-}
 
-wait_for_api() {
-    local url="$1"
-    local max_wait="${2:-60}"
-    local waited=0
-    
     log_info "Waiting for API: $url (max ${max_wait}s)"
     while [[ $waited -lt $max_wait ]]; do
         if curl -sf "$url" --max-time 5 > /dev/null 2>&1; then


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1418

### Description of Changes

Remove the first, less useful `wait_for_api()` definition in `tests/lib/test-framework.sh`. The second definition (with progress dots and 2-second sleep) remains.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] Modified script passes `bash -n` and `shellcheck`

### Testing Notes

- Ran `bash -n tests/lib/test-framework.sh`: passed.
- Ran `shellcheck --severity=warning --exclude=SC1091 tests/lib/test-framework.sh`: passed.
- Ran `bash scripts/checks/check-ai-elisions.sh --staged`: passed.
- Ran `bash scripts/checks/check-paths.sh`: passed.

### Verification

- [x] Only one `wait_for_api` definition exists
- [x] Tests that rely on `wait_for_api` still behave correctly
- [x] CI quick-tests workflow passes

### Related Issues
- Closes #1418

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
