### PR TITLE
Stop vault bootstrap agents restarting forever after success (#1480)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -822,11 +822,15 @@ function start() {
                 # bootstrap agent only requires a change in services/docker-compose.yml.
                 # NOTE: --replace is Podman-only (unsupported by plain Docker), so any
                 # existing same-named container is removed explicitly first instead.
+                # NOTE: --restart on-failure (not unless-stopped) -- these are one-shot
+                # jobs that exit 0 on success. docker-compose.yml documents the same
+                # policy for these services; unless-stopped would restart them forever
+                # even after a successful run, burning CPU for no benefit.
                 for _agent in "${VAULT_BOOTSTRAP_AGENTS[@]}"; do
                     local _base="${_agent%-bootstrap}"
                     local _script="bootstrap-password-${_base#vault-agent-}.sh"
                     "$_bin" rm -f "$_agent" >/dev/null 2>&1 || true
-                    "$_bin" run -d --name "$_agent" --restart unless-stopped \
+                    "$_bin" run -d --name "$_agent" --restart on-failure \
                         --network host \
                         --cap-drop ALL --cap-add SETUID --cap-add SETGID --cap-add DAC_OVERRIDE \
                         --tmpfs /vault/file:noexec,nosuid,size=1m \


### PR DESCRIPTION
## Summary
`stack.sh`'s manual `docker run` loop for the Vault bootstrap agents used `--restart unless-stopped`. These are one-shot jobs (read a password from Vault KV, write it to `/run/secrets/`, exit 0), and `docker-compose.yml` already documents that they should use `restart: on-failure`. `unless-stopped` restarts regardless of exit code, so a successful run gets immediately restarted, succeeds again, and loops forever.

Fixes #1480

## Found via
A diagnosis from another AI agent (Kimi, via OpenCode) correctly flagged abnormal CPU usage from two looping bootstrap containers, but misdiagnosed the cause as an invalid Vault token. Disproven via direct verification: the live token returned `HTTP 200` with valid root policy, and logs showed zero errors -- only successful `Bootstrap complete` cycles, 28,220+ times.

## Change
Changed `--restart unless-stopped` to `--restart on-failure` on the `docker run` line, matching `docker-compose.yml`'s documented design and its sibling services (which are started via `docker compose up` and already use the correct policy).

## Testing
- [x] `bash -n lib/aixcl/commands/stack.sh`
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/stack.sh` (clean)
- [x] `./scripts/checks/check-ai-elisions.sh --staged` (clean)
- [x] Verified locally: recreated a bootstrap container via this exact code path with a valid token -- succeeded once, `RestartCount: 0`, `ExitCode: 0`, stayed `Exited` (no loop)
- [x] Verified the `on-failure` policy still retries correctly on genuine failure: same test with an invalid token retried as expected (81 retries observed before the test was corrected) rather than silently giving up

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-16
- Method: Live diagnosis (docker inspect, docker logs, direct Vault API query) cross-checking another agent's report; fix verified against both the success path and the genuine-failure retry path
- Scope: lib/aixcl/commands/stack.sh (bootstrap agent startup loop only)
- Confirmation: yes, code change made (5 insertions, 1 deletion)
