### PR TITLE
Derive Vault bootstrap agents from compose and profile (#1421)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -672,11 +672,15 @@ function start() {
     # has run and the token is available. This eliminates the token-refresh cascade.
     # All vault-dependent services are excluded from the initial bring-up.
     # They are started explicitly after vault-init runs with the correct token.
-    local VAULT_BOOTSTRAP_AGENTS=(
-        vault-agent-postgres-bootstrap
-        vault-agent-openwebui-bootstrap
-        vault-agent-pgadmin-bootstrap
-        vault-agent-grafana-bootstrap
+    # Bootstrap agents are derived from compose service names and intersected
+    # with the active profile so the bld profile only waits for agents that
+    # are actually part of the profile.
+    local VAULT_BOOTSTRAP_AGENTS=()
+    readarray -t VAULT_BOOTSTRAP_AGENTS < <(_get_vault_bootstrap_agents "$profile")
+
+    # Other vault-dependent services must also be deferred until after Vault
+    # is initialized and the root token is available.
+    local VAULT_DEPENDENT_SERVICES=(
         vault-agent-postgres
         vault-agent-openwebui
         postgres
@@ -685,16 +689,18 @@ function start() {
         postgres-exporter
         grafana
     )
+
+    local deferred_services=("${VAULT_BOOTSTRAP_AGENTS[@]}" "${VAULT_DEPENDENT_SERVICES[@]}")
     local non_bootstrap_services=()
     for _svc in "${profile_services[@]}"; do
-        local _is_bootstrap=false
-        for _ba in "${VAULT_BOOTSTRAP_AGENTS[@]}"; do
-            if [ "$_svc" = "$_ba" ]; then
-                _is_bootstrap=true
+        local _is_deferred=false
+        for _defer in "${deferred_services[@]}"; do
+            if [ "$_svc" = "$_defer" ]; then
+                _is_deferred=true
                 break
             fi
         done
-        if [ "$_is_bootstrap" = false ]; then
+        if [ "$_is_deferred" = false ]; then
             non_bootstrap_services+=("$_svc")
         fi
     done
@@ -794,46 +800,22 @@ function start() {
                 # Force-recreate bootstrap agents with explicit VAULT_TOKEN.
                 # podman-compose 1.0.6 does not interpolate exported shell variables
                 # into compose environment blocks — pass the token directly via podman run.
-                "$_bin" run -d --replace --name vault-agent-postgres-bootstrap --restart unless-stopped \
-                    --network host \
-                    --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
-                    --tmpfs /vault/file:noexec,nosuid,size=1m \
-                    --tmpfs /vault/logs:noexec,nosuid,size=1m \
-                    --env VAULT_ADDR=http://127.0.0.1:8200 \
-                    --env "VAULT_TOKEN=${_vtoken}" \
-                    -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-postgres.sh:/usr/local/bin/bootstrap-password-postgres.sh:ro" \
-                    -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-postgres.sh
-                "$_bin" run -d --replace --name vault-agent-openwebui-bootstrap --restart unless-stopped \
-                    --network host \
-                    --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
-                    --tmpfs /vault/file:noexec,nosuid,size=1m \
-                    --tmpfs /vault/logs:noexec,nosuid,size=1m \
-                    --env VAULT_ADDR=http://127.0.0.1:8200 \
-                    --env "VAULT_TOKEN=${_vtoken}" \
-                    -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-openwebui.sh:/usr/local/bin/bootstrap-password-openwebui.sh:ro" \
-                    -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-openwebui.sh
-                "$_bin" run -d --replace --name vault-agent-pgadmin-bootstrap --restart unless-stopped \
-                    --network host \
-                    --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
-                    --tmpfs /vault/file:noexec,nosuid,size=1m \
-                    --tmpfs /vault/logs:noexec,nosuid,size=1m \
-                    --env VAULT_ADDR=http://127.0.0.1:8200 \
-                    --env "VAULT_TOKEN=${_vtoken}" \
-                    -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-pgadmin.sh:/usr/local/bin/bootstrap-password-pgadmin.sh:ro" \
-                    -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-pgadmin.sh
-                "$_bin" run -d --replace --name vault-agent-grafana-bootstrap --restart unless-stopped \
-                    --network host \
-                    --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
-                    --tmpfs /vault/file:noexec,nosuid,size=1m \
-                    --tmpfs /vault/logs:noexec,nosuid,size=1m \
-                    --env VAULT_ADDR=http://127.0.0.1:8200 \
-                    --env "VAULT_TOKEN=${_vtoken}" \
-                    -v "${SCRIPT_DIR}/scripts/vault/bootstrap-password-grafana.sh:/usr/local/bin/bootstrap-password-grafana.sh:ro" \
-                    -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 /usr/local/bin/bootstrap-password-grafana.sh
+                # The agent list is derived from compose service names so adding a new
+                # bootstrap agent only requires a change in services/docker-compose.yml.
+                for _agent in "${VAULT_BOOTSTRAP_AGENTS[@]}"; do
+                    local _base="${_agent%-bootstrap}"
+                    local _script="bootstrap-password-${_base#vault-agent-}.sh"
+                    "$_bin" run -d --replace --name "$_agent" --restart unless-stopped \
+                        --network host \
+                        --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
+                        --tmpfs /vault/file:noexec,nosuid,size=1m \
+                        --tmpfs /vault/logs:noexec,nosuid,size=1m \
+                        --env VAULT_ADDR=http://127.0.0.1:8200 \
+                        --env "VAULT_TOKEN=${_vtoken}" \
+                        -v "${SCRIPT_DIR}/scripts/vault/${_script}:/usr/local/bin/${_script}:ro" \
+                        -v aixcl-vault-secrets:/run/secrets \
+                        docker.io/hashicorp/vault:2.0.2 "/usr/local/bin/${_script}"
+                done
                 # Start non-bootstrap vault agents via compose
                 run_compose up -d --no-deps \
                     vault-agent-postgres \
@@ -1765,10 +1747,16 @@ function status() {
     check_operational_service "Vault Agent (PostgreSQL)" "vault-agent-postgres" "vault-agent-postgres" "" ""
     check_operational_service "Vault Agent (Open WebUI)" "vault-agent-openwebui" "vault-agent-openwebui" "" ""
     # Bootstrap agents are one-shot: they exit 0 on success. "one-shot" treats exit 0 as healthy.
-    check_operational_service "Vault Agent Bootstrap (PostgreSQL)" "vault-agent-postgres-bootstrap" "vault-agent-postgres-bootstrap" "one-shot" ""
-    check_operational_service "Vault Agent Bootstrap (Open WebUI)" "vault-agent-openwebui-bootstrap" "vault-agent-openwebui-bootstrap" "one-shot" ""
-    check_operational_service "Vault Agent Bootstrap (pgAdmin)" "vault-agent-pgadmin-bootstrap" "vault-agent-pgadmin-bootstrap" "one-shot" ""
-    check_operational_service "Vault Agent Bootstrap (Grafana)" "vault-agent-grafana-bootstrap" "vault-agent-grafana-bootstrap" "one-shot" ""
+    # Derive the list from compose/profile so status checks stay in sync with the active profile.
+    local _status_bootstrap_agents=()
+    readarray -t _status_bootstrap_agents < <(_get_vault_bootstrap_agents "$current_profile")
+    for _agent in "${_status_bootstrap_agents[@]}"; do
+        local _label="${_agent#vault-agent-}"
+        _label="${_label%-bootstrap}"
+        _label="$(tr "-" " " <<<"$_label")"
+        _label="$(awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' <<<"$_label")"
+        check_operational_service "Vault Agent Bootstrap ($_label)" "$_agent" "$_agent" "one-shot" ""
+    done
 
     # Health Summary section
     echo ""

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1751,10 +1751,17 @@ function status() {
     local _status_bootstrap_agents=()
     readarray -t _status_bootstrap_agents < <(_get_vault_bootstrap_agents "$current_profile")
     for _agent in "${_status_bootstrap_agents[@]}"; do
-        local _label="${_agent#vault-agent-}"
-        _label="${_label%-bootstrap}"
-        _label="$(tr "-" " " <<<"$_label")"
-        _label="$(awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' <<<"$_label")"
+        local _label
+        case "$_agent" in
+            *openwebui*) _label="Open WebUI" ;;
+            *pgadmin*)   _label="pgAdmin" ;;
+            *)
+                _label="${_agent#vault-agent-}"
+                _label="${_label%-bootstrap}"
+                _label="$(tr "-" " " <<<"$_label")"
+                _label="$(awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)}1' <<<"$_label")"
+                ;;
+        esac
         check_operational_service "Vault Agent Bootstrap ($_label)" "$_agent" "$_agent" "one-shot" ""
     done
 

--- a/lib/cli/profile.sh
+++ b/lib/cli/profile.sh
@@ -10,8 +10,9 @@
 #   2. services/docker-compose.yml - define the service
 # See: docs/developer/adding-services.md for complete checklist
 
-# Get the repository root relative to this script
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Get the repository root relative to this script.
+# Intentionally namespaced to avoid overwriting the caller's SCRIPT_DIR.
+_PROFILE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Valid profiles array
 # shellcheck disable=SC2034
@@ -44,12 +45,45 @@ declare -A PROFILE_DESCRIPTIONS=(
 # calling shell. Expands $INFERENCE_ENGINE using the current environment.
 _load_profile_services() {
     local profile="$1"
-    local env_file="${SCRIPT_DIR}/config/profiles/${profile}.env"
+    local env_file="${_PROFILE_SCRIPT_DIR}/config/profiles/${profile}.env"
     (
         # shellcheck disable=SC1090
         source "$env_file" 2>/dev/null || true
         printf '%s' "${PROFILE_SERVICES:-}"
     )
+}
+
+# Derive the Vault bootstrap agent list for a profile directly from
+# services/docker-compose.yml service names matching ^vault-agent-.*-bootstrap$,
+# then intersect with the active profile's services. This eliminates the need
+# to maintain the same list in lib/cli/profile.sh and lib/aixcl/commands/stack.sh.
+_get_vault_bootstrap_agents() {
+    local profile="$1"
+    local compose_file="${_PROFILE_SCRIPT_DIR}/services/docker-compose.yml"
+
+    if [ ! -f "$compose_file" ]; then
+        return 0
+    fi
+
+    local all_agents
+    all_agents=$(python3 -c '
+import re, sys, yaml
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+for name in sorted(data.get("services", {}).keys()):
+    if re.match(r"^vault-agent-.*-bootstrap$", name):
+        print(name)
+' "$compose_file" 2>/dev/null)
+
+    if [ -z "$all_agents" ]; then
+        return 0
+    fi
+
+    local active_services
+    active_services=$(get_profile_services_for_profile "$profile" | tr ' ' '\n')
+
+    # Intersection: agents that exist in both compose and the active profile.
+    comm -12 <(printf '%s\n' "$all_agents" | sort) <(printf '%s\n' "$active_services" | sort)
 }
 
 # Profile service mappings (Docker-managed services only)
@@ -201,5 +235,5 @@ print_profile_info() {
 # Export functions for use in other modules
 export -f is_valid_profile get_profile_description get_profile_services
 export -f get_profile_db_storage_enabled list_profiles print_profile_info
-export -f get_profile_services_for_profile get_runtime_core_services _load_profile_services
+export -f get_profile_services_for_profile get_runtime_core_services _load_profile_services _get_vault_bootstrap_agents
 

--- a/lib/cli/profile.sh
+++ b/lib/cli/profile.sh
@@ -65,6 +65,12 @@ _get_vault_bootstrap_agents() {
         return 0
     fi
 
+    if ! python3 -c 'import yaml' 2>/dev/null; then
+        echo "[ERROR] python3 PyYAML is required to discover Vault bootstrap agents." >&2
+        echo "        Install with: pip3 install pyyaml" >&2
+        return 1
+    fi
+
     local all_agents
     all_agents=$(python3 -c '
 import re, sys, yaml
@@ -73,7 +79,7 @@ with open(sys.argv[1]) as f:
 for name in sorted(data.get("services", {}).keys()):
     if re.match(r"^vault-agent-.*-bootstrap$", name):
         print(name)
-' "$compose_file" 2>/dev/null)
+' "$compose_file")
 
     if [ -z "$all_agents" ]; then
         return 0

--- a/tests/lib/tests/test-02-vault-bootstrap-agents.sh
+++ b/tests/lib/tests/test-02-vault-bootstrap-agents.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Test 02: derive Vault bootstrap agents from compose and intersect with profile
+# No running stack required
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${SCRIPT_DIR}/lib/core/common.sh"
+source "${SCRIPT_DIR}/lib/cli/profile.sh"
+source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
+
+log_test_start "test-02-vault-bootstrap-agents"
+
+bld_agents="$(_get_vault_bootstrap_agents bld)"
+sys_agents="$(_get_vault_bootstrap_agents sys)"
+
+# bld profile only includes postgres bootstrap agent
+assert_string_contains "$bld_agents" "vault-agent-postgres-bootstrap" "bld includes postgres bootstrap agent"
+assert_string_not_contains "$bld_agents" "vault-agent-openwebui-bootstrap" "bld excludes openwebui bootstrap agent"
+assert_string_not_contains "$bld_agents" "vault-agent-pgadmin-bootstrap" "bld excludes pgadmin bootstrap agent"
+assert_string_not_contains "$bld_agents" "vault-agent-grafana-bootstrap" "bld excludes grafana bootstrap agent"
+
+# sys profile includes all four bootstrap agents
+assert_string_contains "$sys_agents" "vault-agent-postgres-bootstrap" "sys includes postgres bootstrap agent"
+assert_string_contains "$sys_agents" "vault-agent-openwebui-bootstrap" "sys includes openwebui bootstrap agent"
+assert_string_contains "$sys_agents" "vault-agent-pgadmin-bootstrap" "sys includes pgadmin bootstrap agent"
+assert_string_contains "$sys_agents" "vault-agent-grafana-bootstrap" "sys includes grafana bootstrap agent"
+
+log_test_pass "Vault bootstrap agents derived from compose and profile"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1421

### Description of Changes

Eliminate the hardcoded `VAULT_BOOTSTRAP_AGENTS` array in `lib/aixcl/commands/stack.sh` and replace it with a runtime-derived list that:

- Parses `services/docker-compose.yml` for services matching `^vault-agent-.*-bootstrap$` (via `_get_vault_bootstrap_agents()` in `lib/cli/profile.sh`)
- Intersects the compose-derived list with the active profile's services so `bld` only waits for `vault-agent-postgres-bootstrap`, not all four agents
- Derives the bootstrap script name from the agent name (`vault-agent-X-bootstrap` -> `bootstrap-password-X.sh`) so adding a new bootstrap agent requires only a change in `services/docker-compose.yml`

Also separates the previously conflated `VAULT_BOOTSTRAP_AGENTS` (which contained both bootstrap agents and non-bootstrap vault-dependent services) into distinct `VAULT_BOOTSTRAP_AGENTS` and `VAULT_DEPENDENT_SERVICES` arrays.

Addresses the latent `bld` profile bug identified in the issue: with a hardcoded list of 4 agents, `bld` stack start would wait on agents that were never started.

Also renames `SCRIPT_DIR` to `_PROFILE_SCRIPT_DIR` in `lib/cli/profile.sh` to avoid overwriting the caller's `SCRIPT_DIR` (follow-up from PR #1449 review).

### Files Changed

- `lib/cli/profile.sh` -- `_get_vault_bootstrap_agents()`, `_PROFILE_SCRIPT_DIR` rename
- `lib/aixcl/commands/stack.sh` -- derive `VAULT_BOOTSTRAP_AGENTS` at runtime, separate `VAULT_DEPENDENT_SERVICES`
- `tests/lib/tests/test-02-vault-bootstrap-agents.sh` -- new lib unit test

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] bash -n on modified scripts passed
- [x] shellcheck --severity=warning --exclude=SC1091 passed
- [x] check-ai-elisions --staged passed
- [x] check-paths.sh passed
- [x] bash tests/run-tests.sh --category lib passed

### PR Validation Requirements
- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:cli, component:infrastructure
- [x] **Title Format**: compliant

### Testing Notes

- `bash -n lib/cli/profile.sh lib/aixcl/commands/stack.sh`: passed
- `shellcheck --severity=warning --exclude=SC1091` on modified files: passed
- `bash tests/run-tests.sh --category lib`: passed (3 tests including new test-02)
- `./aixcl help`: passed
- `bash scripts/checks/check-ai-elisions.sh --staged`: passed

### Verification
- [x] `./aixcl stack start --profile bld` only starts `vault-agent-postgres-bootstrap`, not all four
- [x] `./aixcl stack start --profile sys` starts all four bootstrap agents
- [x] `./aixcl stack status` reports the correct set of bootstrap agents per profile
- [x] Adding a new bootstrap agent in `docker-compose.yml` is picked up automatically

### Related Issues
- Closes #1421

## Notes

This commit is unsigned because the agent environment lacks a TTY for GPG pinentry. Per DEVELOPMENT.md Section 4, agent-driven commits may be unsigned with operator authorization.

PR created on behalf of the implementation agent (OpenCode) after an accidental empty `gh pr create` call.
