### PR TITLE
Document no-hard-wrap convention for issue and PR bodies (#1482)

### DIFF
--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -30,6 +30,13 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 - Reference issue: `Fixes #<n>` or `Addresses #<n>`
 - First line under 72 characters
 
+## Issue and Pull Request Bodies
+- Do **not** hard-wrap prose paragraphs at a fixed column width.
+- Each paragraph in an issue or PR body should be a single source line, however long.
+- List items, headings, code fences, tables, and command examples keep their normal structure.
+- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited.
+- This convention applies to issue and PR bodies specifically; other markdown files in the repository keep their existing wrapping style unless separately agreed.
+
 ## Lazy-Loading
 Load files on a need-to-know basis:
 - Creating an issue -> Read `.github/ISSUE_TEMPLATE/task.md` first

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -34,7 +34,8 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 - Do **not** hard-wrap prose paragraphs at a fixed column width.
 - Each paragraph in an issue or PR body should be a single source line, however long.
 - List items, headings, code fences, tables, and command examples keep their normal structure.
-- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited.
+- Multiple discrete references inside a single list item should be split into separate list entries rather than comma-packed on one line.
+- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited. Separating discrete references keeps diffs localized to the changed item.
 - This convention applies to issue and PR bodies specifically; other markdown files in the repository keep their existing wrapping style unless separately agreed.
 
 ## Lazy-Loading

--- a/.opencode/rules/formatting.md
+++ b/.opencode/rules/formatting.md
@@ -30,6 +30,13 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 - Reference issue: `Fixes #<n>` or `Addresses #<n>`
 - First line under 72 characters
 
+## Issue and Pull Request Bodies
+- Do **not** hard-wrap prose paragraphs at a fixed column width.
+- Each paragraph in an issue or PR body should be a single source line, however long.
+- List items, headings, code fences, tables, and command examples keep their normal structure.
+- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited.
+- This convention applies to issue and PR bodies specifically; other markdown files in the repository keep their existing wrapping style unless separately agreed.
+
 ## Lazy-Loading
 Load files on a need-to-know basis:
 - Creating an issue -> Read `.github/ISSUE_TEMPLATE/task.md` first

--- a/.opencode/rules/formatting.md
+++ b/.opencode/rules/formatting.md
@@ -34,7 +34,8 @@ in lib/) so non-UTF-8 terminals degrade gracefully.
 - Do **not** hard-wrap prose paragraphs at a fixed column width.
 - Each paragraph in an issue or PR body should be a single source line, however long.
 - List items, headings, code fences, tables, and command examples keep their normal structure.
-- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited.
+- Multiple discrete references inside a single list item should be split into separate list entries rather than comma-packed on one line.
+- Rationale: GitHub's renderer reflows paragraphs to the viewport anyway, while hard-wrapping creates noisy multi-line diffs whenever a paragraph is edited. Separating discrete references keeps diffs localized to the changed item.
 - This convention applies to issue and PR bodies specifically; other markdown files in the repository keep their existing wrapping style unless separately agreed.
 
 ## Lazy-Loading


### PR DESCRIPTION
Fixes #1482

## Summary
Documents the agreed formatting conventions for GitHub issue and PR bodies in both `.claude/rules/formatting.md` and `.opencode/rules/formatting.md`.

## Changes
- Added a new "Issue and Pull Request Bodies" section to both formatting.md mirrors.
- Prose paragraphs must not be hard-wrapped: each paragraph is a single source line regardless of length.
- Lists, headings, code fences, tables, and command examples keep their normal structure.
- Multiple discrete references in a single list entry should be split into one item per line rather than comma-packed on one line.

## Testing
- Verified the two formatting.md files are byte-identical.
- Ran `./scripts/checks/check-agents.sh` successfully.
- Ran `./scripts/checks/check-ai-elisions.sh --staged` successfully.
- Ran `./scripts/checks/check-paths.sh` successfully (only pre-existing username warnings unrelated to this change).

## Notes
- This convention applies to issue and PR bodies specifically. Other markdown files in the repository keep their existing wrapping style unless separately agreed.
- The retroactive reformatting of today's issue/PR bodies was done directly via `gh issue edit` and `gh pr edit`; those changes are not part of this PR's diff.

---
- Agent: OpenCode (ollama-cloud/kimi-k2.7-code)
- Date: 2026-06-16
- Method: Updated both formatting.md mirrors; reformatted issue/PR bodies via `gh issue edit`/`gh pr edit`
- Scope: `.claude/rules/formatting.md`, `.opencode/rules/formatting.md`, issues #1463 #1465 #1466 #1471 #1473 #1475 #1477 #1480 #1482, PRs #1464 #1467 #1468 #1469 #1470 #1472 #1474 #1476 #1478 #1479 #1481
- Confirmation: yes
