### PR TITLE
Allowlist historical Slack webhook commits in gitleaks config (#1548)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,3 +12,8 @@ paths = [
   '''config/\.env\.example''',
   '''CHANGELOG\.md''',
 ]
+commits = [
+  "e282f4bc9df1b4d6a6eb37967a6600b10bb3c59e",
+  "238eae8c5d602831d568790d4dad4675cd876832",
+  "f3de0a4121fa0597887b3761ae3ce30e0c5d502d",
+]


### PR DESCRIPTION
## Summary

Three commits in the deleted `lambda/` directory contain Slack webhook URLs that trigger gitleaks false positives when scanning full git history locally. The webhooks were confirmed non-existent. This allowlists the specific commit SHAs in `.gitleaks.toml`.

CI is unaffected -- the gitleaks job uses `fetch-depth: 1` and only scans the current PR state, so these historical commits are never scanned in CI. This fix is purely for clean local housekeeping runs.

Fixes #1548.

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-19
- Method: gitleaks scan, commit SHA identification, .gitleaks.toml update
- Scope: .gitleaks.toml only
- Confirmation: yes
---