### PR TITLE
Wire remaining CI checks into pre-commit and pre-push hooks (#1554)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,40 @@ repos:
         args: ['--staged']
         pass_filenames: false
         stages: [pre-commit]
+
+      - id: check-generated-files
+        name: Check for tracked generated files
+        language: script
+        entry: scripts/checks/check-generated-files.sh
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: check-agents
+        name: Check agent and skill mirror parity
+        language: script
+        entry: scripts/checks/check-agents.sh
+        pass_filenames: false
+        stages: [pre-commit]
+        files: '^(\.claude|\.opencode)/'
+
+      - id: check-paths
+        name: Check documentation relative links
+        language: script
+        entry: scripts/checks/check-paths.sh
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: security-tests
+        name: Run security tests
+        language: script
+        entry: tests/run-security-tests.sh
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: lib-tests
+        name: Run library unit tests
+        language: script
+        entry: tests/run-lib-tests.sh
+        pass_filenames: false
+        stages: [pre-push]
+        files: '^(lib|tests)/'

--- a/docs/developer/pre-commit-setup.md
+++ b/docs/developer/pre-commit-setup.md
@@ -13,6 +13,10 @@ That's it. Hooks run automatically on `git commit` from that point forward.
 
 ## What runs
 
+Hooks run at two stages. Commit-time hooks run on every `git commit`; push-time hooks run on `git push` and are reserved for broader or slower checks.
+
+### Commit-time hooks
+
 | Hook | Catches |
 |------|---------|
 | `trailing-whitespace` | Trailing spaces (excluding markdown) |
@@ -25,18 +29,33 @@ That's it. Hooks run automatically on `git commit` from that point forward.
 | `gitleaks` | Secret patterns in staged files (uses `.gitleaks.toml` allowlist) |
 | `no-non-ascii-punctuation` | Smart quotes, em dashes, ellipsis in markdown |
 | `check-ai-elisions` | AI placeholder text standing in for real content |
+| `check-generated-files` | Generated files accidentally tracked in git |
+| `check-agents` | `.claude/` vs `.opencode/` mirror parity (only when those paths change) |
+
+### Push-time hooks
+
+| Hook | Catches |
+|------|---------|
+| `check-paths` | Broken relative links in documentation |
+| `security-tests` | Security test suite (`tests/security/`) |
+| `lib-tests` | Library unit tests (`tests/run-tests.sh --category lib`; only when `lib/` or `tests/` change) |
 
 ## Run manually
 
 ```bash
-# Run against all files (useful after first install)
+# Run commit-time hooks against all files (useful after first install)
 pre-commit run --all-files
+
+# Run push-time hooks against all files
+pre-commit run --all-files --hook-stage pre-push
 
 # Run a specific hook
 pre-commit run shellcheck --all-files
+pre-commit run check-paths --hook-stage pre-push
 
-# Skip hooks for a single commit (use sparingly)
+# Skip hooks for a single commit or push (use sparingly)
 SKIP=shellcheck git commit -m "..."
+SKIP=lib-tests git push
 ```
 
 ## Update hook versions

--- a/tests/run-lib-tests.sh
+++ b/tests/run-lib-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run library unit tests -- used by pre-push hook and CI
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec bash "${SCRIPT_DIR}/run-tests.sh" --category lib

--- a/tests/run-security-tests.sh
+++ b/tests/run-security-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run all security tests -- used by pre-push hook and CI
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Running security tests..."
+for test in "${SCRIPT_DIR}/security/"*.sh; do
+    echo "  $test"
+    bash "$test" || exit 1
+done
+echo "All security tests passed."


### PR DESCRIPTION
## Summary

Fixes #1554

### Description of Changes

Closes the remaining gap between CI checks and local development by wiring five scripts into the pre-commit hook framework. Two run at commit time; three run at push time to avoid blocking granular commits with broader checks.

**Commit-time hooks added:**

- `check-generated-files` -- `scripts/checks/check-generated-files.sh` (mirrors `documentation-checks.yml`)
- `check-agents` -- `scripts/checks/check-agents.sh` with `files:` filter for `.claude/` and `.opencode/` paths only (mirrors `check-opencode.yml`)

**Push-time hooks added:**

- `check-paths` -- `scripts/checks/check-paths.sh` (mirrors `documentation-checks.yml`)
- `security-tests` -- `tests/run-security-tests.sh` wrapper (mirrors `quick-tests.yml`)
- `lib-tests` -- `tests/run-lib-tests.sh` wrapper with `files:` filter for `lib/` and `tests/` paths (mirrors `quick-tests.yml`)

Two thin wrapper scripts added (`tests/run-security-tests.sh`, `tests/run-lib-tests.sh`) to give pre-commit clean entry points into the existing test infrastructure.

`docs/developer/pre-commit-setup.md` updated to document the commit vs push stage split and the new hooks.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch named correctly
- [x] Commit messages follow conventional style
- [x] `yamllint -c .yamllint.yml .pre-commit-config.yaml` -- clean
- [x] `shellcheck` on both wrapper scripts -- clean
- [x] `./scripts/checks/check-ai-elisions.sh --staged` -- passed
- [x] `bash tests/run-security-tests.sh` -- all security tests passed
- [x] `bash tests/run-lib-tests.sh` -- all lib tests passed
- [x] Assignee set at creation
- [x] Component labels set at creation
- [x] Title format correct (no colons)

### Verification

- [x] `git commit` triggers `check-generated-files` and `check-agents` (when `.claude/` or `.opencode/` files staged)
- [x] `git push` triggers `check-paths`, `security-tests`, and `lib-tests`
- [x] All hooks pass on a clean repository
- [x] CI workflows unchanged and green

### Related Issues

- Fixes #1554

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-19
- Method: read CI workflows and pre-commit config, edited .pre-commit-config.yaml and docs, created two wrapper scripts, ran yamllint/shellcheck/elision/test checks locally
- Scope: .pre-commit-config.yaml, docs/developer/pre-commit-setup.md, tests/run-security-tests.sh, tests/run-lib-tests.sh
- Confirmation: yes
---
