### PR TITLE
Never remove volumes on stack stop force-shutdown (#1465)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1030,7 +1030,11 @@ function stop() {
     done
 
     echo "Warning: Services did not stop gracefully. Forcing shutdown..."
-    run_compose down --remove-orphans -v
+    # NOTE: deliberately no -v here. Volume removal is a destructive,
+    # explicit operation reserved for `./aixcl utils prune` / `prune --all`.
+    # A slow/stuck container must never cause persistent data (Vault seal
+    # state, Postgres databases, etc.) to be silently destroyed.
+    run_compose down --remove-orphans
     "${DOCKER_BIN:-docker}" ps -q | xargs -r "${DOCKER_BIN:-docker}" stop
 
     _print_stopped_status "$profile"


### PR DESCRIPTION
## Summary
`./aixcl stack stop` silently destroyed all volumes (including `aixcl-vault-data` and `aixcl-pgdata`) whenever a container failed to stop gracefully within 60 seconds. The force-shutdown fallback ran `docker compose down --remove-orphans -v`, with only a generic "Forcing shutdown..." message -- no indication that persistent data was about to be destroyed.

Fixes #1465

## Change
Removed `-v` from the force-shutdown fallback in `stop()` (`lib/aixcl/commands/stack.sh`). Containers are still force-stopped via the existing `docker ps -q | xargs -r docker stop` line; volumes are now left alone in every code path of `stop()`. Volume removal remains exclusive to `./aixcl utils prune` / `prune --all`, which are explicit, clearly-labelled operations.

## Testing
- [x] `bash -n lib/aixcl/commands/stack.sh`
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/stack.sh` (clean)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` (clean)
- [x] Manual: trigger the force-shutdown path (slow-stopping container) and confirm `docker volume ls` count is unchanged before/after (human verification)

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Diagnosed via code review of stop() correlated with live volume/artefact timestamps observed during troubleshooting; implemented targeted one-line fix
- Scope: lib/aixcl/commands/stack.sh (stop function only)
- Confirmation: yes, code change made (5 lines added, 1 removed)
