### PR TITLE
Enforce discrete-references rule in PR body validation (#1487)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -45,12 +45,14 @@ gh pr create \
 - Assignee: required, set at creation (not after)
 - Label: at least one `component:*` label, set at creation (not after)
 - NEVER use two-step creation -- webhook fires on `opened` event, labels/assignee must be present
+- Body references: one issue/PR reference per list item -- no comma-packing (enforced by CI: `validate-pr-body-references` job in `pr-validation.yml`)
+- Check locally before pushing: `echo "$BODY" | bash scripts/checks/check-pr-references.sh`
 
 ## CI Workflows Summary
 
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
-| pr-validation.yml | PR open/edit | Title format, assignee, component label |
+| pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,8 @@ assignees: ["<assignee>"]
 
 <!-- IMPORTANT: When creating via CLI, use --body-file or quoted HEREDOC to prevent backtick command substitution. Do not use inline --body with multiline strings containing backticks. -->
 
+<!-- REFERENCES: List one issue/PR reference per line. Do not comma-pack multiple #N references on a single line. -->
+
 ## Bug Summary
 Provide a clear, concise description of the bug.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,8 @@ assignees: ["<assignee>"]
 
 <!-- IMPORTANT: When creating via CLI, use --body-file or quoted HEREDOC to prevent backtick command substitution. Do not use inline --body with multiline strings containing backticks. -->
 
+<!-- REFERENCES: List one issue/PR reference per line. Do not comma-pack multiple #N references on a single line. -->
+
 ## Feature Overview
 Describe the requested feature.
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -10,6 +10,8 @@ assignees: ["<assignee>"]
 
 <!-- IMPORTANT: When creating via CLI, use --body-file or quoted HEREDOC to prevent backtick command substitution. Do not use inline --body with multiline strings containing backticks. -->
 
+<!-- REFERENCES: List one issue/PR reference per line. Do not comma-pack multiple #N references on a single line. -->
+
 ## Task Summary
 Describe what needs to be done.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,4 +36,7 @@ To verify this change is complete:
 - [ ] Tests cover change
 
 ### Related Issues
+
+List one reference per line. Do not comma-pack multiple references on a single line.
+
 - Closes #<ISSUE_NUMBER>

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -97,3 +97,21 @@ jobs:
           echo "ERROR: PR must have at least one component label (component:*)"
           echo "Available component labels: component:cli, component:infrastructure, component:runtime-core, etc."
           exit 1
+
+  validate-pr-body-references:
+    name: Validate PR Body Reference List Style
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check for comma-packed issue references
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          body=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.body // ""')
+          echo "$body" | bash scripts/checks/check-pr-references.sh

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -45,12 +45,14 @@ gh pr create \
 - Assignee: required, set at creation (not after)
 - Label: at least one `component:*` label, set at creation (not after)
 - NEVER use two-step creation -- webhook fires on `opened` event, labels/assignee must be present
+- Body references: one issue/PR reference per list item -- no comma-packing (enforced by CI: `validate-pr-body-references` job in `pr-validation.yml`)
+- Check locally before pushing: `echo "$BODY" | bash scripts/checks/check-pr-references.sh`
 
 ## CI Workflows Summary
 
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
-| pr-validation.yml | PR open/edit | Title format, assignee, component label |
+| pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |

--- a/scripts/checks/check-pr-references.sh
+++ b/scripts/checks/check-pr-references.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Checks that no list item in a PR or issue body comma-packs multiple #N references.
+# Each issue/PR reference must be on its own list item line.
+#
+# Usage:
+#   check-pr-references.sh <file>          # check a body saved to a file
+#   echo "$BODY" | check-pr-references.sh  # check body from stdin
+#
+# Exit 0 = clean. Exit 1 = violations found.
+
+set -euo pipefail
+
+input_file="${1:-/dev/stdin}"
+
+violations=()
+
+while IFS= read -r line; do
+    # Only check list item lines (- or *)
+    if [[ "$line" =~ ^[[:space:]]*[-*] ]]; then
+        # Count #N references on this line
+        count=$(grep -oE '#[0-9]+' <<< "$line" | wc -l)
+        if [[ "$count" -ge 2 ]]; then
+            violations+=("$line")
+        fi
+    fi
+done < "$input_file"
+
+if [[ "${#violations[@]}" -eq 0 ]]; then
+    echo "OK: no comma-packed issue references found"
+    exit 0
+fi
+
+echo "ERROR: each issue/PR reference must be on its own list item line"
+echo "Found ${#violations[@]} violation(s):"
+for v in "${violations[@]}"; do
+    echo "  $v"
+done
+echo ""
+echo "Fix: split comma-packed references into separate list items, e.g.:"
+echo "  - Closes #1"
+echo "  - Closes #2"
+exit 1

--- a/scripts/checks/check-pr-references.sh
+++ b/scripts/checks/check-pr-references.sh
@@ -17,9 +17,11 @@ violations=()
 while IFS= read -r line; do
     # Only check list item lines (- or *)
     if [[ "$line" =~ ^[[:space:]]*[-*] ]]; then
-        # Count #N references on this line
-        count=$(grep -oE '#[0-9]+' <<< "$line" | wc -l)
-        if [[ "$count" -ge 2 ]]; then
+        # Strip inline code (backtick spans) before checking -- examples in
+        # code spans are not subject to the reference style rule
+        stripped=$(echo "$line" | sed 's/`[^`]*`//g')
+        # Flag only comma-separated #N references: #123, #456 or #123,#456
+        if echo "$stripped" | grep -qE '#[0-9]+[[:space:]]*,[[:space:]]*#[0-9]+'; then
             violations+=("$line")
         fi
     fi


### PR DESCRIPTION
## Summary

Fixes #1487

### Description of Changes

Enforces the discrete-references list rule (one issue/PR reference per list item, no comma-packing) at the CI level so it cannot be ignored:

- Adds a `validate-pr-body-references` job to `pr-validation.yml` that fetches the PR body via the GitHub API and fails if any list item contains two or more `#N` references separated by a comma
- Adds `scripts/checks/check-pr-references.sh` for local checking before pushing
- Updates `.github/PULL_REQUEST_TEMPLATE.md` `Related Issues` section with an explicit one-reference-per-line note
- Adds a `REFERENCES` comment to all three issue templates
- Updates `.claude/rules/ci-checks.md` and its mirror `.opencode/rules/ci-checks.md` to document the new check and the local command

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] Assignee: sbadakhc
- [x] Component Label: component:infrastructure
- [x] Title Format: compliant

### Testing Notes

- `echo "- Closes #1, #2" | bash scripts/checks/check-pr-references.sh` exits 1 with clear error
- `echo "- Closes #1" | bash scripts/checks/check-pr-references.sh` exits 0
- `shellcheck` passes on `check-pr-references.sh`
- `yamllint` passes on `pr-validation.yml`
- `check-paths.sh` and `check-ai-elisions.sh` pass

### Verification

- [x] A PR body containing comma-packed references fails the new CI job
- [x] A PR body with one reference per line passes
- [x] Human: confirm template guidance reads clearly

### Related Issues

- Fixes #1487
- Addresses #1482

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: Implemented CI job, local check script, template updates, and rules mirror update
- Scope: .github/workflows/pr-validation.yml, scripts/checks/check-pr-references.sh, .github/PULL_REQUEST_TEMPLATE.md, .github/ISSUE_TEMPLATE/*.md, .claude/rules/ci-checks.md, .opencode/rules/ci-checks.md
- Confirmation: yes
