### PR TITLE
Surface developer tooling checks in aixcl utils check-env (#1552)

### DIFF
--- a/lib/core/env_check.sh
+++ b/lib/core/env_check.sh
@@ -271,6 +271,43 @@ check_env() {
         echo "   Note: Ollama engine doesn't require hf"
     fi
 
+    # Check developer tooling (warnings only -- does not block stack)
+    echo -e "\nChecking developer tooling..."
+
+    if command -v pre-commit &>/dev/null; then
+        local pc_version
+        pc_version=$(pre-commit --version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "pre-commit installed ($pc_version)"
+        if [ -f ".git/hooks/pre-commit" ]; then
+            print_success "pre-commit hooks activated"
+        else
+            print_warning "pre-commit installed but hooks not activated"
+            echo "   Run: pre-commit install"
+        fi
+    else
+        print_warning "pre-commit not installed -- local quality gates will not run"
+        echo "   Install: pip install pre-commit"
+        echo "   Activate: pre-commit install"
+    fi
+
+    if command -v gitleaks &>/dev/null; then
+        local gl_version
+        gl_version=$(gitleaks version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "gitleaks installed ($gl_version)"
+    else
+        print_warning "gitleaks not installed -- secret scanning runs CI-only until installed"
+        echo "   Install v8.21.2+ from: https://github.com/gitleaks/gitleaks/releases"
+    fi
+
+    if command -v git-cliff &>/dev/null; then
+        local gc_version
+        gc_version=$(git-cliff --version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "git-cliff installed ($gc_version)"
+    else
+        print_warning "git-cliff not installed -- required for cut-release skill"
+        echo "   Install from: https://github.com/orhun/git-cliff/releases"
+    fi
+
     if [ $missing_deps -eq 1 ]; then
         echo -e "\n"
         print_error "Environment check failed. Please address the issues above."


### PR DESCRIPTION
## Summary

Fixes #1552

### Description of Changes

Adds a "Checking developer tooling..." section to `check_env()` in `lib/core/env_check.sh` so that `./aixcl utils check-env` surfaces warnings when `pre-commit`, `gitleaks`, or `git-cliff` are absent.

All three checks are warning-only -- they do not set `missing_deps` and do not affect the exit code. The stack check still passes for a developer who has none of the tools installed; they simply see actionable install instructions alongside the runtime results.

Verified locally:

- gitleaks installed: shows success line with version
- pre-commit absent: warns with `pip install pre-commit` and `pre-commit install` instructions
- git-cliff absent: warns with release URL and note that it is required for the cut-release skill
- Exit code remains 0; "Environment check passed!" still printed

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly (`issue-1552/surface-dev-tooling-in-check-env`)
- [x] Commit messages follow conventional style
- [x] `shellcheck --severity=warning --exclude=SC1091 lib/core/env_check.sh` -- clean
- [x] `bash -n lib/core/env_check.sh` -- syntax ok
- [x] `./scripts/checks/check-ai-elisions.sh --staged` -- passed
- [x] `./aixcl utils check-env` run locally and new section confirmed
- [x] Assignee set at creation
- [x] Component labels set at creation
- [x] Title format correct (no colons)

### Verification

- [x] `./aixcl utils check-env` shows "Checking developer tooling..." section
- [x] Missing tools produce warnings, not errors; exit code is 0
- [x] Installed tools produce success lines with versions
- [x] No regressions in existing runtime checks

### Related Issues

- Fixes #1552

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-19
- Method: read lib/core/env_check.sh, edited one file, ran shellcheck/bash-n/elision checks, ran ./aixcl utils check-env to verify output
- Scope: lib/core/env_check.sh
- Confirmation: yes
---
