### PR TITLE
Convert box-drawing diagrams to plain ASCII (#1477)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -6,12 +6,12 @@ This directory contains configuration files for AIXCL.
 
 ```
 config/
-├── .env.example           # Template for environment variables
-├── opencode.json.example  # Template for OpenCode AI configuration
-├── README.md              # This file
-└── profiles/
-    ├── bld.env            # Observability-focused profile
-    └── sys.env            # System-oriented profile
++-- .env.example           # Template for environment variables
++-- opencode.json.example  # Template for OpenCode AI configuration
++-- README.md              # This file
+`-- profiles/
+    +-- bld.env            # Observability-focused profile
+    `-- sys.env            # System-oriented profile
 ```
 
 ## Files

--- a/docs/developer/vault-integration.md
+++ b/docs/developer/vault-integration.md
@@ -15,35 +15,35 @@ Vault runs in **production server mode** with file-based persistent storage. Sec
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                      AIXCL Stack                           │
-│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐   │
-│  │   Services   │────│ Vault Agent  │────│    Vault     │   │
-│  │ (PostgreSQL) │    │  (sidecar)   │    │   Server     │   │
-│  │  (Grafana)   │    └──────────────┘    └──────────────┘   │
-│  └──────────────┘                            │              │
-│                                              │              │
-│                              ┌───────────────┴──────────┐   │
-│                              ▼                          │   │
-│                       ┌──────────────┐                  │   │
-│                       │  PostgreSQL  │                  │   │
-│                       │ (Dynamic     │                  │   │
-│                       │  Creds)      │                  │   │
-│                       └──────────────┘                  │   │
-│                                                         │   │
-│  ┌────────────────────────────────────────────────┐    │   │
-│  │ Audit Log: Every credential access logged       │    │   │
-│  └────────────────────────────────────────────────┘    │   │
-└─────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------+
+|                      AIXCL Stack                           |
+|  +--------------+    +--------------+    +--------------+   |
+|  |   Services   |----| Vault Agent  |----|    Vault     |   |
+|  | (PostgreSQL) |    |  (sidecar)   |    |   Server     |   |
+|  |  (Grafana)   |    +--------------+    +--------------+   |
+|  +--------------+                            |              |
+|                                              |              |
+|                              +---------------+----------+   |
+|                              v                          |   |
+|                       +--------------+                  |   |
+|                       |  PostgreSQL  |                  |   |
+|                       | (Dynamic     |                  |   |
+|                       |  Creds)      |                  |   |
+|                       +--------------+                  |   |
+|                                                         |   |
+|  +------------------------------------------------+    |   |
+|  | Audit Log: Every credential access logged       |    |   |
+|  +------------------------------------------------+    |   |
++-------------------------------------------------------------+
 ```
 
 ## Dynamic Secrets Flow
 
-1. **Service needs DB credentials** → Requests from Vault Agent
-2. **Vault generates new credentials** → Creates PostgreSQL user with random password
-3. **Service uses credentials** → Connects to database
-4. **TTL expires** → Vault automatically revokes PostgreSQL user
-5. **New credentials generated** → Seamless rotation
+1. **Service needs DB credentials** -> Requests from Vault Agent
+2. **Vault generates new credentials** -> Creates PostgreSQL user with random password
+3. **Service uses credentials** -> Connects to database
+4. **TTL expires** -> Vault automatically revokes PostgreSQL user
+5. **New credentials generated** -> Seamless rotation
 
 ## Quick Start
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -6,15 +6,15 @@ This directory contains shared library modules for the AIXCL project.
 
 ```
 lib/
-├── core/           # Core utility libraries
-│   ├── color.sh    # Terminal color/formatting utilities
-│   ├── common.sh   # Common functions (env loading, service validation)
-│   ├── docker_utils.sh  # Docker/Compose utilities
-│   ├── env_check.sh     # Environment validation
-│   ├── logging.sh       # Logging utilities
-│   └── pgadmin_utils.sh # pgAdmin utilities
-└── cli/            # CLI-specific libraries
-    └── profile.sh  # Profile management (bld, sys)
++-- core/           # Core utility libraries
+|   +-- color.sh    # Terminal color/formatting utilities
+|   +-- common.sh   # Common functions (env loading, service validation)
+|   +-- docker_utils.sh  # Docker/Compose utilities
+|   +-- env_check.sh     # Environment validation
+|   +-- logging.sh       # Logging utilities
+|   `-- pgadmin_utils.sh # pgAdmin utilities
+`-- cli/            # CLI-specific libraries
+    `-- profile.sh  # Profile management (bld, sys)
 ```
 
 ## Usage

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,32 +6,32 @@ This directory contains scripts used by AIXCL, Docker Compose, and GitHub Action
 
 ```
 scripts/
-├── checks/           # CI validation scripts
-│   ├── check-agents.sh
-│   ├── check-generated-files.sh
-│   └── check-paths.sh
-├── db/               # Database management
-├── exporters/        # Metrics exporters
-├── hooks/            # Git hooks
-├── runtime/          # Container entrypoint scripts
-│   ├── configure-openwebui-direct-connections.sh
-│   ├── grafana-entrypoint.sh
-│   ├── llamacpp-entrypoint.sh
-│   ├── ollama-entrypoint.sh
-│   ├── openwebui-entrypoint.sh
-│   ├── openwebui-vault-entrypoint.sh
-│   ├── pgadmin-entrypoint.sh
-│   ├── postgres-exporter-entrypoint.sh
-│   ├── postgres-secret-entrypoint.sh
-│   └── vllm-entrypoint.sh
-├── security/         # Security checks
-├── utils/            # Setup and utility scripts
-│   ├── init-volumes.sh
-│   ├── setup-gpg.sh
-│   ├── setup-hooks.sh
-│   ├── setup-podman-rootless.sh
-│   └── validate-volume-consistency.sh
-└── vault/            # Vault agent and bootstrap scripts
++-- checks/           # CI validation scripts
+|   +-- check-agents.sh
+|   +-- check-generated-files.sh
+|   `-- check-paths.sh
++-- db/               # Database management
++-- exporters/        # Metrics exporters
++-- hooks/            # Git hooks
++-- runtime/          # Container entrypoint scripts
+|   +-- configure-openwebui-direct-connections.sh
+|   +-- grafana-entrypoint.sh
+|   +-- llamacpp-entrypoint.sh
+|   +-- ollama-entrypoint.sh
+|   +-- openwebui-entrypoint.sh
+|   +-- openwebui-vault-entrypoint.sh
+|   +-- pgadmin-entrypoint.sh
+|   +-- postgres-exporter-entrypoint.sh
+|   +-- postgres-secret-entrypoint.sh
+|   `-- vllm-entrypoint.sh
++-- security/         # Security checks
++-- utils/            # Setup and utility scripts
+|   +-- init-volumes.sh
+|   +-- setup-gpg.sh
+|   +-- setup-hooks.sh
+|   +-- setup-podman-rootless.sh
+|   `-- validate-volume-consistency.sh
+`-- vault/            # Vault agent and bootstrap scripts
 ```
 
 ## Categories

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,33 +18,33 @@ This test suite executes actual `./aixcl` commands and validates system state ch
 
 ```
 tests/
-├── run-tests.sh              # Main test runner (entry point)
-├── test-results.md           # Generated report (OVERWRITTEN)
-├── lib/
-│   ├── test-framework.sh     # Assertions and utilities
-│   ├── state-capture.sh      # State management
-│   └── cleanup.sh            # Cleanup utilities
-├── command-tests/            # Individual CLI command tests
-│   ├── test-00-preflight.sh
-│   ├── test-00a-stack-token-reload.sh
-│   ├── test-01-stack-start.sh
-│   ├── test-02-stack-status.sh
-│   ├── test-03-engine-set-ollama.sh
-│   ├── test-04-engine-set-vllm.sh
-│   ├── test-05-engine-set-llamacpp.sh
-│   ├── test-06-engine-auto.sh
-│   ├── test-07-models-add-ollama.sh
-│   ├── test-08-models-add-vllm.sh
-│   ├── test-09-models-add-llamacpp.sh
-│   ├── test-10-models-list.sh
-│   ├── test-11-service-restart.sh
-│   ├── test-13-opencode-prompts.sh
-│   ├── test-14-opencode-vllm.sh
-│   ├── test-15-opencode-llamacpp.sh
-│   ├── test-16-engine-model-integration.sh
-│   └── test-99-stack-stop.sh
-└── workflow-tests/
-    └── test-readme-quickstart.sh
++-- run-tests.sh              # Main test runner (entry point)
++-- test-results.md           # Generated report (OVERWRITTEN)
++-- lib/
+|   +-- test-framework.sh     # Assertions and utilities
+|   +-- state-capture.sh      # State management
+|   `-- cleanup.sh            # Cleanup utilities
++-- command-tests/            # Individual CLI command tests
+|   +-- test-00-preflight.sh
+|   +-- test-00a-stack-token-reload.sh
+|   +-- test-01-stack-start.sh
+|   +-- test-02-stack-status.sh
+|   +-- test-03-engine-set-ollama.sh
+|   +-- test-04-engine-set-vllm.sh
+|   +-- test-05-engine-set-llamacpp.sh
+|   +-- test-06-engine-auto.sh
+|   +-- test-07-models-add-ollama.sh
+|   +-- test-08-models-add-vllm.sh
+|   +-- test-09-models-add-llamacpp.sh
+|   +-- test-10-models-list.sh
+|   +-- test-11-service-restart.sh
+|   +-- test-13-opencode-prompts.sh
+|   +-- test-14-opencode-vllm.sh
+|   +-- test-15-opencode-llamacpp.sh
+|   +-- test-16-engine-model-integration.sh
+|   `-- test-99-stack-stop.sh
+`-- workflow-tests/
+    `-- test-readme-quickstart.sh
 ```
 
 ## Quick Start
@@ -103,7 +103,7 @@ Validate complete user workflows:
 
 | Test | Description |
 |------|-------------|
-| test-readme-quickstart.sh | README Steps 1-5: Clone→Start→Engine→Model→OpenCode |
+| test-readme-quickstart.sh | README Steps 1-5: Clone -> Start -> Engine -> Model -> OpenCode |
 
 ## Test Results
 


### PR DESCRIPTION
## Summary
Part 2 of the ASCII compliance sweep tracked in #1477. Converts unicode box-drawing diagrams to plain ASCII in 5 files, per the mandate in `.claude/rules/formatting.md` / `.opencode/rules/formatting.md`.

Addresses #1477 (part 2 of 2 -- arrows/checkmarks were part 1, #1478)

## Change
Two distinct ASCII conventions used, matching standard practice for each diagram type:
- **Tree listings** (`lib/README.md`, `scripts/README.md`, `tests/README.md`, `config/README.md`): `+--` / `` `-- `` / `|`, matching `tree --charset=ascii` output (backtick marks the last branch in a group)
- **Rectangle/box diagram** (`docs/developer/vault-integration.md`): uniform `+` for all four corners and T-junctions, `-` for horizontal, `|` for vertical, `v` for the down-arrow

Every unicode box character occupies exactly the same single-column width as its ASCII replacement, so this was a character-for-character substitution with no respacing needed. I visually re-verified each converted diagram/tree after substitution (see before/after in the diff).

Also fixed a stray unicode arrow found in `tests/README.md` while converting its tree listing.

## Testing
- [x] `grep -lP '[^\x00-\x7F]'` confirms all 5 files are now fully ASCII clean
- [x] `./scripts/checks/check-agents.sh` passes
- [x] `bash scripts/checks/check-paths.sh` passes (pre-existing warning only, unrelated)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` clean
- [x] Visually re-checked each tree/diagram renders correctly after conversion (not just a mechanical diff)

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Character-for-character ASCII substitution per diagram-type convention, with visual re-verification of each converted diagram
- Scope: lib/README.md, scripts/README.md, tests/README.md, config/README.md, docs/developer/vault-integration.md
- Confirmation: yes, doc changes made
