### PR TITLE
Tolerate postgres container creation race in vault init (#1473)

### DIFF
--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -874,6 +874,20 @@ main() {
     # vault-agent-postgres / vault-agent-openwebui (and by extension Open
     # WebUI, pgAdmin, Grafana). Skip gracefully if Postgres isn't part of
     # this deployment -- runtime core must stay usable without it.
+    #
+    # A mass `compose up -d` of many services can leave the postgres
+    # container not yet listed for a few seconds even though it IS part of
+    # this deployment and about to start. Tolerate a short existence wait
+    # here before falling back to the skip path, so a busy/slow host
+    # doesn't lose this race. wait_for_postgres() below handles the
+    # separate (longer) "container exists but isn't ready yet" wait.
+    local _pg_exists_retries=15
+    while [ "$_pg_exists_retries" -gt 0 ] \
+            && ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; do
+        sleep 2
+        _pg_exists_retries=$((_pg_exists_retries - 1))
+    done
+
     if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; then
         wait_for_postgres || return 1
         enable_database_engine || return 1


### PR DESCRIPTION
## Summary
The database secrets engine setup gate in `vault-init.sh`'s `main()` (introduced in #1466) checked Postgres presence with a single, immediate `docker ps | grep postgres` and no retry. When `stack start` brings up ~18 services in one mass `compose up -d`, Postgres can take a few seconds longer than Vault to be listed. If the gate ran before that, the entire database engine setup (mount, connection config, roles, policies) was silently skipped -- even though Postgres was part of the deployment and started successfully moments later.

Fixes #1473

## Change
Added a short (up to 30s) existence-retry before the gate decides to skip, matching the tolerance `wait_for_postgres()` already has for the separate "container exists but isn't accepting connections yet" case. No behavior change when Postgres is already listed immediately -- confirmed at 0 added delay in that case, which is the common/normal path.

## Testing
- [x] `bash -n lib/aixcl/commands/vault-init.sh`
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/vault-init.sh` (clean)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` (clean)
- [x] Regression check: `./aixcl vault init` with Postgres already running completes in ~5s total, confirming zero added delay on the common path
- [x] Repeated fresh prune/init/start cycles reliably complete the database engine setup without needing a manual `vault init` re-run (timing- dependent race, hard to force deterministically; human verification recommended over a few more fresh-deploy cycles)

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Race condition observed during local regression testing of #1471, root-caused via direct Vault API inspection (database/roles/aixcl-app 404 despite Postgres being healthy moments later)
- Scope: lib/aixcl/commands/vault-init.sh (main(), database engine setup gate only)
- Confirmation: yes, code change made (14 insertions, 0 deletions)
