### PR TITLE
Hotfix .env permissions for existing installations (#1562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Release v1.1.40 -- Vault reliability and pre-commit hardening. Permanently fixes
 - [x] **Vault Split-State Self-Healing**: `vault-init.sh` now detects the split state (Vault initialized but `vault-keys.gpg` missing) and automatically wipes `aixcl-vault-data` and re-initializes, replacing the misleading loop-inducing error message. Closes #1557.
 - [x] **Vault prune() Ordering**: `utils.sh` deleted `.security/vault-keys.gpg` before removing volumes; a silent volume-removal failure left keys gone but vault data intact, creating split state. Artefact deletion now happens after volume removal. Closes #1557.
 - [x] **Gitleaks Allowlist for Historical Slack Webhook Commits**: Added `.gitleaks.toml` allowlist entries for historical Slack webhook URL commits that blocked gitleaks on the full git history. Closes #1548.
+- [x] **`.env` Permissions Not Corrected on Existing Installations**: The `chmod 600` fix from #1520 only fired in the creation guard; any `.env` created before that fix retained 644 permanently. Moved `chmod 600` outside the guard in `service_utils.sh` and `engine.sh` so it runs unconditionally on every start. Closes #1562.
 
 ## [v1.1.39] - 2026-06-19
 

--- a/lib/aixcl/commands/engine.sh
+++ b/lib/aixcl/commands/engine.sh
@@ -17,14 +17,14 @@ _clear_opencode_model() {
 
 function engine() {
     local action="${1:-}"
-    
+
     if [ -z "$action" ]; then
         echo "Usage: ./aixcl engine {set <engine>|auto}"
         echo "  set   - Manually set engine (ollama, vllm, llamacpp)"
         echo "  auto  - Auto-detect optimal engine based on hardware"
         return 1
     fi
-    
+
     if [ "$action" = "set" ]; then
         shift
         local engine="${1:-}"
@@ -33,12 +33,12 @@ function engine() {
             echo "Valid options: ollama, vllm, llamacpp"
             return 1
         fi
-        
+
         # Check if .env exists, if not use .env.example
         if [ ! -f "${SCRIPT_DIR}/.env" ] && [ -f "${SCRIPT_DIR}/.env.example" ]; then
             cp "${SCRIPT_DIR}/.env.example" "${SCRIPT_DIR}/.env"
-            chmod 600 "${SCRIPT_DIR}/.env"
         fi
+        [ -f "${SCRIPT_DIR}/.env" ] && chmod 600 "${SCRIPT_DIR}/.env"
 
         if grep -qE "^[[:space:]]*#?INFERENCE_ENGINE=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
             sed -i "s/^[[:space:]]*#*INFERENCE_ENGINE=.*/INFERENCE_ENGINE=$engine/" "${SCRIPT_DIR}/.env"
@@ -46,7 +46,7 @@ function engine() {
             echo "INFERENCE_ENGINE=$engine" >> "${SCRIPT_DIR}/.env"
         fi
         echo "[x] Inference engine set to: $engine"
-        
+
         # Set vLLM-specific configuration when switching to vLLM
         # Configure Open WebUI Ollama API setting based on engine
         # When using Ollama: ENABLE_OLLAMA_API=true (for full Ollama feature support)
@@ -58,13 +58,13 @@ function engine() {
             local enable_ollama="false"
             echo "[x] Open WebUI Ollama API disabled (using OpenAI-compatible API)"
         fi
-        
+
         if grep -qE "^[[:space:]]*#?ENABLE_OLLAMA_API=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
             sed -i "s/^[[:space:]]*#*ENABLE_OLLAMA_API=.*/ENABLE_OLLAMA_API=$enable_ollama/" "${SCRIPT_DIR}/.env"
         else
             echo "ENABLE_OLLAMA_API=$enable_ollama" >> "${SCRIPT_DIR}/.env"
         fi
-        
+
         if [ "$engine" = "vllm" ]; then
             # Set enforce-eager flag to true by default for vLLM (disable for better performance on bare metal)
             local enforce_eager="${VLLM_ENFORCE_EAGER:-true}"
@@ -85,10 +85,10 @@ function engine() {
             fi
             echo "[x] OpenCode output token limit set to: $opencode_token_limit"
             echo "   This prevents OpenCode from exceeding vLLM token limits."
-            
+
             # Export for current session
             export OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX="$opencode_token_limit"
-            
+
             # Set default model for vLLM to Qwen2.5-Coder-0.5B-Instruct
             local vllm_default_model="Qwen/Qwen2.5-Coder-0.5B-Instruct"
             if ! grep -qE "^[[:space:]]*#?INFERENCE_MODEL=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
@@ -96,7 +96,7 @@ function engine() {
                 echo "[x] Default vLLM model set to: $vllm_default_model"
             fi
         fi
-        
+
         _clear_opencode_model
 
         echo "Note: Restart the stack for the change to take effect:"
@@ -105,8 +105,8 @@ function engine() {
         # Check if .env exists, if not use .env.example
         if [ ! -f "${SCRIPT_DIR}/.env" ] && [ -f "${SCRIPT_DIR}/.env.example" ]; then
             cp "${SCRIPT_DIR}/.env.example" "${SCRIPT_DIR}/.env"
-            chmod 600 "${SCRIPT_DIR}/.env"
         fi
+        [ -f "${SCRIPT_DIR}/.env" ] && chmod 600 "${SCRIPT_DIR}/.env"
 
         # Determine engine based on hardware
         if has_nvidia_container_toolkit; then
@@ -116,28 +116,28 @@ function engine() {
         else
             local engine="ollama"
         fi
-        
+
         echo "Auto-detected engine: $engine"
-        
+
         # Configure Open WebUI Ollama API setting based on auto-detected engine
         if [ "$engine" = "ollama" ]; then
             local enable_ollama="true"
         else
             local enable_ollama="false"
         fi
-        
+
         if grep -qE "^[[:space:]]*#?ENABLE_OLLAMA_API=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
             sed -i "s/^[[:space:]]*#*ENABLE_OLLAMA_API=.*/ENABLE_OLLAMA_API=$enable_ollama/" "${SCRIPT_DIR}/.env"
         else
             echo "ENABLE_OLLAMA_API=$enable_ollama" >> "${SCRIPT_DIR}/.env"
         fi
-        
+
         if [ "$engine" = "ollama" ]; then
             echo "[x] Open WebUI Ollama API enabled (for full Ollama feature support)"
         else
             echo "[x] Open WebUI Ollama API disabled (using OpenAI-compatible API)"
         fi
-        
+
         _clear_opencode_model
 
         echo "Note: Restart the stack for the change to take effect:"

--- a/lib/core/service_utils.sh
+++ b/lib/core/service_utils.sh
@@ -9,30 +9,30 @@
 container_start() {
     local service="$1"
     local force_recreate="${2:-false}"
-    
+
     # Resolve 'engine' alias
     local actual_service="$service"
     if [[ "$service" == "engine" ]]; then
         actual_service=$(get_container_name "engine")
     fi
-    
+
     local container_name
     container_name=$(get_container_name "$service")
-    
+
     # Set up compose command with GPU detection
     set_compose_cmd
-    
+
     # Check if already running
     if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
         log_info "Service '$service' is already running."
         return 0
     fi
-    
+
     # Remove existing containers (running or stopped)
     log_info "Cleaning up existing containers for $actual_service..."
     # podman-compose does not support 'rm' subcommand; use direct podman rm instead
     "${DOCKER_BIN:-docker}" rm -f "$container_name" 2>/dev/null || true
-    
+
     # Remove hash-prefixed containers directly
     local hash_prefixed
     hash_prefixed=$("${DOCKER_BIN:-docker}" ps -a --format "{{.ID}} {{.Names}}" 2>/dev/null | grep -E "_${container_name}$|^[0-9a-f]+_${container_name}$" | awk '{print $1}') || true
@@ -41,30 +41,32 @@ container_start() {
             "${DOCKER_BIN:-docker}" rm -f "$container_id" 2>/dev/null || true
         done
     fi
-    
+
     # Remove exact match
     "${DOCKER_BIN:-docker}" rm -f "$container_name" 2>/dev/null || true
-    
+
     log_info "Starting service: $service..."
-    
+
     # Ensure .env exists for services that need it
     if [ ! -f "${SCRIPT_DIR}/.env" ] && { [ "$service" = "open-webui" ] || [ "$service" = "postgres" ] || [ "$service" = "pgadmin" ]; }; then
         if [ -f "${SCRIPT_DIR}/config/.env.example" ]; then
             log_warning ".env file not found. Copying from config/.env.example..."
             cp "${SCRIPT_DIR}/config/.env.example" "${SCRIPT_DIR}/.env"
-            chmod 600 "${SCRIPT_DIR}/.env"
             load_env_file "${SCRIPT_DIR}/.env"
         else
             log_error ".env file required for service '$service'"
             return 1
         fi
     fi
-    
+    # Enforce 600 on .env unconditionally -- pre-existing files from before
+    # the permissions fix retain their original mode otherwise.
+    [ -f "${SCRIPT_DIR}/.env" ] && chmod 600 "${SCRIPT_DIR}/.env"
+
     # Generate pgAdmin config if needed
     if [ "$service" = "pgadmin" ]; then
         generate_pgadmin_config
     fi
-    
+
     # Start the container
     if [ "$force_recreate" = "true" ]; then
         if run_compose up -d --force-recreate --no-deps "$actual_service"; then
@@ -81,10 +83,10 @@ container_start() {
             return 1
         fi
     fi
-    
+
     # Wait briefly for initialization
     sleep 2
-    
+
     # Verify it's running
     if "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "^${container_name}$|_[0-9a-f]+_${container_name}$|^[0-9a-f]+_${container_name}$"; then
         log_info "Service '$service' is now running."
@@ -98,29 +100,29 @@ container_start() {
 # Usage: container_stop <service>
 container_stop() {
     local service="$1"
-    
+
     # Resolve 'engine' alias
     local actual_service="$service"
     if [[ "$service" == "engine" ]]; then
         actual_service=$(get_container_name "engine")
     fi
-    
+
     local container_name
     container_name=$(get_container_name "$service")
-    
+
     # Check if running
     if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -q "^${container_name}$"; then
         log_info "Service '$service' is not running."
         return 0
     fi
-    
+
     set_compose_cmd
-    
+
     log_info "Stopping service: $service..."
-    
+
     if run_compose stop "$actual_service"; then
         log_success "Successfully stopped service: $service"
-        
+
         # Clean up pgAdmin config if stopping pgadmin
         if [ "$service" = "pgadmin" ] && [ -f "pgadmin-servers.json" ]; then
             rm -f pgadmin-servers.json
@@ -138,9 +140,9 @@ container_stop() {
 container_restart() {
     local service="$1"
     local force_recreate="${2:-false}"
-    
+
     log_info "Restarting service: $service..."
-    
+
     if container_stop "$service"; then
         if container_start "$service" "$force_recreate"; then
             log_success "Successfully restarted service: $service"


### PR DESCRIPTION
## Summary

Fixes #1562

The `.env` permissions fix from PR #1563 was merged to dev after the v1.1.40 release PR (#1561) was already merged to main. This hotfix brings the two missing commits directly into main so v1.1.40 is complete as intended.

### Changes

- Cherry-pick of `6cf2b5a`: moves `chmod 600` outside the creation guard in `service_utils.sh` and `engine.sh` so it runs unconditionally on every start, correcting permissions on pre-existing installations
- CHANGELOG: adds the `.env` permissions entry to the v1.1.40 Fixed section

### Verification

- [x] `.env` permissions corrected to 600 on stack start for a pre-existing 644 file
- [x] All CI checks green

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-23
- Method: cherry-picked fix commit from dev, added CHANGELOG entry
- Scope: lib/core/service_utils.sh, lib/aixcl/commands/engine.sh, CHANGELOG.md
- Confirmation: yes
---
