### PR TITLE
Replace non-ASCII arrows and checkmarks with plain ASCII (#1477)

### DIFF
--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -32,6 +32,6 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 
 ## Lazy-Loading
 Load files on a need-to-know basis:
-- Creating an issue → Read `.github/ISSUE_TEMPLATE/task.md` first
-- Creating a PR → Read `.github/PULL_REQUEST_TEMPLATE.md` first
-- Releasing → Read `CHANGELOG.md` to extract latest version entry
+- Creating an issue -> Read `.github/ISSUE_TEMPLATE/task.md` first
+- Creating a PR -> Read `.github/PULL_REQUEST_TEMPLATE.md` first
+- Releasing -> Read `CHANGELOG.md` to extract latest version entry

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -20,13 +20,13 @@
 
 **You MUST NOT:**
 - Remove/replace/disable runtime core components
-- Introduce runtime core → operational service dependencies
+- Introduce runtime core -> operational service dependencies
 - Merge runtime logic with monitoring/admin tooling
 - Collapse service boundaries
 - Add external libraries, cloud services, telemetry, or analytics without explicit approval
 
 ## Escalation
-1. If working on an issue → Post clarification as issue comment
-2. If no issue exists → Ask human operator directly; do not create issue unilaterally
-3. If security concern → Flag with `[SECURITY]` prefix and await explicit approval
-4. If authority conflict → Document override request and obtain explicit confirmation
+1. If working on an issue -> Post clarification as issue comment
+2. If no issue exists -> Ask human operator directly; do not create issue unilaterally
+3. If security concern -> Flag with `[SECURITY]` prefix and await explicit approval
+4. If authority conflict -> Document override request and obtain explicit confirmation

--- a/.opencode/rules/formatting.md
+++ b/.opencode/rules/formatting.md
@@ -32,6 +32,6 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 
 ## Lazy-Loading
 Load files on a need-to-know basis:
-- Creating an issue → Read `.github/ISSUE_TEMPLATE/task.md` first
-- Creating a PR → Read `.github/PULL_REQUEST_TEMPLATE.md` first
-- Releasing → Read `CHANGELOG.md` to extract latest version entry
+- Creating an issue -> Read `.github/ISSUE_TEMPLATE/task.md` first
+- Creating a PR -> Read `.github/PULL_REQUEST_TEMPLATE.md` first
+- Releasing -> Read `CHANGELOG.md` to extract latest version entry

--- a/.opencode/rules/security.md
+++ b/.opencode/rules/security.md
@@ -20,13 +20,13 @@
 
 **You MUST NOT:**
 - Remove/replace/disable runtime core components
-- Introduce runtime core → operational service dependencies
+- Introduce runtime core -> operational service dependencies
 - Merge runtime logic with monitoring/admin tooling
 - Collapse service boundaries
 - Add external libraries, cloud services, telemetry, or analytics without explicit approval
 
 ## Escalation
-1. If working on an issue → Post clarification as issue comment
-2. If no issue exists → Ask human operator directly; do not create issue unilaterally
-3. If security concern → Flag with `[SECURITY]` prefix and await explicit approval
-4. If authority conflict → Document override request and obtain explicit confirmation
+1. If working on an issue -> Post clarification as issue comment
+2. If no issue exists -> Ask human operator directly; do not create issue unilaterally
+3. If security concern -> Flag with `[SECURITY]` prefix and await explicit approval
+4. If authority conflict -> Document override request and obtain explicit confirmation

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,7 +23,7 @@ Read the following documents before beginning work:
 3. `docs/developer/development-workflow.md` -- full workflow guide
 4. `docs/architecture/governance/` -- platform invariants and service contracts
 
-**VALIDATION REQUIRED:** If any documents in #3 or #4 are absent → **HALT** and ask the human operator directly, per AGENTS.md Section 7 (do not create issues unilaterally). Await human clarification before proceeding.
+**VALIDATION REQUIRED:** If any documents in #3 or #4 are absent -> **HALT** and ask the human operator directly, per AGENTS.md Section 7 (do not create issues unilaterally). Await human clarification before proceeding.
 
 ---
 
@@ -99,16 +99,16 @@ This repository uses a **two-branch strategy** with clear promotion flow:
 | `main` | Production-ready code | Final releases only |
 | `dev` | Active development, feature integration | All feature development |
 
-### Correct Workflow (Feature → Dev → Main)
+### Correct Workflow (Feature -> Dev -> Main)
 
 **ALWAYS follow this path:**
 
 ```
-Feature Branch → Dev → Main
-      ↑            ↑       ↑
-   create        PR      PR
-   from         merge   merge
-   dev          (test)  (final test)
+Feature Branch -> Dev -> Main
+      ^             ^       ^
+   create         PR      PR
+   from          merge   merge
+   dev           (test)  (final test)
 ```
 
 #### Step-by-Step
@@ -148,9 +148,9 @@ See AGENTS.md Section 8 -- Emergency Workflow Override for the protocol to proce
 
 | Workflow | Status | Why |
 |----------|--------|-----|
-| `feature → main` | WRONG | Bypasses dev testing |
-| `main → feature` | WRONG | Wrong base branch |
-| `main → dev` | WRONG | Dev feeds main, not vice versa |
+| `feature -> main` | WRONG | Bypasses dev testing |
+| `main -> feature` | WRONG | Wrong base branch |
+| `main -> dev` | WRONG | Dev feeds main, not vice versa |
 
 ### Emergency Hotfixes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,9 +156,9 @@ Planned capabilities:
 
 ### Attack Vectors
 
-#### 1. Prompt Injection → Data Exfiltration
+#### 1. Prompt Injection -> Data Exfiltration
 
-**Path**: Malicious prompt → LLM → Sensitive data in response
+**Path**: Malicious prompt -> LLM -> Sensitive data in response
 
 **Mitigations**:
 - llm-firewall injection detection
@@ -167,9 +167,9 @@ Planned capabilities:
 
 **Residual Risk**: Medium (sophisticated jailbreaks possible)
 
-#### 2. Container Escape → Host Compromise
+#### 2. Container Escape -> Host Compromise
 
-**Path**: Exploit privileged container → Root on host
+**Path**: Exploit privileged container -> Root on host
 
 **Mitigations**:
 - Remove/disable cAdvisor in production
@@ -178,9 +178,9 @@ Planned capabilities:
 
 **Residual Risk**: High (if privileged containers required)
 
-#### 3. Credential Theft → Lateral Movement
+#### 3. Credential Theft -> Lateral Movement
 
-**Path**: Steal .env credentials → Access PostgreSQL/Ollama
+**Path**: Steal .env credentials -> Access PostgreSQL/Ollama
 
 **Mitigations**:
 - Docker secrets (in progress)
@@ -189,9 +189,9 @@ Planned capabilities:
 
 **Residual Risk**: Low (with secrets implementation)
 
-#### 4. Model Extraction → IP Theft
+#### 4. Model Extraction -> IP Theft
 
-**Path**: High-volume API queries → Reconstruct training data
+**Path**: High-volume API queries -> Reconstruct training data
 
 **Mitigations**:
 - Rate limiting (100 req/hour)
@@ -202,7 +202,7 @@ Planned capabilities:
 
 #### 5. Supply Chain Poisoning
 
-**Path**: Malicious Ollama model → Backdoor in inference
+**Path**: Malicious Ollama model -> Backdoor in inference
 
 **Mitigations**:
 - Local LLM preference (reduces attack surface)

--- a/docs/architecture/governance/01_ai_guidance.md
+++ b/docs/architecture/governance/01_ai_guidance.md
@@ -22,7 +22,7 @@ Do **not** attempt to generalize or abstract the runtime core.
 Agents **must not**:
 
 - Remove, replace, or conditionally disable runtime core components
-- Introduce dependencies from runtime core → operational services
+- Introduce dependencies from runtime core -> operational services
 - Merge runtime logic with monitoring, logging, or admin tooling
 - Collapse service boundaries
 - Introduce architectural indirection without explicit instruction

--- a/docs/operations/model-recommendations.md
+++ b/docs/operations/model-recommendations.md
@@ -10,12 +10,12 @@ The Qwen 2.5 Coder series is optimized for coding tasks with excellent performan
 
 | Model | Size | VRAM* | Best For | Ollama | vLLM | llama.cpp |
 |-------|------|-------|----------|--------|------|-----------|
-| `0.5b` | ~400MB | ~1GB | Ultra-lightweight, IoT, edge devices | ✅ | ✅ | ✅ |
-| `1.5b` | ~1GB | ~2.5GB | Lightweight, fast responses | ✅ | ✅ | ✅ |
-| `3b` | ~2GB | ~5GB | Balanced performance | ✅ | ✅ | ✅ |
-| `7b` | ~4.5GB | ~9GB | Higher quality, more capacity | ✅ | ✅ | ✅ |
-| `14b` | ~9GB | ~18GB | Best quality, larger GPUs | ✅ | ✅ | ✅ |
-| `32b` | ~20GB | ~40GB | Maximum quality, professional workstations | ✅ | ✅ | ✅ |
+| `0.5b` | ~400MB | ~1GB | Ultra-lightweight, IoT, edge devices | Yes | Yes | Yes |
+| `1.5b` | ~1GB | ~2.5GB | Lightweight, fast responses | Yes | Yes | Yes |
+| `3b` | ~2GB | ~5GB | Balanced performance | Yes | Yes | Yes |
+| `7b` | ~4.5GB | ~9GB | Higher quality, more capacity | Yes | Yes | Yes |
+| `14b` | ~9GB | ~18GB | Best quality, larger GPUs | Yes | Yes | Yes |
+| `32b` | ~20GB | ~40GB | Maximum quality, professional workstations | Yes | Yes | Yes |
 
 \* VRAM estimates are for inference with default context length. Actual usage varies by batch size and context.
 


### PR DESCRIPTION
## Summary
Part 1 of the ASCII compliance sweep tracked in #1477. Replaces non-ASCII arrows and decorative checkmarks across 7 files with plain ASCII equivalents, per the mandate in `.claude/rules/formatting.md` / `.opencode/rules/formatting.md`.

Addresses #1477 (part 1 of 2 -- box-drawing diagram conversion is a separate PR due to higher review risk)

## Change
- Replaced unicode arrows (`->`, `^`) with ASCII equivalents in: `.claude/rules/formatting.md`, `.opencode/rules/formatting.md`, `.claude/rules/security.md`, `.opencode/rules/security.md`, `DEVELOPMENT.md`, `SECURITY.md`, `docs/architecture/governance/01_ai_guidance.md`
- Replaced decorative checkmarks with `Yes` in `docs/operations/model-recommendations.md`'s capability table -- this is a general doc, not release notes, so the documented checkmark exception in `formatting.md` doesn't apply
- Left two checkmarks untouched, both correctly within the documented exception: `.github/RELEASE_TEMPLATE.md`, and `formatting.md` line 10 (the rule text itself, illustrating that exact exception with the literal character)

## Testing
- [x] `grep -lP '[^\x00-\x7F]'` confirms all 7 changed files are now ASCII clean (except the two intentionally-exempted checkmarks)
- [x] `./scripts/checks/check-agents.sh` passes (rules mirror parity)
- [x] `bash scripts/checks/check-paths.sh` passes (pre-existing warning only, unrelated)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` clean

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Repo-wide grep audit followed by targeted ASCII substitution, verified file-by-file
- Scope: .claude/rules/formatting.md, .opencode/rules/formatting.md, .claude/rules/security.md, .opencode/rules/security.md, DEVELOPMENT.md, SECURITY.md, docs/architecture/governance/01_ai_guidance.md, docs/operations/model-recommendations.md
- Confirmation: yes, doc changes made
