### PR TITLE
Make vault bootstrap agents Docker-engine compatible (#1471)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -797,15 +797,36 @@ function start() {
                 echo "Starting Vault bootstrap agents..."
                 local _vtoken="${VAULT_TOKEN}"
                 local _bin="${DOCKER_BIN:-podman}"
+
+                # Ensure the shared secrets volume is writable by the image's
+                # non-root runtime user (uid 100, gid 1000) regardless of
+                # which engine created it. Podman rootless remaps this
+                # transparently via user namespaces; plain Docker does not,
+                # so a root-owned volume directory silently blocks every
+                # bootstrap agent below from writing its secret. Fix
+                # ownership narrowly (no chmod 777, no running the agents
+                # themselves as root) -- the same "briefly root, then drop
+                # privilege" pattern already used by the open-webui and
+                # pgadmin entrypoints elsewhere in this codebase. Safe to
+                # run every time: a no-op once ownership is already correct.
+                # --network none: this one-shot container only touches a
+                # volume, it never needs network access.
+                "$_bin" run --rm --network none --user 0:0 -v aixcl-vault-secrets:/run/secrets \
+                    docker.io/hashicorp/vault:2.0.2 chown -R 100:1000 /run/secrets \
+                    >/dev/null 2>&1 || true
+
                 # Force-recreate bootstrap agents with explicit VAULT_TOKEN.
                 # podman-compose 1.0.6 does not interpolate exported shell variables
                 # into compose environment blocks — pass the token directly via podman run.
                 # The agent list is derived from compose service names so adding a new
                 # bootstrap agent only requires a change in services/docker-compose.yml.
+                # NOTE: --replace is Podman-only (unsupported by plain Docker), so any
+                # existing same-named container is removed explicitly first instead.
                 for _agent in "${VAULT_BOOTSTRAP_AGENTS[@]}"; do
                     local _base="${_agent%-bootstrap}"
                     local _script="bootstrap-password-${_base#vault-agent-}.sh"
-                    "$_bin" run -d --replace --name "$_agent" --restart unless-stopped \
+                    "$_bin" rm -f "$_agent" >/dev/null 2>&1 || true
+                    "$_bin" run -d --name "$_agent" --restart unless-stopped \
                         --network host \
                         --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
                         --tmpfs /vault/file:noexec,nosuid,size=1m \


### PR DESCRIPTION
## Summary
Two compatibility gaps in the Vault bootstrap-agent startup loop only surface under a genuine Docker engine (not rootless Podman), affecting any non-Podman deployment -- including GitHub Codespaces, Docker Desktop, or any CI runner using plain Docker.

Fixes #1471

## Change
- Replaced `docker run -d --replace ...` with an explicit `"$_bin" rm -f "$_agent" || true` followed by a plain `run -d`. `--replace` is Podman-only; plain Docker has no equivalent and fails with `unknown flag: --replace`.
- Added a narrowly-scoped ownership fix for the shared `aixcl-vault-secrets` volume before the bootstrap loop runs: a one-shot `--network none --user 0:0` container that `chown`s the volume to exactly the uid/gid (`100:1000`) the `hashicorp/vault` image already runs as. Mirrors the existing "briefly root, then drop privilege" pattern already used by the `open-webui` and `pgadmin` entrypoints elsewhere in this codebase. No `chmod 777`, no running the bootstrap agents themselves as root -- this tightens correctness rather than loosening anything (under Podman this was already a no-op via user-namespace remapping; under Docker it makes the previously-accidental behavior explicit and correct).

## Testing
- [x] `bash -n lib/aixcl/commands/stack.sh`
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/stack.sh` (clean)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` (clean)
- [x] Verified locally under Podman across multiple full `stack stop` / `stack start --profile sys` cycles -- all four bootstrap agents (Postgres, Open WebUI, pgAdmin, Grafana) complete successfully every time, no regressions, ends at 19/19 healthy
- [x] Verified live on a real GitHub Codespace (genuine Docker engine) via `gh codespace ssh` -- the exact `unknown flag: --replace` and `Permission denied` errors this fixes were reproduced and resolved operationally there before being committed as a proper code fix here

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Root-caused live on a real GitHub Codespace via gh codespace ssh, fix implemented and regression-tested locally under Podman across multiple full restart cycles
- Scope: lib/aixcl/commands/stack.sh (bootstrap agent startup loop only)
- Confirmation: yes, code change made (22 insertions, 1 deletion)
