### PR TITLE
Release v1.1.40 (#1559)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,3 +12,8 @@ paths = [
   '''config/\.env\.example''',
   '''CHANGELOG\.md''',
 ]
+commits = [
+  "e282f4bc9df1b4d6a6eb37967a6600b10bb3c59e",
+  "238eae8c5d602831d568790d4dad4675cd876832",
+  "f3de0a4121fa0597887b3761ae3ce30e0c5d502d",
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,40 @@ repos:
         args: ['--staged']
         pass_filenames: false
         stages: [pre-commit]
+
+      - id: check-generated-files
+        name: Check for tracked generated files
+        language: script
+        entry: scripts/checks/check-generated-files.sh
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: check-agents
+        name: Check agent and skill mirror parity
+        language: script
+        entry: scripts/checks/check-agents.sh
+        pass_filenames: false
+        stages: [pre-commit]
+        files: '^(\.claude|\.opencode)/'
+
+      - id: check-paths
+        name: Check documentation relative links
+        language: script
+        entry: scripts/checks/check-paths.sh
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: security-tests
+        name: Run security tests
+        language: script
+        entry: tests/run-security-tests.sh
+        pass_filenames: false
+        stages: [pre-push]
+
+      - id: lib-tests
+        name: Run library unit tests
+        language: script
+        entry: tests/run-lib-tests.sh
+        pass_filenames: false
+        stages: [pre-push]
+        files: '^(lib|tests)/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,12 @@ repos:
       - id: yamllint
         args: ['-c', '.yamllint.yml']
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        args: ['--config', '.gitleaks.toml']
+
   - repo: local
     hooks:
       - id: no-non-ascii-punctuation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.40] - 2026-06-23
+
+### Summary
+
+Release v1.1.40 -- Vault reliability and pre-commit hardening. Permanently fixes the recurring Vault split-state failure with self-healing logic and prune ordering correction; adds a vault rekey command for key rotation; wires all CI quality checks into pre-commit/pre-push hooks for local parity; surfaces developer tooling gaps in check-env.
+
+### Added
+
+- [x] **vault rekey Command**: New `./aixcl vault rekey` subcommand implements vault operator rekey -- generates new unseal key shares and GPG-encrypts them to `.security/vault-keys.gpg`. Use after GPG key rotation or when existing shares may have been exposed. Closes #1557.
+- [x] **Pre-commit CI/Local Parity**: Wired all remaining CI quality checks (check-generated-files, check-agents, check-paths, security-tests, lib-tests) into `.pre-commit-config.yaml` at commit and push stages, eliminating gaps between local and CI quality gates. Closes #1554.
+- [x] **Developer Tooling Checks in check-env**: `./aixcl utils check-env` and `scripts/checks/check-environment.sh` now warn when pre-commit, gitleaks, or git-cliff are absent, improving developer experience on fresh setups. Closes #1552.
+- [x] **Gitleaks Pre-commit Hook**: Added gitleaks v8.21.2 to `.pre-commit-config.yaml` so secret scanning runs on every local commit, not just in CI. Closes #1550.
+
+### Changed
+
+- [x] **Bump actions/checkout to 7.0.0**: Dependabot update for the actions/checkout GitHub Action.
+
+### Fixed
+
+- [x] **Vault Split-State Self-Healing**: `vault-init.sh` now detects the split state (Vault initialized but `vault-keys.gpg` missing) and automatically wipes `aixcl-vault-data` and re-initializes, replacing the misleading loop-inducing error message. Closes #1557.
+- [x] **Vault prune() Ordering**: `utils.sh` deleted `.security/vault-keys.gpg` before removing volumes; a silent volume-removal failure left keys gone but vault data intact, creating split state. Artefact deletion now happens after volume removal. Closes #1557.
+- [x] **Gitleaks Allowlist for Historical Slack Webhook Commits**: Added `.gitleaks.toml` allowlist entries for historical Slack webhook URL commits that blocked gitleaks on the full git history. Closes #1548.
+
+## [v1.1.39] - 2026-06-19
+
+### Summary
+
+Release v1.1.39 -- Developer tooling, repository health automation, and CI hardening. Adds a housekeeping skill, gitleaks secret scanning in CI, Dependabot for dependency tracking, git-cliff for changelog automation, an app-layer test scaffold, and auto-close of linked issues on PR merge.
+
+### Added
+
+- [x] **Housekeeping Skill**: Added `housekeeping` skill with 12 checks covering lean policy, mirror parity, branch hygiene, secret scanning, shellcheck sweep, and more. Closes #1518.
+- [x] **Auto-Close Linked Issues**: Added GitHub Actions workflow to automatically close issues referenced in PR bodies when the PR merges to dev. Closes #1522.
+- [x] **Gitleaks Secret Scanning in CI**: Added gitleaks to the `security.yml` CI workflow using direct CLI install; scans all PRs and pushes for hardcoded secrets. Closes #1524.
+- [x] **Dependabot Configuration**: Added `.github/dependabot.yml` for automated Docker image and GitHub Actions version tracking. Closes #1525.
+- [x] **git-cliff Changelog Automation**: Added `cliff.toml` config and updated the `cut-release` skill to use git-cliff for generating CHANGELOG draft entries from conventional commits. Closes #1527.
+- [x] **App Layer Test Structure**: Established `tests/apps/` directory with a scaffold for per-app integration tests, separate from platform and library tests. Closes #1528.
+
+### Changed
+
+- [x] **OpenCode Demoted to Supported Client**: Corrected AGENTS.md, invariants, and governance docs to treat OpenCode as a supported AI coding client rather than a platform invariant; AIXCL is client-agnostic above the OpenAI-compatible API layer. Closes #1516.
+
+### Fixed
+
+- [x] **Housekeeping Skill False Positives and Env File Permissions**: Fixed false positives in branch hygiene and secret scanning checks; hardened env file permission check to avoid flagging example files. Closes #1520.
+
+### Documentation
+
+- [x] **Docker Compose Overlay Validation**: Documented the behavior and usage of the compose overlay validation check that catches long lines and missing keys in YAML overrides. Closes #1538.
+
 ## [v1.1.38] - 2026-06-17
 
 ### Summary
