### PR TITLE
Fix single quotes in release.yml awk comment (#1456)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             index($0, "## [") == 1 && in_section { in_section=0 }
             !in_section { next }
 
-            # Section header detection (accept both '###Summary' and '### Summary')
+            # Section header detection (accept both ###Summary and ### Summary)
             match($0, /^###[ \t]*Summary/) { section="Summary"; is_summary=1; next }
             match($0, /^###[ \t]*Fixed/)    { section="Fixed";    next }
             match($0, /^###[ \t]*Changed/)  { section="Changed";  next }


### PR DESCRIPTION
## Summary

- Remove single quotes from the awk comment on the section-header detection block (line 64 of `release.yml`)
- The apostrophes terminated the shell single-quoted awk program early, causing exit code 2 and "no such file or directory" on every tag push
- This bug caused the v1.1.34 release workflow to fail; the release was created manually as a workaround

## Test plan

- [x] `yamllint -c .yamllint.yml .github/workflows/release.yml` -- clean
- [x] `./scripts/checks/check-ai-elisions.sh --staged` -- clean
- [x] CI green; next release tag push should produce a successful workflow run

Fixes #1456

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-15
- Method: Release workflow failure diagnosis and one-line fix
- Scope: .github/workflows/release.yml line 64
- Confirmation: yes
---
