### PR TITLE
Add git-cliff config and update cut-release skill (#1527)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -76,22 +76,23 @@ Each agent post must include the standard agent identification block
 
 ## Step 3 -- Update CHANGELOG.md
 
-Generate a draft from conventional commits using git-cliff (if installed), then
-edit the output to match the required format:
+Generate a draft from conventional commits using git-cliff (if installed),
+then edit to match the required format:
 
 ```bash
-# Generate draft for the next version (replace vX.Y.Z with the computed $NEXT)
+# Generate draft for commits since the last tag
 git cliff --unreleased --tag "$NEXT" 2>/dev/null \
   || echo "git-cliff not installed -- write entry manually"
 ```
 
-The draft output pre-fills Added/Fixed/Changed sections from commit messages.
-You MUST:
-- Fill in the `### Summary` line (cliff leaves a placeholder)
-- Verify and tighten every entry -- commit message bodies rarely read as release notes
-- Confirm all `Closes #N` references are correct
+The draft pre-fills Added/Fixed/Changed/Documentation sections from commit
+messages. You MUST still:
+- Write the `### Summary` line (cliff leaves a placeholder)
+- Verify and tighten every entry -- commit bodies rarely read as release notes
+- Confirm all `Closes #N` references are present and correct
 
-Read `CHANGELOG.md` first to confirm the current format, then prepend the edited entry:
+Read `CHANGELOG.md` first to confirm the current format, then prepend the
+edited entry under `## [Unreleased]`:
 
 ```markdown
 ## [v1.1.N] - YYYY-MM-DD

--- a/.opencode/skills/cut-release/SKILL.md
+++ b/.opencode/skills/cut-release/SKILL.md
@@ -76,7 +76,23 @@ Each agent post must include the standard agent identification block
 
 ## Step 3 -- Update CHANGELOG.md
 
-Read `CHANGELOG.md` first to confirm the current format, then add a new entry:
+Generate a draft from conventional commits using git-cliff (if installed),
+then edit to match the required format:
+
+```bash
+# Generate draft for commits since the last tag
+git cliff --unreleased --tag "$NEXT" 2>/dev/null \
+  || echo "git-cliff not installed -- write entry manually"
+```
+
+The draft pre-fills Added/Fixed/Changed/Documentation sections from commit
+messages. You MUST still:
+- Write the `### Summary` line (cliff leaves a placeholder)
+- Verify and tighten every entry -- commit bodies rarely read as release notes
+- Confirm all `Closes #N` references are present and correct
+
+Read `CHANGELOG.md` first to confirm the current format, then prepend the
+edited entry under `## [Unreleased]`:
 
 ```markdown
 ## [v1.1.N] - YYYY-MM-DD

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,43 +1,30 @@
 [changelog]
 header = ""
 body = """
-## [{{ version | trim_start_matches(pat="v") | prepend(value="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 
 ### Summary
-<!-- TODO: write one-sentence release summary here -->
-
-{% if commits | filter(attribute="group", value="Added") | length > 0 %}\
+<!-- TODO: one sentence describing the release -->
+{% if commits | filter(attribute="group", value="Added") | length > 0 %}
 ### Added
-{% for commit in commits | filter(attribute="group", value="Added") %}\
-- [x] **{{ commit.message | split(pat=":") | last | trim | title }}**: \
-{{ commit.message | split(pat=":") | last | trim }}.
-{% endfor %}
-
-{% endif %}\
-{% if commits | filter(attribute="group", value="Changed") | length > 0 %}\
+{% for commit in commits | filter(attribute="group", value="Added") %}
+- [x] **{{ commit.message | split(pat=":") | last | trim | capitalize }}**: {{ commit.message | split(pat=":") | last | trim | capitalize }}.{% endfor %}
+{% endif %}
+{% if commits | filter(attribute="group", value="Changed") | length > 0 %}
 ### Changed
-{% for commit in commits | filter(attribute="group", value="Changed") %}\
-- [x] **{{ commit.message | split(pat=":") | last | trim | title }}**: \
-{{ commit.message | split(pat=":") | last | trim }}.
-{% endfor %}
-
-{% endif %}\
-{% if commits | filter(attribute="group", value="Fixed") | length > 0 %}\
+{% for commit in commits | filter(attribute="group", value="Changed") %}
+- [x] **{{ commit.message | split(pat=":") | last | trim | capitalize }}**: {{ commit.message | split(pat=":") | last | trim | capitalize }}.{% endfor %}
+{% endif %}
+{% if commits | filter(attribute="group", value="Fixed") | length > 0 %}
 ### Fixed
-{% for commit in commits | filter(attribute="group", value="Fixed") %}\
-- [x] **{{ commit.message | split(pat=":") | last | trim | title }}**: \
-{{ commit.message | split(pat=":") | last | trim }}.
-{% endfor %}
-
-{% endif %}\
-{% if commits | filter(attribute="group", value="Documentation") | length > 0 %}\
+{% for commit in commits | filter(attribute="group", value="Fixed") %}
+- [x] **{{ commit.message | split(pat=":") | last | trim | capitalize }}**: {{ commit.message | split(pat=":") | last | trim | capitalize }}.{% endfor %}
+{% endif %}
+{% if commits | filter(attribute="group", value="Documentation") | length > 0 %}
 ### Documentation
-{% for commit in commits | filter(attribute="group", value="Documentation") %}\
-- [x] **{{ commit.message | split(pat=":") | last | trim | title }}**: \
-{{ commit.message | split(pat=":") | last | trim }}.
-{% endfor %}
-
-{% endif %}\
+{% for commit in commits | filter(attribute="group", value="Documentation") %}
+- [x] **{{ commit.message | split(pat=":") | last | trim | capitalize }}**: {{ commit.message | split(pat=":") | last | trim | capitalize }}.{% endfor %}
+{% endif %}
 """
 trim = true
 footer = ""
@@ -60,10 +47,9 @@ commit_parsers = [
   { message = "^\\[OVERRIDE\\]", group = "Changed" },
   { message = "^Merge", skip = true },
   { message = "^Sync", skip = true },
+  { message = "^Release", skip = true },
 ]
 filter_commits = true
 tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
-skip_tags = ""
-ignore_tags = ""
 topo_order = false
 sort_commits = "newest"


### PR DESCRIPTION
## Summary

- Adds `cliff.toml` configuring git-cliff to parse conventional commits into CHANGELOG-compatible draft entries; maps feat/fix/refactor/chore/docs/test/ci to Added/Fixed/Changed/Documentation sections; skips Merge/Sync/Release commits; rewrites `(#N)` references as `(Closes #N)`
- Updates `Step 3` of `.claude/skills/cut-release/SKILL.md` and `.opencode/skills/cut-release/SKILL.md` to use `git cliff --unreleased --tag "$NEXT"` as a draft generator before manual editing

## Why

CHANGELOG.md is manually maintained today. At app prototyping velocity that becomes a bottleneck. git-cliff generates a draft from well-formed conventional commits, reducing Step 3 of the release process to editing rather than authoring from scratch. The existing `release.yml` workflow and manual review step are unchanged.

## Test plan

- [x] `git cliff --unreleased` produces output on a branch with conventional commits
- [x] Output format is close to the existing CHANGELOG style (may need minor edits)
- [x] Mirror parity: `diff .claude/skills/cut-release/SKILL.md .opencode/skills/cut-release/SKILL.md` is clean

Fixes #1527

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-19
- Method: Created cliff.toml and updated cut-release skill in both mirror locations
- Scope: cliff.toml, .claude/skills/cut-release/SKILL.md, .opencode/skills/cut-release/SKILL.md
- Confirmation: yes
---