### PR TITLE
Fix rootless detection false positive and open-webui non-root PID 1 (#1569)

### DIFF
--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -12,20 +12,20 @@ load_env_file() {
             # Skip empty lines and comments
             [ -z "$line" ] && continue
             [ "${line#\#}" != "$line" ] && continue
-            
+
             # Extract key and value, handling quoted values
             if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
                 local key="${BASH_REMATCH[1]}"
                 local value="${BASH_REMATCH[2]}"
-                
+
                 # Remove leading/trailing whitespace from key
                 key="${key%"${key##*[![:space:]]}"}"
                 key="${key#"${key%%[![:space:]]*}"}"
-                
+
                 # Remove leading/trailing whitespace from value
                 value="${value%"${value##*[![:space:]]}"}"
                 value="${value#"${value%%[![:space:]]*}"}"
-                
+
                 # Remove surrounding quotes if present
                 if [[ "$value" =~ ^\".*\"$ ]]; then
                     value="${value#\"}"
@@ -34,7 +34,7 @@ load_env_file() {
                     value="${value#\'}"
                     value="${value%\'}"
                 fi
-                
+
                 # Only export if key is not empty and contains valid characters
                 # Note: Bash cannot export variables with hyphens
                 # Docker Compose reads these directly from .env file, so we don't need to export them
@@ -126,60 +126,60 @@ has_nvidia() {
      if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
          return 0
      fi
-     
+
      # Check for NVIDIA Container Toolkit
      if command -v nvidia-container-cli >/dev/null 2>&1; then
          return 0
      fi
-     
+
      # Check for installation via package managers
      if command -v dpkg >/dev/null 2>&1 && dpkg -l 2>/dev/null | grep -q nvidia-container-toolkit; then
          return 0
      fi
-     
+
      if command -v rpm >/dev/null 2>&1 && rpm -qa | grep -q nvidia-container-toolkit; then
          return 0
      fi
-     
+
      # Check for Docker/Podman configured with nvidia runtime
      if ${DOCKER_BIN:-docker} info 2>/dev/null | grep -qi "nvidia"; then
          return 0
      fi
-     
+
      # Check for hardware via pciutils (if available)
      if command -v lspci >/dev/null 2>&1 && lspci | grep -qi "nvidia"; then
          return 0
      fi
-     
+
      return 1
  }
- 
+
 # Check for NVIDIA Container Toolkit (specifically for GPU monitoring)
 has_nvidia_container_toolkit() {
      # Check for NVIDIA Container Toolkit CLI (primary method)
      if command -v nvidia-ctk >/dev/null 2>&1; then
          return 0
      fi
-     
+
      # Check for nvidia-container-cli as alternative
      if command -v nvidia-container-cli >/dev/null 2>&1; then
          return 0
      fi
-     
+
      # Check for toolkit installation files
      if [ -f "/usr/bin/nvidia-container-toolkit" ] || [ -f "/usr/local/bin/nvidia-container-toolkit" ]; then
          return 0
      fi
-     
+
      # Check for installation via package managers
      if command -v dpkg >/dev/null 2>&1 && dpkg -l 2>/dev/null | grep -q nvidia-container-toolkit; then
          return 0
      fi
-     
+
      if command -v rpm >/dev/null 2>&1 && rpm -qa 2>/dev/null | grep -q nvidia-container-toolkit; then
          return 0
      fi
-     
+
       # Check for NVIDIA container runtime in Docker/Podman
       if ${DOCKER_BIN:-docker} info 2>/dev/null | grep -qi "nvidia.*runtime"; then
           return 0
@@ -224,6 +224,10 @@ is_rootless() {
         if podman info --format '{{.Host.Rootless}}' 2>/dev/null | grep -q "true"; then
             return 0
         fi
+        # Fallback for Podman versions where Go template fields differ -- parse YAML output
+        if podman info 2>/dev/null | grep -q "rootless: true"; then
+            return 0
+        fi
     fi
     # Fallback: check if we are not root but can run docker
     if [ "$(id -u)" != "0" ] && command -v docker >/dev/null 2>&1; then
@@ -261,7 +265,7 @@ get_docker_sock() {
             fi
         fi
     fi
-    
+
     # Default to standard root socket
     echo "/var/run/docker.sock"
 }
@@ -274,25 +278,25 @@ validate_db_name() {
     name="$1"
     local context
     context="${2:-database}"
-    
+
     # Check if empty
     if [ -z "$name" ]; then
         echo "Error: Database name for $context cannot be empty" >&2
         return 1
     fi
-    
+
     # Check length (PostgreSQL limit is 63 bytes)
     if [ "${#name}" -gt 63 ]; then
         echo "Error: Database name '$name' exceeds 63 characters" >&2
         return 1
     fi
-    
+
     # Validate against whitelist pattern: alphanumeric + underscore, must start with letter or underscore
     if [[ ! "$name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
         echo "Error: Database name '$name' contains invalid characters. Use only letters, numbers, and underscores. Must start with a letter or underscore." >&2
         return 1
     fi
-    
+
     # Check for reserved PostgreSQL database names
     local lower_name
     lower_name=$(echo "$name" | tr '[:upper:]' '[:lower:]')
@@ -302,6 +306,6 @@ validate_db_name() {
             return 1
             ;;
     esac
-    
+
     return 0
 }

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -104,9 +104,10 @@ if [ "$(id -u)" = "0" ]; then
     chmod 1777 /tmp
 
     echo "Switching to webui user (UID: $USER_ID)..."
-    export -n USER_ID GROUP_ID
     export HOME=/home/webui
-    exec su -m webui -c 'exec /usr/local/bin/openwebui-entrypoint.sh'
+    # setpriv execs directly (unlike su which forks), so PID 1 becomes the non-root process
+    exec setpriv --reuid="$USER_ID" --regid="$GROUP_ID" --clear-groups -- \
+        /usr/local/bin/openwebui-entrypoint.sh
 fi
 
 # Running as non-root


### PR DESCRIPTION
## Summary

Fixes #1569

### Bug 1 -- is_rootless() false positive on Podman

`is_rootless()` in `lib/core/common.sh` queries two Go template fields to detect rootless Podman:

- `{{.Host.ServiceIsRootless}}` -- exits 125 (field not found) on this Podman version
- `{{.Host.Rootless}}` -- exits 125 (field not found) on this Podman version

Both fail silently, so `is_rootless()` returns false even when Podman is running rootless. This causes `check-env` to emit a spurious "Root container engine detected in production profile" warning. Fixed by adding a YAML-parse fallback: `podman info 2>/dev/null | grep -q "rootless: true"`.

### Bug 2 -- open-webui PID 1 as root

The `openwebui-entrypoint.sh` used `exec su -m webui -c '...'` to drop privileges. `su` forks to run the command rather than exec'ing directly, so `su` (UID 0) retained PID 1 while uvicorn (UID 1000) ran as a child. Fixed by replacing `su` with `setpriv --reuid --regid --clear-groups`, which exec's the target command directly so uvicorn becomes PID 1 as UID 1000.

`pgadmin` is unchanged -- PID 1 was already `gunicorn` running at UID 5050 before this PR.

### Verification

- [x] `./aixcl utils check-env` reports "Rootless container engine detected" (no warning)
- [x] After `./aixcl stack restart`, `podman exec open-webui cat /proc/1/status` shows UID 1000
- [x] All CI checks green

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-23
- Method: runtime inspection via podman exec and /proc/1/status, source read of is_rootless() and both entrypoint scripts
- Scope: lib/core/common.sh, scripts/runtime/openwebui-entrypoint.sh
- Confirmation: yes
---
