### PR TITLE
Fix PR reference check to catch slash-separated references (#1492)

### DIFF
--- a/scripts/checks/check-pr-references.sh
+++ b/scripts/checks/check-pr-references.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Checks that no list item in a PR or issue body comma-packs multiple #N references.
+# Checks that no list item in a PR or issue body bunches multiple #N references.
 # Each issue/PR reference must be on its own list item line.
+# Catches comma-separated (#N, #M), slash-separated (#N/#M), and space-separated (#N #M).
 #
 # Usage:
 #   check-pr-references.sh <file>          # check a body saved to a file
@@ -20,8 +21,8 @@ while IFS= read -r line; do
         # Strip inline code (backtick spans) before checking -- examples in
         # code spans are not subject to the reference style rule
         stripped=$(echo "$line" | sed 's/`[^`]*`//g')
-        # Flag only comma-separated #N references: #123, #456 or #123,#456
-        if echo "$stripped" | grep -qE '#[0-9]+[[:space:]]*,[[:space:]]*#[0-9]+'; then
+        # Flag bunched #N references separated by comma, slash, or bare space
+        if echo "$stripped" | grep -qE '#[0-9]+[[:space:]]*[,/][[:space:]]*#[0-9]+|#[0-9]+[[:space:]]+#[0-9]+'; then
             violations+=("$line")
         fi
     fi
@@ -32,7 +33,7 @@ if [[ "${#violations[@]}" -eq 0 ]]; then
     exit 0
 fi
 
-echo "ERROR: each issue/PR reference must be on its own list item line"
+echo "ERROR: each issue/PR reference must be on its own list item line (no comma, slash, or space-separated bunching)"
 echo "Found ${#violations[@]} violation(s):"
 for v in "${violations[@]}"; do
     echo "  $v"


### PR DESCRIPTION
## Summary

Fixes #1492

### Description of Changes

Extends `scripts/checks/check-pr-references.sh` to catch slash-separated (`#N/#M`) and bare space-separated (`#N #M`) issue references in addition to the existing comma check. Also updates the error message to name all three separators, and updates the script header comment.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] Assignee: sbadakhc
- [x] Component Label: component:infrastructure
- [x] Title Format: compliant

### Testing Notes

- `echo "- Closes #1471/#1473" | bash scripts/checks/check-pr-references.sh` exits 1
- `echo "- Closes #1471, #1473" | bash scripts/checks/check-pr-references.sh` exits 1
- `echo "- Closes #1471 and #1473" | bash scripts/checks/check-pr-references.sh` exits 0
- `echo "- Closes #1471" | bash scripts/checks/check-pr-references.sh` exits 0
- Backtick-exemption still works
- `shellcheck` passes

### Verification

- [x] CI job `validate-pr-body-references` passes on this PR
- [x] Human: confirm all test cases above behave as documented

### Related Issues

- Fixes #1492
- Addresses #1487

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: Pattern extension to cover slash and space separators; gap identified during issue #1490 body review
- Scope: scripts/checks/check-pr-references.sh
- Confirmation: yes