@@ -1522,4 +1572,3 @@ None
 - Database credentials are managed via environment variables
 - Connection pooling with configurable pool size
 - Graceful degradation when database is unavailable (service opencodes without persistence)
-

--- a/docs/developer/pre-commit-setup.md
+++ b/docs/developer/pre-commit-setup.md
@@ -22,6 +22,7 @@ That's it. Hooks run automatically on `git commit` from that point forward.
 | `check-merge-conflict` | Unresolved conflict markers |
 | `shellcheck` | Shell script issues (`--severity=warning --exclude=SC1091`) |
 | `yamllint` | YAML style violations (using `.yamllint.yml`) |
+| `gitleaks` | Secret patterns in staged files (uses `.gitleaks.toml` allowlist) |
 | `no-non-ascii-punctuation` | Smart quotes, em dashes, ellipsis in markdown |
 | `check-ai-elisions` | AI placeholder text standing in for real content |
 

--- a/docs/developer/pre-commit-setup.md
+++ b/docs/developer/pre-commit-setup.md
@@ -13,6 +13,10 @@ That's it. Hooks run automatically on `git commit` from that point forward.
 
 ## What runs
 
+Hooks run at two stages. Commit-time hooks run on every `git commit`; push-time hooks run on `git push` and are reserved for broader or slower checks.
+
+### Commit-time hooks
+
 | Hook | Catches |
 |------|---------|
 | `trailing-whitespace` | Trailing spaces (excluding markdown) |
@@ -25,18 +29,33 @@ That's it. Hooks run automatically on `git commit` from that point forward.
 | `gitleaks` | Secret patterns in staged files (uses `.gitleaks.toml` allowlist) |
 | `no-non-ascii-punctuation` | Smart quotes, em dashes, ellipsis in markdown |
 | `check-ai-elisions` | AI placeholder text standing in for real content |
+| `check-generated-files` | Generated files accidentally tracked in git |
+| `check-agents` | `.claude/` vs `.opencode/` mirror parity (only when those paths change) |
+
+### Push-time hooks
+
+| Hook | Catches |
+|------|---------|
+| `check-paths` | Broken relative links in documentation |
+| `security-tests` | Security test suite (`tests/security/`) |
+| `lib-tests` | Library unit tests (`tests/run-tests.sh --category lib`; only when `lib/` or `tests/` change) |
 
 ## Run manually
 
 ```bash
-# Run against all files (useful after first install)
+# Run commit-time hooks against all files (useful after first install)
 pre-commit run --all-files
+
+# Run push-time hooks against all files
+pre-commit run --all-files --hook-stage pre-push
 
 # Run a specific hook
 pre-commit run shellcheck --all-files
+pre-commit run check-paths --hook-stage pre-push
 
-# Skip hooks for a single commit (use sparingly)
+# Skip hooks for a single commit or push (use sparingly)
 SKIP=shellcheck git commit -m "..."
+SKIP=lib-tests git push
 ```
 
 ## Update hook versions

