### PR TITLE
Add LLM output tracing wrapper and app builder guide (#1529)

### DIFF
--- a/docs/developer/app-builder-guide.md
+++ b/docs/developer/app-builder-guide.md
@@ -1,0 +1,101 @@
+# App Builder Guide
+
+This guide covers everything a developer needs to build an application on top of AIXCL.
+
+For prerequisites and stack startup see [development-workflow.md](development-workflow.md).
+
+## Inference API
+
+AIXCL exposes an OpenAI-compatible HTTP API via Ollama at `http://localhost:11434/v1`.
+No authentication is required for local development.
+
+```bash
+curl http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen2.5-coder:0.5b",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+List available models:
+
+```bash
+./aixcl models list
+```
+
+## LLM Output Tracing
+
+When debugging unexpected model behaviour the first question is always "what prompt did we
+send and what did the model return?" The tracing wrapper answers that without requiring any
+changes to your app code.
+
+### Design decision
+
+Traces are stored as JSON-lines files under `logs/traces/` (one file per app per day).
+The `logs/` directory is gitignored -- traces never reach the repository. A relational
+store (the stack already runs Postgres) was considered but ruled out for the prototype
+phase: JSON-lines requires no schema migration, is trivially grep-able, and can be
+imported into Postgres later if volume justifies it.
+
+### Usage
+
+```bash
+# Inline prompt
+./scripts/utils/trace-llm-call.sh \
+  --app my-app \
+  --model qwen2.5-coder:0.5b \
+  --prompt "Explain recursion in one sentence"
+
+# Stdin prompt (pipeline-friendly)
+echo "Explain recursion in one sentence" | \
+  ./scripts/utils/trace-llm-call.sh --app my-app --model qwen2.5-coder:0.5b
+```
+
+The script prints the model response to stdout and writes a trace entry to
+`logs/traces/my-app-YYYY-MM-DD.jsonl`. It can be used as a drop-in replacement for
+direct `curl` calls in prototype scripts.
+
+### Trace schema
+
+Each line in a trace file is a JSON object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `timestamp` | string (ISO 8601) | UTC time of the API call |
+| `app` | string | Value passed via `--app` |
+| `model` | string | Value passed via `--model` |
+| `prompt` | string | Full prompt text sent to the model |
+| `response` | string | Full response text returned by the model |
+| `duration_ms` | integer | Round-trip time in milliseconds |
+| `status` | string | `ok`, `http_error_NNN`, or `connection_error` |
+
+### Querying traces
+
+```bash
+# Print all traces for today
+cat logs/traces/my-app-$(date +%Y-%m-%d).jsonl | python3 -m json.tool
+
+# Filter by status
+grep '"status":"ok"' logs/traces/my-app-$(date +%Y-%m-%d).jsonl | wc -l
+
+# Pretty-print the last trace entry
+tail -1 logs/traces/my-app-$(date +%Y-%m-%d).jsonl | python3 -m json.tool
+
+# Extract prompts and responses side by side
+python3 - << 'EOF'
+import json
+with open(f"logs/traces/my-app-$(date +%Y-%m-%d).jsonl") as f:
+    for line in f:
+        e = json.loads(line)
+        print(f"[{e['timestamp']}] {e['duration_ms']}ms {e['status']}")
+        print(f"  PROMPT:   {e['prompt'][:80]}")
+        print(f"  RESPONSE: {e['response'][:80]}")
+EOF
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Inference API base URL |

--- a/scripts/utils/trace-llm-call.sh
+++ b/scripts/utils/trace-llm-call.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# LLM Call Tracer for AIXCL App Prototypes
+#
+# Usage:
+#   ./scripts/utils/trace-llm-call.sh --app <name> --model <model> --prompt <text>
+#   echo "prompt text" | ./scripts/utils/trace-llm-call.sh --app <name> --model <model>
+#
+# Calls the AIXCL inference API and appends a JSON-lines trace entry to
+# logs/traces/<app>-YYYY-MM-DD.jsonl. Response text is written to stdout
+# so the script can be used as a transparent wrapper in pipelines.
+#
+# Schema: timestamp, app, model, prompt, response, duration_ms, status
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+log_error() { echo -e "${RED}[trace-llm-call]${NC} $1" >&2; }
+log_info()  { echo -e "${GREEN}[trace-llm-call]${NC} $1" >&2; }
+
+usage() {
+    echo "Usage: $0 --app <name> --model <model> [--prompt <text>]" >&2
+    echo "  --app     Application name (used for log file naming)" >&2
+    echo "  --model   Model identifier (e.g. qwen2.5-coder:0.5b)" >&2
+    echo "  --prompt  Prompt text; reads from stdin if omitted" >&2
+    exit 1
+}
+
+APP=""
+MODEL=""
+PROMPT=""
+API_BASE="${OLLAMA_BASE_URL:-http://localhost:11434}/v1"
+TRACE_DIR="${PROJECT_DIR}/logs/traces"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app)    APP="$2";    shift 2 ;;
+        --model)  MODEL="$2";  shift 2 ;;
+        --prompt) PROMPT="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) log_error "Unknown argument: $1"; usage ;;
+    esac
+done
+
+[[ -z "$APP" || -z "$MODEL" ]] && usage
+
+# Read prompt from stdin if not supplied via flag
+if [[ -z "$PROMPT" ]]; then
+    if [[ -t 0 ]]; then
+        log_error "--prompt not given and stdin is a terminal -- provide prompt text"
+        usage
+    fi
+    PROMPT=$(cat)
+fi
+
+# Sanitize app name for use as filename component
+APP_SAFE="${APP//[^a-zA-Z0-9_-]/-}"
+
+mkdir -p "$TRACE_DIR"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TRACE_DATE=$(date -u +"%Y-%m-%d")
+TRACE_FILE="${TRACE_DIR}/${APP_SAFE}-${TRACE_DATE}.jsonl"
+
+# Build JSON payload -- use python3 to safely escape all special characters
+PAYLOAD=$(python3 -c "
+import json, sys
+print(json.dumps({'model': sys.argv[1], 'messages': [{'role': 'user', 'content': sys.argv[2]}]}))
+" "$MODEL" "$PROMPT")
+
+# Call the API and capture HTTP status code separately
+START_MS=$(date +%s%3N)
+HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "${API_BASE}/chat/completions" 2>/dev/null || echo -e "\nconnection_failed")
+END_MS=$(date +%s%3N)
+DURATION_MS=$(( END_MS - START_MS ))
+
+HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -1)
+RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | head -n -1)
+
+# Determine status and extract response text
+if [[ "$HTTP_CODE" == "200" ]]; then
+    STATUS="ok"
+    RESPONSE_TEXT=$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.stdin.read())
+    print(d['choices'][0]['message']['content'], end='')
+except Exception as e:
+    print(f'parse_error: {e}', end='')
+" <<< "$RESPONSE_BODY")
+elif [[ "$HTTP_CODE" == "connection_failed" ]]; then
+    STATUS="connection_error"
+    RESPONSE_TEXT="inference API unreachable at ${API_BASE}"
+else
+    STATUS="http_error_${HTTP_CODE}"
+    RESPONSE_TEXT="$RESPONSE_BODY"
+fi
+
+# Append JSON-lines trace entry
+python3 -c "
+import json, sys
+entry = {
+    'timestamp':   sys.argv[1],
+    'app':         sys.argv[2],
+    'model':       sys.argv[3],
+    'prompt':      sys.argv[4],
+    'response':    sys.argv[5],
+    'duration_ms': int(sys.argv[6]),
+    'status':      sys.argv[7],
+}
+print(json.dumps(entry))
+" "$TIMESTAMP" "$APP" "$MODEL" "$PROMPT" "$RESPONSE_TEXT" "$DURATION_MS" "$STATUS" >> "$TRACE_FILE"
+
+log_info "trace written to ${TRACE_FILE}"
+
+# Surface errors but still exit cleanly so callers can inspect the trace
+if [[ "$STATUS" != "ok" ]]; then
+    log_error "API call failed: $STATUS"
+    exit 1
+fi
+
+# Write response to stdout (transparent wrapper behaviour)
+echo "$RESPONSE_TEXT"


### PR DESCRIPTION
Fixes #1529

## What

Adds a thin LLM call tracing wrapper for app prototype debugging, and seeds `docs/developer/app-builder-guide.md` with the tracing section.

## Changes

- `scripts/utils/trace-llm-call.sh` -- wraps the AIXCL inference API, measures round-trip time, appends a JSON-lines entry to `logs/traces/<app>-YYYY-MM-DD.jsonl`, and writes the model response to stdout for use in pipelines
- `docs/developer/app-builder-guide.md` -- new file covering the inference API endpoint, the design decision (JSON-lines over Postgres for the prototype phase), tracing usage, schema reference, and query examples

## Trace schema

`timestamp`, `app`, `model`, `prompt`, `response`, `duration_ms`, `status`

## Notes

- `logs/` is already in `.gitignore` -- traces never reach the repository
- `OLLAMA_BASE_URL` is respected if set; defaults to `http://localhost:11434`
- The builder guide stub will be expanded by #1530

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-24
- Method: implementation from issue spec and codebase style review
- Scope: scripts/utils/, docs/developer/, .gitignore
- Confirmation: yes
---
