### PR TITLE
Replace eval with indirect expansion in app_parser.sh (#1420)

### DIFF
--- a/lib/core/app_parser.sh
+++ b/lib/core/app_parser.sh
@@ -254,7 +254,9 @@ _app_service_count() {
     local count=0
     while true; do
         local svc_name
-        svc_name="$(eval "echo \${APP_SERVICE_${count}_NAME:-}" 2>/dev/null || true)"
+        local varname
+        varname="APP_SERVICE_${count}_NAME"
+        svc_name="${!varname:-}"
         if [ -z "$svc_name" ]; then
             break
         fi


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1420

### Description of Changes

Replace the unnecessary `eval` in `lib/core/app_parser.sh` `_app_service_count()` with bash indirect expansion. This is the cleanest, lowest-risk `eval` removal identified in the issue.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] Modified script passes `bash -n` and `shellcheck`

### Testing Notes

- Ran `bash -n lib/core/app_parser.sh`: passed.
- Ran `shellcheck --severity=warning --exclude=SC1091 lib/core/app_parser.sh`: passed.
- Ran `bash scripts/checks/check-ai-elisions.sh --staged`: passed.
- Ran `bash scripts/checks/check-paths.sh`: passed.

### Verification

- [x] `./aixcl app list` still functions
- [x] `./aixcl app start <app>` still parses manifests correctly
- [x] No `eval` remains on the modified code path
- [x] CI quick-tests workflow passes

### Related Issues
- Closes #1420

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
