### PR TITLE
Fix pr-validation double-trigger blocking release merges (#1576)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
       - dev
-    types: [opened, edited, synchronize, reopened, labeled, unlabeled, assigned, unassigned]
+    types: [opened, edited, synchronize, reopened]
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #1576

## Problem

Creating a PR with `--label` fires both `opened` and `labeled` events simultaneously. With `cancel-in-progress: true`, the `opened` run is CANCELLED by the `labeled` run. GitHub's ruleset sees CANCELLED check runs alongside the SUCCESS ones and blocks the merge, requiring a manual bypass on every release PR.

## Fix

Removed `labeled`, `unlabeled`, `assigned`, and `unassigned` from the `pull_request` trigger types. The validation jobs fetch live PR state via the GitHub API (not from the event payload), so they work correctly regardless of which event triggered the run. Label and assignee validation still fires on `opened`, `edited`, `synchronize`, and `reopened` -- the events that actually matter for PR hygiene.

## Before / After

Before: `types: [opened, edited, synchronize, reopened, labeled, unlabeled, assigned, unassigned]`

After: `types: [opened, edited, synchronize, reopened]`

## Verification

- [x] Agent: one workflow run per PR creation, no CANCELLED check runs
- [x] Human: confirm next release PR to main merges without ruleset bypass

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-24
- Method: root cause analysis and targeted one-line fix to pr-validation.yml trigger types
- Scope: .github/workflows/pr-validation.yml
- Confirmation: yes
---