--- a/lib/aixcl/commands/utils.sh
+++ b/lib/aixcl/commands/utils.sh
@@ -32,17 +32,6 @@ function prune() {
     rm -f .aixcl.initialized .env pgadmin-servers.json
     echo ""
 
-    # The Vault data volume is wiped below, which invalidates the existing
-    # unseal-key/root-token artefacts (they only decrypt to valid key shares
-    # for the specific Vault instance that generated them). Remove them too
-    # so the next `./aixcl vault init` performs a clean re-init instead of
-    # failing with "still sealed after submitting N key shares" (stale keys
-    # vs a fresh volume). The rest of .security/ is left alone -- clearing
-    # the whole directory remains prune_all()'s responsibility.
-    echo "Removing stale Vault unseal artefacts (data volume is about to be wiped)..."
-    rm -f "${SCRIPT_DIR}/.security/vault-keys.gpg" "${SCRIPT_DIR}/.security/vault-root-token.gpg"
-    echo ""
-
     # Remove all containers before volumes -- Podman will not release a volume
     # while any container (even stopped) still references it. stack stop removes
     # running containers but stopped/exited ones may linger with volume mounts.
@@ -57,8 +46,16 @@ function prune() {
     local all_volumes
     all_volumes=$($docker_cmd volume ls -q 2>/dev/null || true)
     if [ -n "$all_volumes" ]; then
-        echo "$all_volumes" | xargs -r $docker_cmd volume rm -f 2>/dev/null || true
+        echo "$all_volumes" | xargs -r "$docker_cmd" volume rm -f 2>/dev/null || true
     fi
+    echo ""
+
+    # Remove Vault unseal artefacts AFTER volumes are gone -- these files are only
+    # valid for the specific Vault instance that generated them. Deleting them before
+    # volume removal risks split state if the volume rm fails. vault-init.sh self-heals
+    # split state automatically, but it is cleaner to avoid it here.
+    echo "Removing Vault unseal artefacts..."
+    rm -f "${SCRIPT_DIR}/.security/vault-keys.gpg" "${SCRIPT_DIR}/.security/vault-root-token.gpg"
     echo ""
 
     # Remove runtime-generated artifacts from host filesystem (bind-mounted directories)

--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -813,6 +813,60 @@ show_summary() {
 # restarts the bootstrap containers with the real token so postgres can proceed.
 
 # ---------------------------------------------------------------------------
+# Split-state recovery: Vault initialized but unseal keys missing
+#
+# This is unrecoverable without the keys -- the existing Vault data cannot
+# be unsealed. Wipe the data volume, restart vault, and perform a fresh init.
+# ---------------------------------------------------------------------------
+
+vault_wipe_and_reinit() {
+    local docker_bin="${DOCKER_BIN:-podman}"
+
+    log_warn "Split state detected: Vault is initialized but unseal keys are missing."
+    log_warn "Vault data is unrecoverable without the unseal keys."
+    log_warn "Wiping vault data volume and performing a fresh initialization..."
+    log_warn "All secrets stored in Vault will be lost. Bootstrap passwords will be regenerated."
+
+    # Stop the vault container so the volume is not held open
+    log_info "Stopping vault container..."
+    "$docker_bin" stop vault 2>/dev/null || true
+    "$docker_bin" rm vault 2>/dev/null || true
+
+    # Remove the vault data volume
+    log_info "Removing vault data volume (aixcl-vault-data)..."
+    if ! "$docker_bin" volume rm aixcl-vault-data 2>/dev/null; then
+        log_error "Failed to remove aixcl-vault-data volume."
+        log_error "  Manual recovery:"
+        log_error "    ${docker_bin} volume rm aixcl-vault-data"
+        log_error "    ./aixcl stack start --profile sys"
+        return 1
+    fi
+
+    # Clear any stale artefacts so operator init starts clean
+    rm -f "$VAULT_KEYS_FILE" "$VAULT_TOKEN_FILE"
+
+    # Restart vault via compose so it picks up a fresh empty volume
+    log_info "Restarting vault container..."
+    local compose_file="${SCRIPT_DIR}/services/docker-compose.yml"
+    if [ -f "$compose_file" ]; then
+        "$docker_bin" compose -f "$compose_file" up -d vault 2>/dev/null || {
+            log_error "Failed to restart vault container via compose."
+            log_error "  Run: ./aixcl stack start --profile sys"
+            return 1
+        }
+    else
+        log_error "Compose file not found at ${compose_file}"
+        return 1
+    fi
+
+    # Wait for the fresh vault API to stabilise before operator init
+    wait_for_vault_api || return 1
+
+    # Fresh operator init generates new keys and token
+    vault_operator_init || return 1
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -833,21 +887,25 @@ main() {
         # First-time init: generate unseal keys and root token
         vault_operator_init || return 1
     else
-        log_info "Vault is already initialized — verifying artefacts and checking seal state..."
+        log_info "Vault is already initialized -- verifying artefacts and checking seal state..."
 
-        # Verify .security/ artefacts exist before attempting to load the token
+        # Verify .security/ artefacts exist before attempting to load the token.
+        # If vault-keys.gpg is missing, data is unrecoverable -- self-heal by wiping
+        # the vault data volume and re-initializing from scratch.
         log_info "Checking .security/ artefacts..."
-        check_artefact_dir  ".security directory"  "$SECURITY_DIR"     "700" || {
-            log_error "  Run: ./aixcl vault init  to re-initialize"
-            return 1
+        check_artefact_dir  ".security directory"  "$SECURITY_DIR"    "700" || {
+            log_warn "  .security directory missing -- treating as split state"
+            mkdir -p "$SECURITY_DIR"
+            chmod 700 "$SECURITY_DIR"
+            vault_wipe_and_reinit || return 1
         }
-        check_artefact_file "vault-keys.gpg"       "$VAULT_KEYS_FILE"  "600" || {
-            log_error "  Unseal keys missing — Vault cannot be unsealed automatically"
-            log_error "  Run: ./aixcl vault init  to recover"
-            return 1
-        }
+
+        if ! check_artefact_file "vault-keys.gpg" "$VAULT_KEYS_FILE" "600" 2>/dev/null; then
+            vault_wipe_and_reinit || return 1
+        fi
+
         check_artefact_file "vault-root-token.gpg" "$VAULT_TOKEN_FILE" "600" || {
-            log_error "  Root token missing — attempting operator init to recover keys..."
+            log_warn "  Root token missing -- performing fresh operator init to recover..."
             vault_operator_init || return 1
         }
 

--- a/lib/aixcl/commands/vault-rekey.sh
+++ b/lib/aixcl/commands/vault-rekey.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# Vault rekey command - Rotate unseal keys and re-encrypt to .security/vault-keys.gpg
+# Part of AIXCL CLI: ./aixcl vault rekey
+#
+# Uses vault operator rekey to generate a new set of unseal key shares,
+# then GPG-encrypts them to .security/vault-keys.gpg. The previous key file
+# is replaced atomically. Use after GPG key rotation or when key shares may
+# have been exposed.
+#
+# Vault must be unsealed and reachable. The current root token must be
+# available (via .security/vault-root-token.gpg or VAULT_TOKEN env var).
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd)}"
+
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+    set -o allexport
+    # shellcheck disable=SC1091
+    source "${SCRIPT_DIR}/.env"
+    set +o allexport
+fi
+
+VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
+VAULT_TOKEN="${VAULT_TOKEN:-}"
+
+SECURITY_DIR="${SCRIPT_DIR}/.security"
+VAULT_KEYS_FILE="${SECURITY_DIR}/vault-keys.gpg"
+VAULT_KEYS_FILE_NEW="${SECURITY_DIR}/vault-keys.gpg.new"
+
+log_info()  { echo "[INFO] $1"; }
+log_warn()  { echo "[WARN] $1"; }
+log_error() { echo "[ERROR] $1"; }
+
+export VAULT_ADDR
+
+is_vault_sealed() {
+    local sealed
+    sealed=$(curl -s "${VAULT_ADDR}/v1/sys/seal-status" \
+        2>/dev/null | jq -r '.sealed // "unknown"')
+    [ "$sealed" = "true" ]
+}
+
+load_vault_token() {
+    if [ -n "$VAULT_TOKEN" ]; then
+        return 0
+    fi
+    local token_file="${SECURITY_DIR}/vault-root-token.gpg"
+    if [ ! -f "$token_file" ]; then
+        log_error "No VAULT_TOKEN in environment and no token file at ${token_file}"
+        return 1
+    fi
+    if [ -z "${GPG_TTY:-}" ]; then
+        GPG_TTY=$(tty 2>/dev/null || true)
+        export GPG_TTY
+    fi
+    local token
+    token=$(gpg --quiet --decrypt "$token_file" 2>/dev/null) || {
+        log_error "Failed to decrypt Vault root token."
+        log_error "  Is your GPG key available? Check: gpg --list-secret-keys"
+        return 1
+    }
+    VAULT_TOKEN="$token"
+    export VAULT_TOKEN
+}
+
+main() {
+    log_info "Starting Vault rekey..."
+    log_info "Vault address: ${VAULT_ADDR}"
+
+    if is_vault_sealed; then
+        log_error "Vault is sealed. Unseal before rekeying."
+        log_error "  Run: ./aixcl vault unseal"
+        return 1
+    fi
+
+    load_vault_token || return 1
+
+    # Discover GPG key
+    local gpg_id
+    gpg_id=$(git -C "${SCRIPT_DIR}" config --get user.signingkey 2>/dev/null || true)
+    if [ -z "$gpg_id" ]; then
+        gpg_id=$(gpg --list-secret-keys --keyid-format LONG 2>/dev/null \
+            | grep -E "^sec" | head -1 | awk '{print $2}' | cut -d'/' -f2 || true)
+    fi
+    if [ -z "$gpg_id" ]; then
+        log_error "No GPG key found. Check: gpg --list-secret-keys"
+        return 1
+    fi
+    log_info "Will encrypt new keys with GPG key: ${gpg_id}"
+
+    # Cancel any in-progress rekey before starting
+    curl -sf -X DELETE "${VAULT_ADDR}/v1/sys/rekey/init" \
+        -H "X-Vault-Token: ${VAULT_TOKEN}" >/dev/null 2>&1 || true
+
+    # Initialise rekey: 5 shares, threshold 3
+    log_info "Initializing rekey (5 shares, threshold 3)..."
+    local init_response
+    init_response=$(curl -sf -X PUT "${VAULT_ADDR}/v1/sys/rekey/init" \
+        -H "X-Vault-Token: ${VAULT_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{"secret_shares": 5, "secret_threshold": 3}' 2>/dev/null) || {
+        log_error "Failed to initialize rekey operation."
+        return 1
+    }
+
+    local nonce required
+    nonce=$(echo "$init_response" | jq -r '.nonce // empty')
+    required=$(echo "$init_response" | jq -r '.required // empty')
+
+    if [ -z "$nonce" ] || [ -z "$required" ]; then
+        log_error "Unexpected rekey init response: ${init_response}"
+        return 1
+    fi
+    log_info "Rekey initialized. Nonce: ${nonce}. Need ${required} key share(s)."
+
+    # Decrypt current key shares
+    log_info "Decrypting current unseal keys..."
+    if [ ! -f "$VAULT_KEYS_FILE" ]; then
+        log_error "Current key file not found at ${VAULT_KEYS_FILE}"
+        log_error "  Cannot rekey without the existing unseal keys."
+        return 1
+    fi
+    if [ -z "${GPG_TTY:-}" ]; then
+        GPG_TTY=$(tty 2>/dev/null || true)
+        export GPG_TTY
+    fi
+    local keys_json
+    keys_json=$(gpg --quiet --decrypt "$VAULT_KEYS_FILE" 2>/dev/null) || {
+        log_error "Failed to decrypt current unseal keys."
+        log_error "  Is your GPG key available? Check: gpg --list-secret-keys"
+        return 1
+    }
+
+    local key_count
+    key_count=$(echo "$keys_json" | jq '.unseal_keys_b64 | length' 2>/dev/null || echo "0")
+    if [ "$key_count" -lt "$required" ]; then
+        log_error "Need ${required} key shares but only found ${key_count} in ${VAULT_KEYS_FILE}"
+        return 1
+    fi
+
+    # Submit key shares to complete rekey
+    local rekey_response=""
+    for i in $(seq 0 $((required - 1))); do
+        local key
+        key=$(echo "$keys_json" | jq -r ".unseal_keys_b64[$i]")
+        log_info "Submitting key share $((i + 1)) of ${required}..."
+        rekey_response=$(curl -sf -X PUT "${VAULT_ADDR}/v1/sys/rekey/update" \
+            -H "X-Vault-Token: ${VAULT_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"key\": \"${key}\", \"nonce\": \"${nonce}\"}" 2>/dev/null) || {
+            log_error "Failed to submit key share $((i + 1))."
+            return 1
+        }
+
+        local complete
+        complete=$(echo "$rekey_response" | jq -r '.complete // false')
+        if [ "$complete" = "true" ]; then
+            break
+        fi
+    done
+
+    local new_key_count
+    new_key_count=$(echo "$rekey_response" | jq '.keys_base64 | length' 2>/dev/null || echo "0")
+    if [ "$new_key_count" -lt 3 ]; then
+        log_error "Rekey response did not contain new key shares (got ${new_key_count})."
+        log_error "  Response: ${rekey_response}"
+        return 1
+    fi
+
+    # GPG-encrypt new key shares to a temp file, then replace atomically
+    log_info "Encrypting new key shares..."
+    echo "$rekey_response" | jq '{unseal_keys_b64: .keys_base64, unseal_threshold: 3}' \
+        | gpg --quiet --encrypt --recipient "$gpg_id" --armor \
+        > "$VAULT_KEYS_FILE_NEW" || {
+        log_error "Failed to GPG-encrypt new unseal keys."
+        rm -f "$VAULT_KEYS_FILE_NEW"
+        return 1
+    }
+    chmod 600 "$VAULT_KEYS_FILE_NEW"
+
+    # Atomic replacement
+    mv "$VAULT_KEYS_FILE_NEW" "$VAULT_KEYS_FILE"
+    log_info "New unseal keys written to ${VAULT_KEYS_FILE}"
+
+    # Verify the new keys work by attempting an unseal cycle on a sealed vault is not
+    # practical here without sealing first -- just verify the file decrypts cleanly.
+    log_info "Verifying new key file decrypts cleanly..."
+    local verify_json
+    verify_json=$(gpg --quiet --decrypt "$VAULT_KEYS_FILE" 2>/dev/null) || {
+        log_error "New key file failed decrypt verification. The old keys may be gone."
+        log_error "  CRITICAL: keep the stack running until you verify the new keys work."
+        return 1
+    }
+    local verify_count
+    verify_count=$(echo "$verify_json" | jq '.unseal_keys_b64 | length' 2>/dev/null || echo "0")
+    if [ "$verify_count" -lt 3 ]; then
+        log_error "Verification failed: decrypted file contains fewer than 3 key shares."
+        return 1
+    fi
+
+    log_info ""
+    log_info "Vault rekey complete."
+    log_info "  New key shares: ${VAULT_KEYS_FILE}"
+    log_info "  BACKUP REMINDER: Copy ${VAULT_KEYS_FILE} to a secure location."
+    log_info "  The previous key shares are no longer valid."
+}
+
+main "$@"

--- a/lib/aixcl/commands/vault.sh
+++ b/lib/aixcl/commands/vault.sh
@@ -8,7 +8,7 @@
 function cmd_vault() {
     local subcommand="${1:-}"
     shift || true
-    
+
     case "$subcommand" in
         start)
             cmd_vault_start "$@"
@@ -34,6 +34,9 @@ function cmd_vault() {
         rotate)
             cmd_vault_rotate "$@"
             ;;
+        rekey)
+            cmd_vault_rekey "$@"
+            ;;
         logs)
             cmd_vault_logs "$@"
             ;;
@@ -56,7 +59,8 @@ function cmd_vault() {
             echo "  status       Check Vault health and initialization state"
             echo "  credentials  View generated dynamic credentials"
             echo "  passwords    View static bootstrap passwords (from Vault KV)"
-            echo "  rotate       Manually trigger credential rotation"
+            echo "  rotate       Manually trigger credential rotation (restarts agents for TTL refresh)
+  rekey        Rotate unseal keys -- generates new shares and re-encrypts to .security/"
             echo "  logs [n]     View Vault container logs (default: 50 lines)"
             echo ""
             echo "Examples:"
@@ -162,7 +166,7 @@ function cmd_vault_rotate() {
         return 1
     fi
     echo "Triggering manual credential rotation..."
-    
+
     # Check if Vault is accessible (via HTTP API, not vault CLI)
     local vault_addr="${VAULT_ADDR:-http://127.0.0.1:8200}"
     if ! curl -sf "${vault_addr}/v1/sys/health" >/dev/null 2>&1; then
@@ -170,11 +174,11 @@ function cmd_vault_rotate() {
         echo "Run: ./aixcl vault init"
         return 1
     fi
-    
+
     # Restart vault agents to trigger immediate rotation
     local agents
     agents=$(${DOCKER_BIN:-docker} ps --format "{{.Names}}" | grep "vault-agent" || true)
-    
+
     if [ -n "$agents" ]; then
         echo "Restarting Vault agents for immediate rotation..."
         while IFS= read -r agent; do
@@ -185,7 +189,7 @@ function cmd_vault_rotate() {
     else
         echo "No Vault agents running. They will pick up new credentials on next TTL refresh."
     fi
-    
+
     return 0
 }
 
@@ -193,17 +197,17 @@ function cmd_vault_logs() {
     # Show Vault container logs, consistent with stack logs behavior
     local tail_count="${1:-50}"
     local container_name="vault"
-    
+
     # Validate tail count
     if [[ ! "$tail_count" =~ ^[0-9]+$ ]] || [[ "$tail_count" -lt 1 ]] || [[ "$tail_count" -gt 10000 ]]; then
         echo "Error: Log line count must be a number between 1 and 10000"
         return 1
     fi
-    
+
     # Check if container exists (running or stopped)
     local actual_container
     actual_container=$("${DOCKER_BIN:-docker}" ps -a --format "{{.Names}}" 2>/dev/null | grep -E "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$" | head -1)
-    
+
     if [ -n "$actual_container" ]; then
         echo "Fetching logs for Vault (last $tail_count lines)..."
         echo ""
@@ -226,7 +230,7 @@ vault_is_enabled_in_profile() {
         profile=$(grep -E "^[[:space:]]*PROFILE[[:space:]]*=" "$env_file" 2>/dev/null | head -1 | cut -d '=' -f2 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || true)
     fi
     [ -z "$profile" ] && profile="sys"
-    
+
     # Check if profile contains vault service
     local profile_services
     profile_services=$(get_profile_services_for_profile "$profile" 2>/dev/null)
@@ -234,6 +238,21 @@ vault_is_enabled_in_profile() {
         return 0
     fi
     return 1
+}
+
+function cmd_vault_rekey() {
+    if ! vault_is_enabled_in_profile; then
+        echo "Vault is not enabled in the current profile."
+        echo "Use --profile bld or --profile sys to enable Vault."
+        return 1
+    fi
+    local rekey_script="${SCRIPT_DIR}/lib/aixcl/commands/vault-rekey.sh"
+    if [ -f "$rekey_script" ]; then
+        bash "$rekey_script" "$@"
+    else
+        echo "Error: vault-rekey.sh not found at $rekey_script"
+        return 1
+    fi
 }
 
 function cmd_vault_unseal() {
@@ -262,4 +281,5 @@ export -f cmd_vault_credentials
 export -f cmd_vault_passwords
 export -f cmd_vault_rotate
 export -f cmd_vault_logs
+export -f cmd_vault_rekey
 export -f cmd_vault_unseal

--- a/lib/core/env_check.sh
+++ b/lib/core/env_check.sh
@@ -271,6 +271,43 @@ check_env() {
         echo "   Note: Ollama engine doesn't require hf"
     fi
 
+    # Check developer tooling (warnings only -- does not block stack)
+    echo -e "\nChecking developer tooling..."
+
+    if command -v pre-commit &>/dev/null; then
+        local pc_version
+        pc_version=$(pre-commit --version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "pre-commit installed ($pc_version)"
+        if [ -f ".git/hooks/pre-commit" ]; then
+            print_success "pre-commit hooks activated"
+        else
+            print_warning "pre-commit installed but hooks not activated"
+            echo "   Run: pre-commit install"
+        fi
+    else
+        print_warning "pre-commit not installed -- local quality gates will not run"
+        echo "   Install: pip install pre-commit"
+        echo "   Activate: pre-commit install"
+    fi
+
+    if command -v gitleaks &>/dev/null; then
+        local gl_version
+        gl_version=$(gitleaks version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "gitleaks installed ($gl_version)"
+    else
+        print_warning "gitleaks not installed -- secret scanning runs CI-only until installed"
+        echo "   Install v8.21.2+ from: https://github.com/gitleaks/gitleaks/releases"
+    fi
+
+    if command -v git-cliff &>/dev/null; then
+        local gc_version
+        gc_version=$(git-cliff --version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "git-cliff installed ($gc_version)"
+    else
+        print_warning "git-cliff not installed -- required for cut-release skill"
+        echo "   Install from: https://github.com/orhun/git-cliff/releases"
+    fi
+
     if [ $missing_deps -eq 1 ]; then
         echo -e "\n"
         print_error "Environment check failed. Please address the issues above."

--- a/scripts/checks/check-environment.sh
+++ b/scripts/checks/check-environment.sh
@@ -269,6 +269,62 @@ check_docker() {
     fi
 }
 
+# Check pre-commit
+check_pre_commit() {
+    info "Checking pre-commit..."
+
+    if ! command -v pre-commit &>/dev/null; then
+        warn "pre-commit not installed -- local hooks will not run"
+        info "Install: pip install pre-commit"
+        info "Activate: pre-commit install"
+        return
+    fi
+
+    local version
+    version=$(pre-commit --version 2>/dev/null | head -1 || echo "version unknown")
+    pass "pre-commit installed ($version)"
+
+    if [ -f ".pre-commit-config.yaml" ]; then
+        if [ -f ".git/hooks/pre-commit" ]; then
+            pass "pre-commit hooks installed in .git/hooks"
+        else
+            warn "pre-commit installed but hooks not activated"
+            info "Run: pre-commit install"
+        fi
+    fi
+}
+
+# Check gitleaks
+check_gitleaks() {
+    info "Checking gitleaks (secret scanning)..."
+
+    if ! command -v gitleaks &>/dev/null; then
+        warn "gitleaks not installed -- secret scanning runs CI-only until installed"
+        info "Install from: https://github.com/gitleaks/gitleaks/releases"
+        info "Recommended: v8.21.2+"
+        return
+    fi
+
+    local version
+    version=$(gitleaks version 2>/dev/null | head -1 || echo "version unknown")
+    pass "gitleaks installed ($version)"
+}
+
+# Check git-cliff
+check_git_cliff() {
+    info "Checking git-cliff (changelog generation)..."
+
+    if ! command -v git-cliff &>/dev/null; then
+        warn "git-cliff not installed -- required for cut-release skill"
+        info "Install from: https://github.com/orhun/git-cliff/releases"
+        return
+    fi
+
+    local version
+    version=$(git-cliff --version 2>/dev/null | head -1 || echo "version unknown")
+    pass "git-cliff installed ($version)"
+}
+
 # Check ShellCheck version
 check_shellcheck() {
     info "Checking ShellCheck..."
@@ -332,6 +388,9 @@ main() {
     # Optional checks
     check_docker
     check_shellcheck
+    check_pre_commit
+    check_gitleaks
+    check_git_cliff
     
     echo ""
     echo "═══════════════════════════════════════════════════════════════"

--- a/tests/run-lib-tests.sh
+++ b/tests/run-lib-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run library unit tests -- used by pre-push hook and CI
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec bash "${SCRIPT_DIR}/run-tests.sh" --category lib

--- a/tests/run-security-tests.sh
+++ b/tests/run-security-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run all security tests -- used by pre-push hook and CI
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Running security tests..."
+for test in "${SCRIPT_DIR}/security/"*.sh; do
+    echo "  $test"
+    bash "$test" || exit 1
+done
+echo "All security tests passed."


### PR DESCRIPTION
## Summary

Release v1.1.40. Updates CHANGELOG.md with the v1.1.40 entry and the missing v1.1.39 entry.

Fixes #1559

### What's in this release

**Vault reliability**

- Vault split-state self-healing: vault-init.sh now detects missing vault-keys.gpg and auto-recovers by wiping and re-initializing
- prune() ordering fix: .security/ artefacts now deleted after volume removal to prevent split state
- New ./aixcl vault rekey command for unseal key rotation without data loss

**CI/local parity**

- All CI quality checks wired into pre-commit/pre-push hooks
- Developer tooling gaps surface in ./aixcl utils check-env
- Gitleaks runs on every local commit

**Also in v1.1.39 (backfilling missing CHANGELOG entry)**

- Housekeeping skill with 12 repository health checks
- Gitleaks in CI security workflow
- Dependabot for Docker and Actions version tracking
- git-cliff changelog automation
- App layer test structure

### Discussion

- Retrospective: https://github.com/xencon/aixcl/discussions/1560

### Change Checklist

- [x] PR targets main (not dev)
- [x] CHANGELOG entries use plain ASCII
- [x] Both v1.1.40 and missing v1.1.39 entries included
- [x] All issues closed before tag
- [x] CI green before merge

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-23
- Method: ran housekeeping checks, drafted CHANGELOG entries from git log and closed issues, staged and verified
- Scope: CHANGELOG.md
- Confirmation: yes
---
