### PR TITLE
Pin actions/checkout to SHA in quick-tests.yml (#1445)

### DIFF
--- a/.github/workflows/quick-tests.yml
+++ b/.github/workflows/quick-tests.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run security tests
         run: |
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check script syntax
         run: |
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run lib test category
         run: |


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1445

### Description of Changes

Pin all three `actions/checkout` usages in `.github/workflows/quick-tests.yml` from the floating `@v6` tag to the `v6.0.3` release SHA, with a version comment for auditability.

### Files Changed

- `.github/workflows/quick-tests.yml`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style

### Testing Notes

- Verified SHA resolves to `actions/checkout` `refs/tags/v6.0.3^{}`: `df4cb1c069e1874edd31b4311f1884172cec0e10`.
- `bash scripts/checks/check-paths.sh`: passed.
- `yamllint -c .yamllint.yml .github/workflows/quick-tests.yml`: passed.
- `bash scripts/checks/check-ai-elisions.sh --staged`: passed.

### Verification

- [x] All three checkout actions use SHA pinning
- [x] YAML is valid
- [x] CI quick-tests workflow passes

### Related Issues
- Closes #1445

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization. This PR modifies `.github/workflows/quick-tests.yml`, so it requires manual merge via the GitHub web UI due to the `workflow` scope requirement.
