### PR TITLE
Add pre-release retrospective step to cut-release skill (#1497)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cut-release
 description: Guided checklist for cutting a new AIXCL release following the versioning cadence
-version: 1.0
+version: 1.1
 ---
 
 # Skill: cut-release
@@ -43,7 +43,38 @@ number from a previous session or document.
   gh pr list --state merged --limit 30
   ```
 
-## Step 2 -- Update CHANGELOG.md
+## Step 2 -- Pre-Release Retrospective
+
+Before updating the CHANGELOG, open a dedicated discussion thread and post
+agent observations. This step is advisory -- the human may proceed once
+formal CI and review checks are complete, even if one agent has nothing
+material to add.
+
+Open the thread (substitute the computed `$NEXT` version):
+
+```bash
+gh api graphql -f query='
+mutation {
+  createDiscussion(input: {
+    repositoryId: "R_kgDOMOfaEA",
+    categoryId: "DIC_kwDOMOfaEM4C_SO-",
+    title: "Release v1.1.N retrospective",
+    body: "Pre-release retrospective for v1.1.N.\n\nBoth agents post observations below: what landed, what was deferred, and any open concerns before the tag goes out."
+  }) {
+    discussion { url number }
+  }
+}'
+```
+
+- [ ] New discussion thread opened titled "Release vX.Y.Z retrospective"
+- [ ] This agent has posted its retrospective (what landed, what was deferred, open concerns)
+- [ ] Kimi has posted its retrospective, or confirmed nothing material to add
+- [ ] Human has reviewed both posts and confirmed readiness to proceed
+
+Each agent post must include the standard agent identification block
+(AGENTS.md Section 9.5). Link the thread URL in the release PR body.
+
+## Step 3 -- Update CHANGELOG.md
 
 Read `CHANGELOG.md` first to confirm the current format, then add a new entry:
 
@@ -73,7 +104,7 @@ Rules:
 - [ ] No non-ASCII punctuation (plain ASCII only -- CI enforces this)
 - [ ] `[Unreleased]` section is cleared (contents moved to new version entry)
 
-## Step 3 -- Merge dev to main
+## Step 4 -- Merge dev to main
 
 ```bash
 # Ensure dev is up to date
@@ -102,7 +133,7 @@ gh pr create \
 - [ ] PR targets `main` (not `dev`) -- releases go to main
 - [ ] CI is green before merging
 
-## Step 4 -- Tag the Release
+## Step 5 -- Tag the Release
 
 After the PR is merged to `main`:
 
@@ -116,7 +147,7 @@ git push origin v1.1.<N>
 - [ ] Tag is pushed to `origin` (upstream), not just `fork`
 - [ ] The `release.yml` workflow fires within 30 seconds of tag push
 
-## Step 5 -- Verify GitHub Release
+## Step 6 -- Verify GitHub Release
 
 ```bash
 # Check workflow status
@@ -130,7 +161,7 @@ gh release view v1.1.<N> --repo xencon/aixcl
 - [ ] Release notes are populated (from CHANGELOG or release template)
 - [ ] No draft status -- release is published
 
-## Step 6 -- Sync dev with main
+## Step 7 -- Sync dev with main
 
 After release, sync `dev` to include the merge commit from `main`:
 
@@ -149,7 +180,7 @@ gh pr create \
 - [ ] Sync PR merged to `dev`
 - [ ] No divergence between `main` and `dev`
 
-## Step 7 -- Close Release Issue
+## Step 8 -- Close Release Issue
 
 - [ ] Close the GitHub issue that tracked this release
 - [ ] Update any MEMORY.md entries referencing the previous version

--- a/.opencode/skills/cut-release/SKILL.md
+++ b/.opencode/skills/cut-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cut-release
 description: Guided checklist for cutting a new AIXCL release following the versioning cadence
-version: 1.0
+version: 1.1
 ---
 
 # Skill: cut-release
@@ -43,7 +43,38 @@ number from a previous session or document.
   gh pr list --state merged --limit 30
   ```
 
-## Step 2 -- Update CHANGELOG.md
+## Step 2 -- Pre-Release Retrospective
+
+Before updating the CHANGELOG, open a dedicated discussion thread and post
+agent observations. This step is advisory -- the human may proceed once
+formal CI and review checks are complete, even if one agent has nothing
+material to add.
+
+Open the thread (substitute the computed `$NEXT` version):
+
+```bash
+gh api graphql -f query='
+mutation {
+  createDiscussion(input: {
+    repositoryId: "R_kgDOMOfaEA",
+    categoryId: "DIC_kwDOMOfaEM4C_SO-",
+    title: "Release v1.1.N retrospective",
+    body: "Pre-release retrospective for v1.1.N.\n\nBoth agents post observations below: what landed, what was deferred, and any open concerns before the tag goes out."
+  }) {
+    discussion { url number }
+  }
+}'
+```
+
+- [ ] New discussion thread opened titled "Release vX.Y.Z retrospective"
+- [ ] This agent has posted its retrospective (what landed, what was deferred, open concerns)
+- [ ] Kimi has posted its retrospective, or confirmed nothing material to add
+- [ ] Human has reviewed both posts and confirmed readiness to proceed
+
+Each agent post must include the standard agent identification block
+(AGENTS.md Section 9.5). Link the thread URL in the release PR body.
+
+## Step 3 -- Update CHANGELOG.md
 
 Read `CHANGELOG.md` first to confirm the current format, then add a new entry:
 
@@ -73,7 +104,7 @@ Rules:
 - [ ] No non-ASCII punctuation (plain ASCII only -- CI enforces this)
 - [ ] `[Unreleased]` section is cleared (contents moved to new version entry)
 
-## Step 3 -- Merge dev to main
+## Step 4 -- Merge dev to main
 
 ```bash
 # Ensure dev is up to date
@@ -102,7 +133,7 @@ gh pr create \
 - [ ] PR targets `main` (not `dev`) -- releases go to main
 - [ ] CI is green before merging
 
-## Step 4 -- Tag the Release
+## Step 5 -- Tag the Release
 
 After the PR is merged to `main`:
 
@@ -116,7 +147,7 @@ git push origin v1.1.<N>
 - [ ] Tag is pushed to `origin` (upstream), not just `fork`
 - [ ] The `release.yml` workflow fires within 30 seconds of tag push
 
-## Step 5 -- Verify GitHub Release
+## Step 6 -- Verify GitHub Release
 
 ```bash
 # Check workflow status
@@ -130,7 +161,7 @@ gh release view v1.1.<N> --repo xencon/aixcl
 - [ ] Release notes are populated (from CHANGELOG or release template)
 - [ ] No draft status -- release is published
 
-## Step 6 -- Sync dev with main
+## Step 7 -- Sync dev with main
 
 After release, sync `dev` to include the merge commit from `main`:
 
@@ -149,7 +180,7 @@ gh pr create \
 - [ ] Sync PR merged to `dev`
 - [ ] No divergence between `main` and `dev`
 
-## Step 7 -- Close Release Issue
+## Step 8 -- Close Release Issue
 
 - [ ] Close the GitHub issue that tracked this release
 - [ ] Update any MEMORY.md entries referencing the previous version


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1497

### Description of Changes

Adds a pre-release retrospective step to the `cut-release` skill, agreed between Claude Code and Kimi in Discussion #1483.

New Step 2 sits between Pre-Release Housekeeping and the CHANGELOG update. Before cutting a release, both agents open a dedicated GitHub Discussion thread in the Agent Collaboration category, post their observations (what landed, what was deferred, open concerns), and the human reviews both before proceeding. The step is advisory -- the human may proceed once formal CI and review checks are complete.

Existing Steps 2-7 renumbered to Steps 3-8. Skill version bumped from 1.0 to 1.1.

Both skill mirrors updated identically:

- `.claude/skills/cut-release/SKILL.md`
- `.opencode/skills/cut-release/SKILL.md`

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] Assignee: sbadakhc
- [x] Component Label: component:infrastructure
- [x] Title Format: compliant

### Testing Notes

- `diff .claude/skills/cut-release/SKILL.md .opencode/skills/cut-release/SKILL.md` exits 0
- `check-ai-elisions.sh --staged` passed clean before commit
- `check-agents.sh` passes (skill files linted)

### Verification

- [x] `diff .claude/skills/cut-release/SKILL.md .opencode/skills/cut-release/SKILL.md` exits 0
- [x] New Step 2 reads clearly in the context of the full checklist
- [x] Step numbering is consistent throughout both files
- [x] No regressions observed

### Related Issues

- Fixes #1497
- Addresses #1483

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: Edited both cut-release SKILL.md mirrors; verified byte-identical parity with diff; elision guard passed
- Scope: .claude/skills/cut-release/SKILL.md, .opencode/skills/cut-release/SKILL.md
- Confirmation: yes
