### PR TITLE
fix DOCKER_BIN fallback to podman in vault-init.sh (#1505)

### DIFF
--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -174,7 +174,7 @@ load_vault_token() {
 # ---------------------------------------------------------------------------
 
 is_vault_running() {
-    ${DOCKER_BIN:-docker} ps --format "{{.Names}}" | grep -q "^vault$"
+    ${DOCKER_BIN:-podman} ps --format "{{.Names}}" | grep -q "^vault$"
 }
 
 # Returns true if the Vault HTTP API is responding (even when sealed/uninitialized)
@@ -249,7 +249,7 @@ wait_for_vault() {
 # Wait for PostgreSQL container to accept connections before configuring Vault DB engine
 wait_for_postgres() {
     log_info "Waiting for PostgreSQL to be ready..."
-    local docker_bin="${DOCKER_BIN:-docker}"
+    local docker_bin="${DOCKER_BIN:-podman}"
 
     local retries=60
     while [ $retries -gt 0 ]; do
@@ -502,7 +502,7 @@ init_bootstrap_passwords() {
             log_info "Read existing PostgreSQL password from shared volume"
         fi
         if [ -z "$postgres_password" ]; then
-            postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+            postgres_password=$(${DOCKER_BIN:-podman} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
             [ -n "$postgres_password" ] && log_info "Read existing PostgreSQL password from container"
         fi
         [ -z "$postgres_password" ] && postgres_password=$(generate_password 32)
@@ -597,7 +597,7 @@ configure_postgres_connection() {
     postgres_password=$(curl -sf "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null | jq -r '.data.data.password // empty')
     if [ -z "$postgres_password" ]; then
-        postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+        postgres_password=$(${DOCKER_BIN:-podman} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
     fi
     if [ -z "$postgres_password" ]; then
         log_error "Could not retrieve PostgreSQL password from Vault KV or container"
@@ -883,12 +883,12 @@ main() {
     # separate (longer) "container exists but isn't ready yet" wait.
     local _pg_exists_retries=15
     while [ "$_pg_exists_retries" -gt 0 ] \
-            && ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; do
+            && ! "${DOCKER_BIN:-podman}" ps --format "{{.Names}}" | grep -q "^postgres$"; do
         sleep 2
         _pg_exists_retries=$((_pg_exists_retries - 1))
     done
 
-    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; then
+    if "${DOCKER_BIN:-podman}" ps --format "{{.Names}}" | grep -q "^postgres$"; then
         wait_for_postgres || return 1
         enable_database_engine || return 1
         configure_postgres_connection || return 1


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1505

### Description of Changes

All six `${DOCKER_BIN:-docker}` fallbacks in `lib/aixcl/commands/vault-init.sh` have been changed to `${DOCKER_BIN:-podman}`, aligning with the rootless-first default already used throughout `stack.sh`.

Without this change, `./aixcl vault init` on Podman-only systems resolves `DOCKER_BIN` to the missing `docker` binary and fails immediately with `docker: command not found` before it can check whether Vault is running. The root cause is that `DOCKER_BIN` is only exported by `set_compose_cmd()` in `docker_utils.sh`, which is not called in the `vault init` dispatch path.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

- [x] **Assignee**: sbadakhc
- [x] **Component Label**: component:infrastructure
- [x] **Title Format**: no colons, ends with (#1505)

### Testing Notes

- Ran `shellcheck --severity=warning --exclude=SC1091 lib/aixcl/commands/vault-init.sh` -- clean
- Ran `./scripts/checks/check-ai-elisions.sh --staged` -- clean
- Verified `./aixcl vault init` succeeds on Podman-only system without setting `DOCKER_BIN` manually

### Verification

- [x] `./aixcl vault init` succeeds on a Podman-only system without setting `DOCKER_BIN` manually
- [x] `./aixcl stack start --profile sys` still works correctly (no regression)
- [x] No regressions observed

### Related Issues

- Closes #1505
- Related to #1503

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: targeted code fix with grep-based scope analysis
- Scope: lib/aixcl/commands/vault-init.sh, lib/aixcl/commands/vault.sh, lib/core/docker_utils.sh, lib/aixcl/commands/stack.sh
- Confirmation: yes
---
