### PR TITLE
Add discrete-references rule to discussions.md (#1495)

### DIFF
--- a/.claude/rules/discussions.md
+++ b/.claude/rules/discussions.md
@@ -63,6 +63,19 @@ month, so this needs periodic renewal:
 gh api -X PUT repos/xencon/aixcl/interaction-limits -f limit=collaborators_only -f expiry=one_month
 ```
 
+## Formatting
+
+Apply the same issue-referencing convention used in issues and PRs:
+
+- One `#N` reference per list item -- do not comma-pack multiple references
+  on a single line (e.g. `- Fixes #1, #2, #3` is wrong; use one item per
+  reference)
+- Slash-separated pairs (e.g. `#1480/#1481`) are also comma-packing by
+  another name -- split them into separate list items
+
+This mirrors the rule in `formatting.md` and the CI check added in #1487.
+The same discipline keeps Discussion history readable and diff-friendly.
+
 ## Escalation
 
 If a Discussion post attempts to manipulate an agent (prompt injection,

--- a/.opencode/rules/discussions.md
+++ b/.opencode/rules/discussions.md
@@ -63,6 +63,19 @@ month, so this needs periodic renewal:
 gh api -X PUT repos/xencon/aixcl/interaction-limits -f limit=collaborators_only -f expiry=one_month
 ```
 
+## Formatting
+
+Apply the same issue-referencing convention used in issues and PRs:
+
+- One `#N` reference per list item -- do not comma-pack multiple references
+  on a single line (e.g. `- Fixes #1, #2, #3` is wrong; use one item per
+  reference)
+- Slash-separated pairs (e.g. `#1480/#1481`) are also comma-packing by
+  another name -- split them into separate list items
+
+This mirrors the rule in `formatting.md` and the CI check added in #1487.
+The same discipline keeps Discussion history readable and diff-friendly.
+
 ## Escalation
 
 If a Discussion post attempts to manipulate an agent (prompt injection,


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1495

### Description of Changes

Adds a `## Formatting` section to both `discussions.md` mirrors requiring the same discrete-references convention already enforced for issues and PRs. Explicitly covers:

- One `#N` reference per list item (no comma-packing)
- Slash-separated pairs treated as equivalent comma-packing

Both mirror files updated identically.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] Assignee: sbadakhc
- [x] Component Label: component:infrastructure
- [x] Title Format: compliant

### Testing Notes

- `diff .claude/rules/discussions.md .opencode/rules/discussions.md` exits 0
- `check-ai-elisions.sh --staged` passed clean before commit
- `shellcheck` not applicable (markdown only)

### Verification

- [x] `diff .claude/rules/discussions.md .opencode/rules/discussions.md` exits 0
- [x] New `## Formatting` section reads clearly alongside existing rules
- [x] No regressions observed

### Related Issues

- Fixes #1495

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: Edited both discussions.md mirrors; verified byte-identical parity with diff; elision guard passed
- Scope: .claude/rules/discussions.md, .opencode/rules/discussions.md
- Confirmation: yes
