### PR TITLE
Clear stale Vault unseal keys when prune wipes vault volume (#1463)

### DIFF
--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -32,6 +32,17 @@ function prune() {
     rm -f .aixcl.initialized .env pgadmin-servers.json
     echo ""
 
+    # The Vault data volume is wiped below, which invalidates the existing
+    # unseal-key/root-token artefacts (they only decrypt to valid key shares
+    # for the specific Vault instance that generated them). Remove them too
+    # so the next `./aixcl vault init` performs a clean re-init instead of
+    # failing with "still sealed after submitting N key shares" (stale keys
+    # vs a fresh volume). The rest of .security/ is left alone -- clearing
+    # the whole directory remains prune_all()'s responsibility.
+    echo "Removing stale Vault unseal artefacts (data volume is about to be wiped)..."
+    rm -f "${SCRIPT_DIR}/.security/vault-keys.gpg" "${SCRIPT_DIR}/.security/vault-root-token.gpg"
+    echo ""
+
     # Remove all containers before volumes -- Podman will not release a volume
     # while any container (even stopped) still references it. stack stop removes
     # running containers but stopped/exited ones may linger with volume mounts.
@@ -61,6 +72,7 @@ function prune() {
     echo ""
 
     echo "Prune complete. Images retained for fast restart."
+    echo "Vault will be freshly re-initialized on next start (new unseal keys and root token)."
     echo "Run './aixcl stack init && ./aixcl stack start --profile sys' to bring the stack back up."
 }
 


### PR DESCRIPTION
## Summary
`./aixcl utils prune` (plain prune, not `--all`) wipes all volumes, including `aixcl-vault-data`, but left `.security/vault-keys.gpg` and `.security/vault-root-token.gpg` behind. On the next stack start, Vault boots with a fresh empty data volume but `vault-init.sh` finds the stale artefacts and tries to unseal it with key shares from the destroyed instance, which can never succeed -- the unseal fails permanently with "still sealed after submitting N key shares".

Fixes #1463

## Change
In `prune()` (`lib/aixcl/commands/utils.sh`), remove the two Vault artefact files alongside the existing state-file cleanup, so the next `./aixcl vault init` performs a clean re-init instead of dead-ending. The rest of `.security/` is untouched -- clearing the whole directory remains `prune_all()`'s job, which is unaffected by this change.

## Testing
- [x] `bash -n lib/aixcl/commands/utils.sh`
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/utils.sh` (clean)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` (clean)
- [x] Manual: `./aixcl utils prune && ./aixcl stack init && ./aixcl stack start --profile sys` results in a freshly initialized, unsealed Vault with no manual recovery steps (human verification)

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Diagnosed via volume/artefact timestamp comparison, implemented targeted fix in lib/aixcl/commands/utils.sh
- Scope: lib/aixcl/commands/utils.sh (prune function only)
- Confirmation: yes, code change made (12 lines added, no deletions)
