### PR TITLE
Release v1.1.38 (#1510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.38] - 2026-06-17
+
+### Summary
+
+Release v1.1.38 -- Podman and WSL hardening. Fixes `.security/` permissions, `DOCKER_BIN` fallback, and a `.env.podman` append bug that caused duplicate environment lines and missing variables (including `GPG_TTY`) on repeated setup runs.
+
+### Fixed
+
+- [x] **`.security/` Directory Permissions**: `setup-podman-rootless.sh` was creating `.security/` with mode 775 instead of the required 700, causing `vault-init.sh` artefact verification to fail. Closes #1503.
+- [x] **DOCKER_BIN Fallback in vault-init.sh**: `vault-init.sh` fell back to `docker` instead of `podman` on Podman-only systems, breaking bootstrap agent container management. Closes #1505.
+- [x] **`.env.podman` Append Bug**: `setup-podman-rootless.sh` appended `DOCKER_HOST` to `.env.podman` on every run, accumulating duplicate lines and omitting required variables (`DOCKER_BIN`, `alias docker=podman`, `GPG_TTY`, `PATH`). The missing `GPG_TTY` caused silent GPG passphrase failures during `./aixcl vault unseal` on WSL, leaving Vault sealed after restart. Fix rewrites the file idempotently with the full variable set on each setup run. Closes #1507.
+
 ## [v1.1.37] - 2026-06-17
 
 ### Summary

--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -174,7 +174,7 @@ load_vault_token() {
 # ---------------------------------------------------------------------------
 
 is_vault_running() {
-    ${DOCKER_BIN:-docker} ps --format "{{.Names}}" | grep -q "^vault$"
+    ${DOCKER_BIN:-podman} ps --format "{{.Names}}" | grep -q "^vault$"
 }
 
 # Returns true if the Vault HTTP API is responding (even when sealed/uninitialized)
@@ -249,7 +249,7 @@ wait_for_vault() {
 # Wait for PostgreSQL container to accept connections before configuring Vault DB engine
 wait_for_postgres() {
     log_info "Waiting for PostgreSQL to be ready..."
-    local docker_bin="${DOCKER_BIN:-docker}"
+    local docker_bin="${DOCKER_BIN:-podman}"
 
     local retries=60
     while [ $retries -gt 0 ]; do
@@ -502,7 +502,7 @@ init_bootstrap_passwords() {
             log_info "Read existing PostgreSQL password from shared volume"
         fi
         if [ -z "$postgres_password" ]; then
-            postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+            postgres_password=$(${DOCKER_BIN:-podman} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
             [ -n "$postgres_password" ] && log_info "Read existing PostgreSQL password from container"
         fi
         [ -z "$postgres_password" ] && postgres_password=$(generate_password 32)
@@ -597,7 +597,7 @@ configure_postgres_connection() {
     postgres_password=$(curl -sf "${VAULT_ADDR}/v1/kv/data/bootstrap/postgres" \
         -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null | jq -r '.data.data.password // empty')
     if [ -z "$postgres_password" ]; then
-        postgres_password=$(${DOCKER_BIN:-docker} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
+        postgres_password=$(${DOCKER_BIN:-podman} exec postgres cat /run/secrets/postgres-password 2>/dev/null | tr -d '\n' || true)
     fi
     if [ -z "$postgres_password" ]; then
         log_error "Could not retrieve PostgreSQL password from Vault KV or container"
@@ -883,12 +883,12 @@ main() {
     # separate (longer) "container exists but isn't ready yet" wait.
     local _pg_exists_retries=15
     while [ "$_pg_exists_retries" -gt 0 ] \
-            && ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; do
+            && ! "${DOCKER_BIN:-podman}" ps --format "{{.Names}}" | grep -q "^postgres$"; do
         sleep 2
         _pg_exists_retries=$((_pg_exists_retries - 1))
     done
 
-    if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^postgres$"; then
+    if "${DOCKER_BIN:-podman}" ps --format "{{.Names}}" | grep -q "^postgres$"; then
         wait_for_postgres || return 1
         enable_database_engine || return 1
         configure_postgres_connection || return 1

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -171,7 +171,14 @@ setup_podman_socket() {
   
   # Export for Docker compatibility
   export DOCKER_HOST="unix://$socket_path"
-  echo "export DOCKER_HOST=\"unix://$socket_path\"" >> "${PROJECT_ROOT}/.env.podman"
+  cat > "${PROJECT_ROOT}/.env.podman" << 'ENVEOF'
+# AIXCL Podman Configuration
+export DOCKER_BIN=podman
+export DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock
+alias docker=podman
+export GPG_TTY=$(tty)
+export PATH="$HOME/.local/bin:$PATH"
+ENVEOF
   log_info "DOCKER_HOST set for Docker compatibility"
 }
 

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -191,8 +191,12 @@ setup_volume_permissions() {
       mkdir -p "$dir"
       log_info "Created: $dir"
     fi
-    # Ensure user ownership
-    chmod u+rwx "$dir"
+    # .security must be owner-only (vault-init verifies mode 700)
+    if [[ "$dir" == *".security" ]]; then
+      chmod 700 "$dir"
+    else
+      chmod u+rwx "$dir"
+    fi
   done
   
   # Setup Podman volumes (rootless)

--- a/tests/lib/tests/test-04-setup-podman-permissions.sh
+++ b/tests/lib/tests/test-04-setup-podman-permissions.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Test 04: setup-podman-rootless.sh sets .security to mode 700
+# No running stack required. Exercises setup_volume_permissions in isolation.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
+
+log_test_start "test-04-setup-podman-permissions"
+
+SETUP_SCRIPT="${SCRIPT_DIR}/scripts/utils/setup-podman-rootless.sh"
+
+assert_file_exists "$SETUP_SCRIPT" "setup-podman-rootless.sh exists"
+
+# Work in a temp directory so we never touch the real .security
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# Stub out init-volumes.sh which setup_volume_permissions calls
+mkdir -p "${TMPDIR_ROOT}/scripts/utils"
+printf '#!/usr/bin/env bash\n: # stub\n' > "${TMPDIR_ROOT}/scripts/utils/init-volumes.sh"
+chmod +x "${TMPDIR_ROOT}/scripts/utils/init-volumes.sh"
+
+# Extract the setup_volume_permissions function definition (lines 179-207)
+# and eval it in the current shell with stubs for its logging helpers.
+log_step() { :; }
+log_info() { :; }
+
+func_def="$(sed -n '/^setup_volume_permissions()/,/^}/p' "$SETUP_SCRIPT")"
+eval "$func_def"
+
+export PROJECT_ROOT="$TMPDIR_ROOT"
+setup_volume_permissions
+
+SECURITY_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/.security")"
+LOGS_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/logs")"
+AUDIT_MODE="$(stat -c "%a" "${TMPDIR_ROOT}/.audit")"
+
+assert_command_success \
+  "[[ '$SECURITY_MODE' == '700' ]]" \
+  ".security directory has mode 700 (got $SECURITY_MODE)"
+
+assert_command_success \
+  "[[ '$LOGS_MODE' != '000' ]]" \
+  "logs directory is accessible (got $LOGS_MODE)"
+
+assert_command_success \
+  "[[ '$AUDIT_MODE' != '000' ]]" \
+  ".audit directory is accessible (got $AUDIT_MODE)"
+
+log_test_pass ".security permissions are correct after setup_volume_permissions"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1510

### Description of Changes

CHANGELOG update for v1.1.38 -- Podman and WSL hardening release covering three fixes:

- `.security/` directory permissions (775 -> 700)
- `DOCKER_BIN` fallback to podman in vault-init.sh
- `.env.podman` append bug and missing variables (GPG_TTY, DOCKER_BIN, etc.)

Retrospective: https://github.com/xencon/aixcl/discussions/1509

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly (`issue-1510/release-v1-1-38` from `dev`)
- [x] Commit messages follow conventional style
- [x] CHANGELOG entry follows v1.1.N format with today's date
- [x] No non-ASCII punctuation in CHANGELOG
- [x] `[Unreleased]` section remains empty
- [x] All CI checks green
- [x] Assignee set
- [x] Component labels set

### Testing Notes

Stack tested in both VM and WSL environments by operator prior to release.

### Verification

- [ ] Behavior works as expected
- [ ] No regressions observed
- [ ] Tests cover change

### Related Issues

- Closes #1510

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-17
- Method: cut-release skill, CHANGELOG authored from git log v1.1.37..dev
- Scope: CHANGELOG.md only
- Confirmation: yes
---
