### PR TITLE
Harden release skills and fix gitleaks pgadmin false positive (#1567)

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -135,8 +135,13 @@ git commit -m "chore: update changelog for v1.1.<N>
 
 Fixes #<issue-number>"
 
-# Push to fork and create PR targeting main (not dev)
-git push fork issue-<N>/release-v1-1-<N>
+# Push to fork
+git push origin issue-<N>/release-v1-1-<N>
+
+# Verify PR body passes reference check BEFORE creating
+cat /tmp/release-pr-body.md | bash scripts/checks/check-pr-references.sh
+
+# Create PR targeting main (not dev)
 gh pr create \
   --repo xencon/aixcl \
   --base main \
@@ -146,7 +151,13 @@ gh pr create \
   --label "Task,component:infrastructure,Maintenance"
 ```
 
+- [ ] PR body verified with `check-pr-references.sh` before creation
 - [ ] PR targets `main` (not `dev`) -- releases go to main
+- [ ] If the release branch is force-pushed after PR creation, confirm the PR HEAD SHA matches before the human merges:
+  ```bash
+  gh pr view <N> --repo xencon/aixcl --json headRefOid --jq '.headRefOid[:8]'
+  # must match: git log --oneline -1
+  ```
 - [ ] CI is green before merging
 
 ## Step 5 -- Tag the Release
@@ -208,3 +219,6 @@ gh pr create \
 - Forgetting to sync `dev` after release (dev diverges from main)
 - Using `latest` in CHANGELOG date instead of actual ISO date
 - Non-ASCII punctuation in CHANGELOG (CI fails the ASCII check)
+- Comma-packed PR body references -- always pipe the body through `check-pr-references.sh` before `gh pr create` and before `gh pr edit`
+- Force-push race: if a branch is force-pushed while the PR is open, GitHub may merge the pre-push HEAD if the human acts quickly. Always confirm `gh pr view <N> --json headRefOid` matches `git log --oneline -1` before asking the human to merge
+- Pre-commit trailing whitespace: if a commit fails with `trailing-whitespace`, the hook already fixed the files in the working tree. Run `git add <files>` to re-stage the linter's fixes and retry the commit -- never use `--no-verify`

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -212,6 +212,7 @@ find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
 
 - [ ] No sensitive runtime env files are world-readable or world-writable
 - [ ] Files under `vault/` or `security/` paths checked specifically
+- [ ] Note: to check whether a file is tracked in git, use `git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0 even when the file is not tracked, making `&& echo TRACKED` a false positive.
 
 ---
 
@@ -235,8 +236,9 @@ else
 fi
 ```
 
-- [ ] No secrets detected in tracked files
+- [ ] No secrets detected
 - [ ] If gitleaks not installed, note it as a tooling gap
+- [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
 
 ---
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,6 +11,7 @@ description = "Known safe patterns in this repository"
 paths = [
   '''config/\.env\.example''',
   '''CHANGELOG\.md''',
+  '''pgadmin-servers\.json''',
 ]
 commits = [
   "e282f4bc9df1b4d6a6eb37967a6600b10bb3c59e",

--- a/.opencode/skills/cut-release/SKILL.md
+++ b/.opencode/skills/cut-release/SKILL.md
@@ -135,8 +135,13 @@ git commit -m "chore: update changelog for v1.1.<N>
 
 Fixes #<issue-number>"
 
-# Push to fork and create PR targeting main (not dev)
-git push fork issue-<N>/release-v1-1-<N>
+# Push to fork
+git push origin issue-<N>/release-v1-1-<N>
+
+# Verify PR body passes reference check BEFORE creating
+cat /tmp/release-pr-body.md | bash scripts/checks/check-pr-references.sh
+
+# Create PR targeting main (not dev)
 gh pr create \
   --repo xencon/aixcl \
   --base main \
@@ -146,7 +151,13 @@ gh pr create \
   --label "Task,component:infrastructure,Maintenance"
 ```
 
+- [ ] PR body verified with `check-pr-references.sh` before creation
 - [ ] PR targets `main` (not `dev`) -- releases go to main
+- [ ] If the release branch is force-pushed after PR creation, confirm the PR HEAD SHA matches before the human merges:
+  ```bash
+  gh pr view <N> --repo xencon/aixcl --json headRefOid --jq '.headRefOid[:8]'
+  # must match: git log --oneline -1
+  ```
 - [ ] CI is green before merging
 
 ## Step 5 -- Tag the Release
@@ -208,3 +219,6 @@ gh pr create \
 - Forgetting to sync `dev` after release (dev diverges from main)
 - Using `latest` in CHANGELOG date instead of actual ISO date
 - Non-ASCII punctuation in CHANGELOG (CI fails the ASCII check)
+- Comma-packed PR body references -- always pipe the body through `check-pr-references.sh` before `gh pr create` and before `gh pr edit`
+- Force-push race: if a branch is force-pushed while the PR is open, GitHub may merge the pre-push HEAD if the human acts quickly. Always confirm `gh pr view <N> --json headRefOid` matches `git log --oneline -1` before asking the human to merge
+- Pre-commit trailing whitespace: if a commit fails with `trailing-whitespace`, the hook already fixed the files in the working tree. Run `git add <files>` to re-stage the linter's fixes and retry the commit -- never use `--no-verify`

--- a/.opencode/skills/housekeeping/SKILL.md
+++ b/.opencode/skills/housekeeping/SKILL.md
@@ -212,6 +212,7 @@ find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
 
 - [ ] No sensitive runtime env files are world-readable or world-writable
 - [ ] Files under `vault/` or `security/` paths checked specifically
+- [ ] Note: to check whether a file is tracked in git, use `git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0 even when the file is not tracked, making `&& echo TRACKED` a false positive.
 
 ---
 
@@ -235,8 +236,9 @@ else
 fi
 ```
 
-- [ ] No secrets detected in tracked files
+- [ ] No secrets detected
 - [ ] If gitleaks not installed, note it as a tooling gap
+- [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #1567

### Changes

**Gitleaks allowlist**

`pgadmin-servers.json` is a runtime-generated file correctly listed in `.gitignore` and never committed. The `--no-git` flag used in the housekeeping secret scan bypasses gitignore and scans all files on disk, causing a false positive on the pgAdmin password it contains at runtime. Added `pgadmin-servers.json` to the `.gitleaks.toml` paths allowlist.

**cut-release skill hardening**

Three lessons from the v1.1.40 release applied to the skill:

- Step 4: mandate `check-pr-references.sh` verification before every `gh pr create` -- the CI check caught comma-packed references twice in the same release session
- Step 4: add force-push race check -- confirm PR HEAD SHA matches the latest push before asking the human to merge
- Common Mistakes: document the pre-commit trailing-whitespace retry pattern (`git add <files>` after hook fixes, then retry)

**housekeeping skill hardening**

- Check 8: note that `git ls-files <file>` exits 0 even for untracked files -- use `--error-unmatch` for reliable tracking checks
- Check 9: note that `--no-git` scans all disk files including gitignored runtime files, and that these belong in `.gitleaks.toml` paths allowlist

Both skills mirrored to `.opencode/skills/`. `check-agents.sh` confirms parity.

### Verification

- [x] `gitleaks detect --source . --no-git` reports no leaks
- [x] `bash scripts/checks/check-agents.sh` confirms mirror parity
- [x] All CI checks green

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-23
- Method: post-release housekeeping, identified gitleaks false positive and three skill gaps from v1.1.40 release session
- Scope: .gitleaks.toml, .claude/skills/cut-release/SKILL.md, .claude/skills/housekeeping/SKILL.md, .opencode/skills/cut-release/SKILL.md, .opencode/skills/housekeeping/SKILL.md
- Confirmation: yes
---
