### PR TITLE
Comprehensive developer tooling audit fixes (#1571)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Install yamllint
-        run: pip install yamllint
+        run: pip install yamllint==1.35.1
 
       - name: Validate YAML files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ['--severity=warning', '--exclude=SC1091']

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ sudo apt-get install -y yamllint
 # ShellCheck 0.11.0+ (apt package 0.9.0 is too old -- use GitHub releases)
 curl -sSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz | tar -xJ -C /tmp
 sudo cp /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+
+# gitleaks 8.21.2+ -- secret scanning (runs in pre-commit and CI)
+curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz -C /tmp
+sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+
+# git-cliff 2.x -- changelog generation (required for cut-release skill)
+curl -sSL https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz | tar -xz -C /tmp
+sudo mv /tmp/git-cliff-2.13.1-x86_64-unknown-linux-gnu/git-cliff /usr/local/bin/git-cliff
 ```
 
 > **VM users (QEMU/SLIRP networking):** If image pulls fail mid-download, add the following to `/etc/docker/daemon.json` to work around MTU limitations:

--- a/lib/core/env_check.sh
+++ b/lib/core/env_check.sh
@@ -20,7 +20,7 @@ check_env() {
 
     # Check Docker / Podman
     local engine_found=0
-    
+
     if command -v podman &> /dev/null; then
         print_success "Podman is installed"
         engine_found=1
@@ -197,10 +197,10 @@ check_env() {
     if [ -z "$available_space" ] || [[ ! "$available_space" =~ ^[0-9]+$ ]]; then
         available_space=$(df -k "${SCRIPT_DIR}" | awk 'END{print $3}' 2>/dev/null || echo "0")
     fi
-    
+
     # Convert KB to GB (roughly)
     local available_gb=$((available_space / 1024 / 1024))
-    
+
     if [ "$available_gb" -lt "$required_space" ]; then
         print_warning "Low disk space. Required: ${required_space}GB, Available: ${available_gb}GB"
         # Only fail if it's extremely low, otherwise just warn for CI/small environments
@@ -215,7 +215,7 @@ check_env() {
     # Check memory
     local total_mem
     total_mem=$(free -g 2>/dev/null | awk '/^Mem:/{print $2}' || echo "")
-    
+
     if [[ -n "$total_mem" && "$total_mem" =~ ^[0-9]+$ ]]; then
         if [ "$total_mem" -lt 8 ]; then
             print_warning "Low memory detected (${total_mem}GB). Recommended: 8GB+"
@@ -238,7 +238,7 @@ check_env() {
                 env_errors=1
             fi
         done
-        
+
         # Validate database name using the shared function
         local db_name
         db_name=$(grep "^[[:space:]]*POSTGRES_DATABASE=" "${SCRIPT_DIR}/.env" | head -1 | cut -d'=' -f2 | sed "s/['\"]//g" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -306,6 +306,15 @@ check_env() {
     else
         print_warning "git-cliff not installed -- required for cut-release skill"
         echo "   Install from: https://github.com/orhun/git-cliff/releases"
+    fi
+
+    if command -v yamllint &>/dev/null; then
+        local yl_version
+        yl_version=$(yamllint --version 2>/dev/null | head -1 || echo "version unknown")
+        print_success "yamllint installed ($yl_version)"
+    else
+        print_warning "yamllint not installed -- YAML validation runs CI-only until installed"
+        echo "   Install: pip install yamllint==1.35.1  or  sudo apt-get install yamllint"
     fi
 
     if [ $missing_deps -eq 1 ]; then


### PR DESCRIPTION
## Summary

Fixes #1571

Comprehensive developer tooling audit identified four gaps between CI, pre-commit, check-env, and documentation. This PR closes all four.

### Change 1 -- yamllint added to check-env

`yamllint` runs on every commit via pre-commit but was invisible to `./aixcl utils check-env`. Added a check to the developer tooling section so operators are warned if it is missing before they hit a commit-time failure.

### Change 2 -- shellcheck-py pre-commit pin bumped to v0.11.0.1

Pre-commit was pinned to shellcheck-py v0.10.0.1 (shellcheck 0.10.0) while local brew and the CI ludeeus action both use shellcheck 0.11.0. Bumped to v0.11.0.1 so all three surfaces run the same version.

### Change 3 -- yamllint pinned in CI

`documentation-checks.yml` used `pip install yamllint` with no version. Pre-commit pins v1.35.1. Pinned CI to `yamllint==1.35.1` to prevent drift.

### Change 4 -- gitleaks and git-cliff install instructions added to README

Both tools are required for CI parity (gitleaks runs in pre-commit and CI; git-cliff is required by the cut-release skill) but had no documented install path. Added versioned curl install steps to the "Contributors only -- CI tools" section of README.md alongside the existing shellcheck and yamllint instructions.

### Verification

- [x] `./aixcl utils check-env` shows yamllint in developer tooling section
- [x] `pre-commit run shellcheck --all-files` uses shellcheck 0.11.0
- [x] CI yamllint step installs v1.35.1
- [x] README CI tools section covers all four tools

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-24
- Method: comprehensive audit of .github/workflows, .pre-commit-config.yaml, lib/core/env_check.sh, README.md; cross-referenced all four sources
- Scope: .pre-commit-config.yaml, .github/workflows/documentation-checks.yml, lib/core/env_check.sh, README.md
- Confirmation: yes
---
