### PR TITLE
Fix app status separator hardcoded at 30 chars (#1460)

### DIFF
--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -641,9 +641,12 @@ app_cmd_status() {
     local total_services=0
     local healthy_services=0
 
+    local _title="${app_name^^} Application Status"
+    local _sep=""
+    for (( _i=0; _i<${#_title}; _i++ )); do _sep="${_sep}="; done
     echo ""
-    echo "${app_name^^} Application Status"
-    echo "=============================="
+    echo "$_title"
+    echo "$_sep"
     echo ""
     echo "App: ${app_name}"
     echo "Status: ${overall_status}"


### PR DESCRIPTION
## Summary

`app_cmd_status()` printed a hardcoded 30-char `======` separator under the app title. The title is `"${app_name^^} Application Status"` whose length varies by app name:

- `ftso` (4 chars) -> title 23 chars, separator 7 chars too long
- `my-monitor-app` (14 chars) -> title 33 chars, separator 3 chars too short

This PR replaces the hardcoded string with a separator computed from the actual title length using a portable `for` loop (no `printf` width magic, no `seq`).

Fixes #1460

## Checklist

- [x] Issue referenced
- [x] Branch from dev
- [x] Commit follows conventional format
- [x] ShellCheck passed (--severity=warning --exclude=SC1091)
- [x] `check-ai-elisions.sh --staged` passed
- [x] CI checks green (human verification)
- [x] Output verified for short and long app names (human verification)

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-15
- Method: Platform fix extracted from ftso branch audit; separator logic applied to current dev app.sh (NOT from the older ftso branch version which was missing register/unregister/provision/secrets)
- Scope: lib/aixcl/commands/app.sh app_cmd_status()
- Confirmation: yes
---
