### PR TITLE
Document check-ai-elisions CI enforcement in rule mirrors (#1428)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -51,7 +51,7 @@ gh pr create \
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
 | pr-validation.yml | PR open/edit | Title format, assignee, component label |
-| bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown |
+| bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |
 | documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, yamllint, compose validate |

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -51,7 +51,7 @@ gh pr create \
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
 | pr-validation.yml | PR open/edit | Title format, assignee, component label |
-| bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown |
+| bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |
 | documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, yamllint, compose validate |


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1428

### Description of Changes

The AI elision guard is already enforced in CI by `.github/workflows/bash-ci.yml` (added in commit `cbebed3`). This PR updates the mirror rule documents to reflect that fact in the CI workflows summary table.

### Files Changed

- `.claude/rules/ci-checks.md`
- `.opencode/rules/ci-checks.md`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] Mirror parity verified

### Testing Notes

- `diff .claude/rules/ci-checks.md .opencode/rules/ci-checks.md`: no output.
- `bash scripts/checks/check-agents.sh`: passed.
- `bash scripts/checks/check-paths.sh`: passed.
- `bash scripts/checks/check-ai-elisions.sh --staged`: passed.

### Verification

- [x] Rule mirrors remain byte-identical
- [x] CI passes
- [x] No broken links introduced

### Related Issues
- Closes #1428

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.
