### PR TITLE
Establish app layer test structure in tests/apps/ (#1528)

### DIFF
--- a/tests/apps/CONTEXT.md
+++ b/tests/apps/CONTEXT.md
@@ -1,0 +1,56 @@
+# CONTEXT: tests/apps/
+
+Test suite for applications built on top of the AIXCL inference platform.
+These tests verify the API surface that app code depends on, not the platform
+internals (those live in `tests/command-tests/`).
+
+## Purpose
+
+- Validate that the inference API is reachable and responds correctly
+- Provide a baseline connectivity test every app can build on
+- Establish patterns for app-specific test files
+
+## Test Files
+
+| File | What it tests | Requires |
+|------|---------------|----------|
+| `test-inference-api.sh` | OpenAI-compatible API connectivity and basic chat completion | Running stack |
+
+## Running
+
+```bash
+# All platform + app tests
+tests/run-tests.sh
+
+# App tests only
+tests/run-tests.sh --category apps
+```
+
+Individual test files can be run standalone when the stack is already up:
+
+```bash
+bash tests/apps/test-inference-api.sh
+```
+
+## Adding Tests for Your App
+
+1. Create `tests/apps/test-<your-app>.sh`
+2. Source the test framework at the top
+3. Use `assert_command_success` / `assert_output_contains` for assertions
+4. Skip gracefully if the stack is not running (see `test-inference-api.sh` for pattern)
+
+## Agent Guidance
+
+**You MAY:**
+- Add test files for new app prototypes following the pattern here
+- Add helper functions to `tests/lib/` if multiple app tests need them
+
+**You MUST NOT:**
+- Assume the stack is running -- skip gracefully if it is not
+- Add tests that require network access outside the local platform
+
+## Cross-References
+
+- `tests/lib/test-framework.sh` -- assertion helpers
+- `tests/run-tests.sh` -- top-level runner
+- `docs/developer/app-builder-guide.md` -- API reference for app builders

--- a/tests/apps/test-inference-api.sh
+++ b/tests/apps/test-inference-api.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test: Inference API connectivity
+# Validates the OpenAI-compatible API endpoint is reachable and responding.
+# Skips gracefully if the stack is not running.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
+
+log_test_start "test-inference-api"
+
+# Resolve API endpoint from .env or fall back to default
+INFERENCE_HOST="${INFERENCE_HOST:-localhost}"
+INFERENCE_PORT="${INFERENCE_PORT:-11434}"
+API_BASE="http://${INFERENCE_HOST}:${INFERENCE_PORT}"
+
+# Skip if stack is not reachable
+if ! curl -sf --max-time 3 "${API_BASE}" > /dev/null 2>&1; then
+    log_info "Inference API not reachable at ${API_BASE} -- stack may not be running"
+    log_info "Start the stack with: ./aixcl stack start --profile sys"
+    log_info "SKIP: test-inference-api (stack not running)"
+    exit 0
+fi
+
+# Test: models endpoint responds
+assert_command_success \
+    "curl -sf --max-time 5 '${API_BASE}/api/tags'" \
+    "Models endpoint responds at ${API_BASE}/api/tags"
+
+# Test: OpenAI-compatible models endpoint responds
+assert_command_success \
+    "curl -sf --max-time 5 '${API_BASE}/v1/models'" \
+    "OpenAI-compatible models endpoint responds at ${API_BASE}/v1/models"
+
+# Test: at least one model is loaded
+MODEL_COUNT=$(curl -sf --max-time 5 "${API_BASE}/v1/models" \
+    | grep -o '"id"' | wc -l | tr -d ' ')
+if [ "${MODEL_COUNT}" -eq 0 ]; then
+    log_info "No models loaded. Pull one with: ./aixcl models add <model-name>"
+    log_info "SKIP: chat completion test (no models loaded)"
+else
+    # Test: chat completion endpoint accepts a request
+    FIRST_MODEL=$(curl -sf --max-time 5 "${API_BASE}/v1/models" \
+        | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+    log_info "Testing chat completion with model: ${FIRST_MODEL}"
+    assert_command_success \
+        "curl -sf --max-time 30 -X POST '${API_BASE}/v1/chat/completions' \
+          -H 'Content-Type: application/json' \
+          -d '{\"model\":\"${FIRST_MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":5}'" \
+        "Chat completion endpoint accepts request for model ${FIRST_MODEL}"
+fi
+
+log_test_pass "Inference API connectivity checks passed"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -79,6 +79,7 @@ Categories:
     command      - CLI command validation tests
     workflow     - README Quick Start workflow test
     lib          - Pure shell library unit tests (no running stack required)
+    apps         - App layer API connectivity tests (skip gracefully if stack not running)
 
 Notes:
     - Tests run sequentially and stop on first failure
@@ -125,6 +126,12 @@ discover_tests() {
 
         if [[ -z "$CATEGORY" ]] || [[ "$CATEGORY" == "lib" ]]; then
             for test in "${TEST_DIR}/lib/tests"/test-*.sh; do
+                [[ -f "$test" ]] && tests+=("$test")
+            done
+        fi
+
+        if [[ -z "$CATEGORY" ]] || [[ "$CATEGORY" == "apps" ]]; then
+            for test in "${TEST_DIR}/apps"/test-*.sh; do
                 [[ -f "$test" ]] && tests+=("$test")
             done
         fi


### PR DESCRIPTION
## Summary

- Adds `tests/apps/CONTEXT.md` with agent orientation and test conventions for app builders
- Adds `tests/apps/test-inference-api.sh` testing the OpenAI-compatible API: models endpoint, v1/models endpoint, and chat completion; skips gracefully when the stack is not running
- Extends `tests/run-tests.sh` with an `apps` category in both discovery logic and help text

## Why

Platform tests cover `./aixcl` CLI internals. App prototypes need a separate test layer validating the API surface they depend on. Establishing the structure now, before app code proliferates, is significantly cheaper than retrofitting it.

## Test plan

- [x] `tests/run-tests.sh --category apps` runs without error when stack is down (skip, not fail)
- [x] `tests/run-tests.sh --category apps` passes connectivity assertions when stack is up
- [x] `tests/run-tests.sh --help` shows the `apps` category in the categories list

Fixes #1528

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-19
- Method: Created tests/apps/ directory with CONTEXT.md, inference API test, and extended run-tests.sh
- Scope: tests/apps/, tests/run-tests.sh
- Confirmation: yes
---