### PR TITLE
fix .security directory permissions in setup-podman-rootless.sh (#1503)

### DIFF
--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -191,8 +191,12 @@ setup_volume_permissions() {
       mkdir -p "$dir"
       log_info "Created: $dir"
     fi
-    # Ensure user ownership
-    chmod u+rwx "$dir"
+    # .security must be owner-only (vault-init verifies mode 700)
+    if [[ "$dir" == *".security" ]]; then
+      chmod 700 "$dir"
+    else
+      chmod u+rwx "$dir"
+    fi
   done
   
   # Setup Podman volumes (rootless)

--- a/tests/lib/tests/test-04-setup-podman-permissions.sh
+++ b/tests/lib/tests/test-04-setup-podman-permissions.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Test 04: setup-podman-rootless.sh sets .security to mode 700
+# No running stack required. Exercises setup_volume_permissions in isolation.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
+
+log_test_start "test-04-setup-podman-permissions"
+
+SETUP_SCRIPT="${SCRIPT_DIR}/scripts/utils/setup-podman-rootless.sh"
+
+assert_file_exists "$SETUP_SCRIPT" "setup-podman-rootless.sh exists"
+
+# Work in a temp directory so we never touch the real .security
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Stub out init-volumes.sh which setup_volume_permissions calls
+mkdir -p "${TMPDIR_ROOT}/scripts/utils"
+printf '#!/usr/bin/env bash\n: # stub\n' > "${TMPDIR_ROOT}/scripts/utils/init-volumes.sh"
+chmod +x "${TMPDIR_ROOT}/scripts/utils/init-volumes.sh"
+
+# Extract the setup_volume_permissions function definition (lines 179-207)
+# and eval it in the current shell with stubs for its logging helpers.
+log_step() { :; }
+log_info() { :; }
+
+func_def="$(sed -n '/^setup_volume_permissions()/,/^}/p' "$SETUP_SCRIPT")"
+eval "$func_def"
+
+export PROJECT_ROOT="$TMPDIR_ROOT"
+setup_volume_permissions
+
+SECURITY_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/.security")"
+LOGS_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/logs")"
+AUDIT_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/.audit")"
+
+assert_command_success \
+  "[[ '$SECURITY_MODE' == '700' ]]" \
+  ".security directory has mode 700 (got $SECURITY_MODE)"
+
+assert_command_success \
+  "[[ '$LOGS_MODE' != '000' ]]" \
+  "logs directory is accessible (got $LOGS_MODE)"
+
+assert_command_success \
+  "[[ '$AUDIT_MODE' != '000' ]]" \
+  ".audit directory is accessible (got $AUDIT_MODE)"
+
+log_test_pass ".security permissions are correct after setup_volume_permissions"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1503

### Description of Changes

`setup_volume_permissions()` in `scripts/utils/setup-podman-rootless.sh` used `chmod u+rwx` for all directories in its loop. This only adds user bits and leaves group/other bits from the umask, producing mode 775 for `.security` on a typical 022 umask. `vault-init.sh` verifies `.security` is mode 700 at every stack start and fails if it is not.

Fix: apply `chmod 700` selectively to `.security`; leave `logs` and `.audit` with the existing additive `chmod u+rwx`.

Also adds `tests/lib/tests/test-04-setup-podman-permissions.sh` which exercises `setup_volume_permissions` in a temp directory and asserts `.security` is mode 700 after the function runs.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:infrastructure
- [x] **Title Format**: no colons, ends with (#1503)

### Testing Notes

- Ran `bash tests/lib/tests/test-04-setup-podman-permissions.sh` -- all assertions pass
- Ran `shellcheck --severity=warning --exclude=SC1091` on both changed files -- clean
- Ran `./scripts/checks/check-ai-elisions.sh --staged` -- clean

### Verification

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1503

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: read-only repository scan and targeted code fix
- Scope: scripts/utils/setup-podman-rootless.sh, tests/lib/tests/test-04-setup-podman-permissions.sh, git history analysis
- Confirmation: yes
---
