### PR TITLE
fix .env.podman append bug in setup-podman-rootless.sh (#1507)

### DIFF
--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -171,7 +171,14 @@ setup_podman_socket() {
   
   # Export for Docker compatibility
   export DOCKER_HOST="unix://$socket_path"
-  echo "export DOCKER_HOST=\"unix://$socket_path\"" >> "${PROJECT_ROOT}/.env.podman"
+  cat > "${PROJECT_ROOT}/.env.podman" << 'ENVEOF'
+# AIXCL Podman Configuration
+export DOCKER_BIN=podman
+export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+alias docker=podman
+export GPG_TTY=$(tty)
+export PATH="$HOME/.local/bin:$PATH"
+ENVEOF
   log_info "DOCKER_HOST set for Docker compatibility"
 }
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1507

### Description of Changes

Replaces the append (`>>`) in `setup_podman_socket()` with a `cat` heredoc write (`>`) so that repeated runs of `setup-podman-rootless.sh` always produce a single, complete `.env.podman` rather than accumulating duplicate `DOCKER_HOST` lines.

The heredoc now writes the full set of required variables:

- `DOCKER_BIN=podman` -- required for CLI compatibility
- `DOCKER_HOST` -- uses `$(id -u)` at source time (portable, no hardcoded UID)
- `alias docker=podman` -- Docker CLI drop-in
- `GPG_TTY=$(tty)` -- required for GPG passphrase prompts during vault unseal on WSL
- `PATH` -- ensures `$HOME/.local/bin` is on the path

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-1507/fix-env-podman-append` from `dev`)
- [x] Commit messages follow conventional style
- [x] ShellCheck passes (no warnings)
- [x] Elision guard clean (`check-ai-elisions.sh --staged`)
- [x] Assignee set
- [x] Component labels set

### Testing Notes

- Reproduced on WSL2 (Ubuntu 24.04): running `setup-podman-rootless.sh` twice previously produced 2 duplicate lines; after this fix the file is overwritten cleanly each time
- Verified `.env.podman` content matches expected variables after a single and double run

### Verification

- [ ] Behavior works as expected
- [ ] No regressions observed
- [ ] Tests cover change

### Related Issues

- Closes #1507

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: code fix in scripts/utils/setup-podman-rootless.sh, ShellCheck and elision guard verified locally
- Scope: scripts/utils/setup-podman-rootless.sh line 174
- Confirmation: yes
---
