### PR TITLE
Align CLI and CI output icons with canonical ICON_* standard (#1581)

### DIFF
--- a/.github/workflows/bash-ci.yml
+++ b/.github/workflows/bash-ci.yml
@@ -43,16 +43,21 @@ jobs:
       - name: Check for Windows line endings (CRLF)
         run: |
           echo "Checking for CRLF line endings..."
-          CRLF_FILES=$(find . -type f -not -path "./.git/*" -not -path "./pgadmin-data/*" -not -path "./logs/*" -exec file {} \; 2>/dev/null | grep -i "with CRLF" | cut -d: -f1 | sed 's|^\./||')
+          CRLF_FILES=$(find . -type f \
+            -not -path "./.git/*" \
+            -not -path "./pgadmin-data/*" \
+            -not -path "./logs/*" \
+            -exec file {} \; 2>/dev/null \
+            | grep -i "with CRLF" | cut -d: -f1 | sed 's|^\./||')
           if [ -n "$CRLF_FILES" ]; then
-            echo "ERROR: Found files with Windows line endings (CRLF):"
+            echo "❌ Found files with Windows line endings (CRLF):"
             echo "$CRLF_FILES"
             echo ""
             echo "Please convert these files to Unix line endings (LF) before committing."
             echo "You can use: sed -i 's/\\r$//' <file>"
             exit 1
           else
-            echo "[OK] No CRLF files found - all line endings are Unix style (LF)"
+            echo "✅ No CRLF files found - all line endings are Unix style (LF)"
           fi
 
   check-ascii-markdown:
@@ -72,14 +77,14 @@ jobs:
             --exclude-dir=.git \
             . 2>/dev/null || true)
           if [ -n "$BAD_FILES" ]; then
-            echo "ERROR: Found markdown files containing non-ASCII Unicode punctuation:"
+            echo "❌ Found markdown files containing non-ASCII Unicode punctuation:"
             echo "$BAD_FILES"
             echo ""
             echo "Prohibited characters: em dash (--), en dash (-), smart quotes, ellipsis, non-breaking space"
             echo "Replace with ASCII equivalents: -- for em/en dash, ... for ellipsis, plain quotes"
             exit 1
           else
-            echo "PASS: All markdown files use ASCII-only punctuation"
+            echo "✅ All markdown files use ASCII-only punctuation"
           fi
 
   check-ai-elisions:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -31,7 +31,7 @@ jobs:
 
           # Check for issue reference (#number)
           if ! echo "$PR_TITLE" | grep -qE '\(#[0-9]+\)$'; then
-            echo "ERROR: PR title must end with issue reference '(#<number>)'"
+            echo "❌ PR title must end with issue reference '(#<number>)'"
             echo "Expected format: '<description> (#<number>)'"
             echo "Current title: $PR_TITLE"
             exit 1
@@ -39,12 +39,12 @@ jobs:
 
           # Check for colons in title (not allowed)
           if echo "$PR_TITLE" | grep -qE '^[^:]+:'; then
-            echo "ERROR: PR title should not contain colons before the issue reference"
+            echo "❌ PR title should not contain colons before the issue reference"
             echo "Expected format: '<description> (#<number>)' (NO colons)"
             exit 1
           fi
 
-          echo "PR title format is valid"
+          echo "✅ PR title format is valid"
 
   validate-pr-assignee:
     name: Validate PR Assignee
@@ -64,12 +64,12 @@ jobs:
           count=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.assignees | length')
 
           if [[ "$count" -gt 0 ]]; then
-            echo "PR has $count assignee(s):"
+            echo "✅ PR has $count assignee(s):"
             gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.assignees[].login'
             exit 0
           fi
 
-          echo "ERROR: PR must have at least one assignee"
+          echo "❌ PR must have at least one assignee"
           exit 1
 
   validate-pr-labels:
@@ -90,11 +90,11 @@ jobs:
           labels=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.labels[].name')
 
           if echo "$labels" | grep -q "component:"; then
-            echo "PR has component label: $(echo "$labels" | grep "component:" | head -1)"
+            echo "✅ PR has component label: $(echo "$labels" | grep "component:" | head -1)"
             exit 0
           fi
 
-          echo "ERROR: PR must have at least one component label (component:*)"
+          echo "❌ PR must have at least one component label (component:*)"
           echo "Available component labels: component:cli, component:infrastructure, component:runtime-core, etc."
           exit 1
 

--- a/lib/core/color.sh
+++ b/lib/core/color.sh
@@ -21,6 +21,7 @@ ICON_SUCCESS="✅"
 ICON_ERROR="❌"
 ICON_WARNING="⚠️"
 ICON_INFO="ℹ️"
+ICON_SKIP="○"
 
 # Print colored success message
 print_success() {
@@ -40,4 +41,9 @@ print_warning() {
 # Print colored info message
 print_info() {
     echo -e "${BLUE}${ICON_INFO}${NC} $1"
+}
+
+# Print skip message (check not applicable or not run)
+print_skip() {
+    echo -e "${YELLOW}${ICON_SKIP}${NC} $1"
 }

--- a/scripts/checks/check-agents.sh
+++ b/scripts/checks/check-agents.sh
@@ -10,24 +10,21 @@ cd "$REPO_ROOT"
 ERRORS=0
 WARNINGS=0
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
 
 error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
+    echo -e "${RED}${ICON_ERROR:-❌}${NC} $1" >&2
     ERRORS=$((ERRORS + 1))
 }
 
 warn() {
-    echo -e "${YELLOW}WARN:${NC} $1" >&2
+    echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} $1" >&2
     WARNINGS=$((WARNINGS + 1))
 }
 
 info() {
-    echo -e "${GREEN}INFO:${NC} $1"
+    print_info "$1"
 }
 
 # Check agent files
@@ -95,7 +92,7 @@ check_skills() {
     while IFS= read -r -d '' file; do
         skill_files+=("$file")
     done < <(find "$skills_dir" -name "SKILL.md" -type f -print0 2>/dev/null || true)
-    
+
     if [[ ${#skill_files[@]} -eq 0 ]]; then
         return 0
     fi

--- a/scripts/checks/check-ai-elisions.sh
+++ b/scripts/checks/check-ai-elisions.sh
@@ -28,23 +28,20 @@ cd "$REPO_ROOT"
 
 ERRORS=0
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
 
 error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
+    echo -e "${RED}${ICON_ERROR:-❌}${NC} $1" >&2
     ((ERRORS++)) || true
 }
 
 warn() {
-    echo -e "${YELLOW}WARN:${NC} $1" >&2
+    echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} $1" >&2
 }
 
 info() {
-    echo -e "${GREEN}INFO:${NC} $1"
+    print_info "$1"
 }
 
 # Placeholder phrases AI tools emit instead of preserved content.
@@ -174,7 +171,7 @@ check_mass_deletions() {
     info "Checking modified files for suspicious mass deletions..."
 
     if [ "${AIXCL_ALLOW_MASS_DELETE:-}" = "1" ]; then
-        warn "Mass-deletion check skipped (AIXCL_ALLOW_MASS_DELETE=1)"
+        print_skip "Mass-deletion check skipped (AIXCL_ALLOW_MASS_DELETE=1)"
         return 0
     fi
 

--- a/scripts/checks/check-environment.sh
+++ b/scripts/checks/check-environment.sh
@@ -13,29 +13,25 @@ ERRORS=0
 WARNINGS=0
 CHECKS_PASSED=0
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
 
 error() {
-    echo -e "${RED}✗${NC} $1" >&2
+    echo -e "${RED}${ICON_ERROR:-❌}${NC} $1" >&2
     ((ERRORS++))
 }
 
 warn() {
-    echo -e "${YELLOW}⚠${NC} $1" >&2
+    echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} $1" >&2
     ((WARNINGS++))
 }
 
 info() {
-    echo -e "${BLUE}ℹ${NC} $1"
+    print_info "$1"
 }
 
 pass() {
-    echo -e "${GREEN}✓${NC} $1"
+    echo -e "${GREEN}${ICON_SUCCESS:-✅}${NC} $1"
     ((CHECKS_PASSED++))
 }
 
@@ -43,7 +39,7 @@ pass() {
 check_command() {
     local cmd=$1
     local required=${2:-true}
-    
+
     if command -v "$cmd" &> /dev/null; then
         local version
         version=$($cmd --version 2>/dev/null | head -1 || echo "version unknown")
@@ -62,19 +58,19 @@ check_command() {
 # Check Git configuration
 check_git_config() {
     info "Checking Git configuration..."
-    
+
     local git_user_name
     local git_user_email
-    
+
     git_user_name=$(git config user.name 2>/dev/null || echo "")
     git_user_email=$(git config user.email 2>/dev/null || echo "")
-    
+
     if [ -n "$git_user_name" ]; then
         pass "Git user.name configured: $git_user_name"
     else
         error "Git user.name not configured. Run: git config --global user.name 'Your Name'"
     fi
-    
+
     if [ -n "$git_user_email" ]; then
         pass "Git user.email configured: $git_user_email"
     else
@@ -85,13 +81,13 @@ check_git_config() {
 # Check GitHub CLI
 check_github_cli() {
     info "Checking GitHub CLI..."
-    
+
     if ! check_command "gh"; then
         error "GitHub CLI (gh) is required for Issue-First workflow"
         info "Install from: https://cli.github.com/"
         return
     fi
-    
+
     # Check authentication
     if gh auth status &>/dev/null; then
         local username
@@ -105,10 +101,10 @@ check_github_cli() {
 # Check Git remotes
 check_git_remotes() {
     info "Checking Git remotes..."
-    
+
     local remotes
     remotes=$(git remote 2>/dev/null || echo "")
-    
+
     if [ -n "$remotes" ]; then
         pass "Git remotes configured:"
         git remote -v | while read -r line; do
@@ -122,24 +118,24 @@ check_git_remotes() {
 # Check OpenCode configuration
 check_opencode_config() {
     info "Checking OpenCode configuration..."
-    
+
     if [ -f "opencode.json" ]; then
         pass "opencode.json exists"
-        
+
         # Validate JSON
         if python3 -m json.tool opencode.json > /dev/null 2>&1; then
             pass "opencode.json is valid JSON"
         else
             error "opencode.json contains invalid JSON"
         fi
-        
+
         # Check for required fields
         if grep -q '"default_agent"' opencode.json; then
             pass "default_agent configured"
         else
             warn "default_agent not configured in opencode.json"
         fi
-        
+
         if grep -q '"instructions"' opencode.json; then
             pass "instructions array configured"
         else
@@ -153,11 +149,11 @@ check_opencode_config() {
 # Check OpenCode directory structure
 check_opencode_structure() {
     info "Checking OpenCode directory structure..."
-    
+
     local dirs=(
         ".opencode/agents"
     )
-    
+
     for dir in "${dirs[@]}"; do
         if [ -d "$dir" ]; then
             local count
@@ -172,14 +168,14 @@ check_opencode_structure() {
 # Check AI directory structure
 check_ai_structure() {
     info "Checking AI directory structure..."
-    
+
     local required_dirs=(
         "ai/actions"
         "ai/governance"
         "ai/orchestration"
         "ai/templates"
     )
-    
+
     for dir in "${required_dirs[@]}"; do
         if [ -d "$dir" ]; then
             pass "$dir exists"
@@ -187,7 +183,7 @@ check_ai_structure() {
             error "$dir directory missing"
         fi
     done
-    
+
     # Check for actions
     local action_count
     action_count=$(find "ai/actions" -name "action-*.md" 2>/dev/null | wc -l)
@@ -201,9 +197,9 @@ check_ai_structure() {
 # Check validation scripts
 check_validation_scripts() {
     info "Checking validation scripts..."
-    
+
     local script="scripts/checks/check-agents.sh"
-    
+
     if [ -f "$script" ]; then
         if [ -x "$script" ]; then
             pass "$script exists and is executable"
@@ -219,11 +215,11 @@ check_validation_scripts() {
 # Check permissions
 check_permissions() {
     info "Checking file permissions..."
-    
+
     # Check if any scripts in scripts/ are not executable
     local non_executable
     non_executable=$(find scripts/ -name "*.sh" -type f ! -perm -111 2>/dev/null || true)
-    
+
     if [ -n "$non_executable" ]; then
         warn "Some shell scripts are not executable:"
         echo "$non_executable" | while read -r file; do
@@ -237,7 +233,7 @@ check_permissions() {
 # Run agent validation
 check_agent_validation() {
     info "Running agent validation..."
-    
+
     if [ -f "scripts/checks/check-agents.sh" ]; then
         if scripts/checks/check-agents.sh > /dev/null 2>&1; then
             pass "Agent validation passed"
@@ -252,12 +248,12 @@ check_agent_validation() {
 # Check for Docker (optional)
 check_docker() {
     info "Checking Docker (optional)..."
-    
+
     if command -v docker &> /dev/null; then
         local version
         version=$(docker --version 2>/dev/null | head -1 || echo "installed")
         pass "Docker installed ($version)"
-        
+
         # Check if Docker daemon is running
         if docker info > /dev/null 2>&1; then
             pass "Docker daemon is running"
@@ -362,56 +358,56 @@ main() {
     echo "  AIXCL Environment Validation"
     echo "═══════════════════════════════════════════════════════════════"
     echo ""
-    
+
     # Required checks
     check_command "git"
     check_git_config
     check_github_cli
     check_git_remotes
-    
+
     echo ""
-    
+
     # Configuration checks
     check_opencode_config
     check_opencode_structure
     check_ai_structure
-    
+
     echo ""
-    
+
     # Validation checks
     check_validation_scripts
     check_agent_validation
     check_permissions
-    
+
     echo ""
-    
+
     # Optional checks
     check_docker
     check_shellcheck
     check_pre_commit
     check_gitleaks
     check_git_cliff
-    
+
     echo ""
     echo "═══════════════════════════════════════════════════════════════"
     echo "  Summary"
     echo "═══════════════════════════════════════════════════════════════"
-    
+
     if [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
-        echo -e "${GREEN}✓ All checks passed!${NC}"
+        echo -e "${GREEN}${ICON_SUCCESS:-✅}${NC} All checks passed!"
         echo ""
         echo "Your environment is ready for AIXCL development."
         echo "Start OpenCode and use /workflow to run the Issue-First workflow."
         exit 0
     elif [ $ERRORS -eq 0 ]; then
-        echo -e "${YELLOW}✓ Checks passed with warnings${NC}"
+        echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} Checks passed with warnings"
         echo ""
         echo "Warnings: $WARNINGS"
         echo ""
         echo "Your environment should work but consider addressing the warnings."
         exit 0
     else
-        echo -e "${RED}✗ Environment validation failed${NC}"
+        echo -e "${RED}${ICON_ERROR:-❌}${NC} Environment validation failed"
         echo ""
         echo "Errors: $ERRORS"
         echo "Warnings: $WARNINGS"

--- a/scripts/checks/check-generated-files.sh
+++ b/scripts/checks/check-generated-files.sh
@@ -9,33 +9,30 @@ cd "$REPO_ROOT"
 
 ERRORS=0
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
 
 error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
+    echo -e "${RED}${ICON_ERROR:-❌}${NC} $1" >&2
     ((ERRORS++)) || true
 }
 
 warn() {
-    echo -e "${YELLOW}WARN:${NC} $1" >&2
+    echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} $1" >&2
 }
 
 info() {
-    echo -e "${GREEN}INFO:${NC} $1"
+    print_info "$1"
 }
 
 # Check for files matching .gitignore patterns that are committed
 check_gitignore_violations() {
     info "Checking for files matching .gitignore patterns..."
-    
+
     # Get list of tracked files that match .gitignore patterns
     local tracked_ignored
     tracked_ignored=$(git ls-files --ignored --exclude-standard 2>/dev/null || true)
-    
+
     if [[ -n "$tracked_ignored" ]]; then
         error "Found tracked files that should be ignored:"
         echo "$tracked_ignored" | while read -r file; do
@@ -49,7 +46,7 @@ check_gitignore_violations() {
 # Check for test backup directories
 check_test_backups() {
     info "Checking for test backup directories..."
-    
+
     if [[ -d "tests/.backup" ]]; then
         local backup_count
         backup_count=$(find tests/.backup -type d -name "test-*" 2>/dev/null | wc -l)
@@ -67,14 +64,14 @@ check_test_backups() {
 # Check for generated test result files
 check_test_results() {
     info "Checking for generated test result files..."
-    
+
     local result_patterns=(
         "tests/test-results.md"
         "tests/*-results.md"
         "tests/*.backup"
         "tests/.backup/*"
     )
-    
+
     # shellcheck disable=SC2206
     for pattern in "${result_patterns[@]}"; do
         # Use glob expansion instead of ls | grep (SC2010)
@@ -94,10 +91,10 @@ check_test_results() {
 # Check for dated operations reports (older than 30 days) - DELETE not archive
 check_dated_reports() {
     info "Checking for dated operations reports (lean repository policy)..."
-    
+
     local old_reports
     old_reports=$(find docs/operations -name "*-20[0-9][0-9]-[0-9][0-9]-[0-9][0-9].md" -type f -mtime +30 2>/dev/null || true)
-    
+
     if [[ -n "$old_reports" ]]; then
         error "Found dated reports (lean repository policy: DELETE, do not archive):"
         echo "$old_reports" | while read -r file; do
@@ -112,12 +109,12 @@ check_dated_reports() {
 # Check for engine test result files
 check_engine_test_results() {
     info "Checking for engine test result files..."
-    
+
     local engine_files=(
         "ENGINE_TEST_RESULTS.md"
         "ENGINE_TEST_PLAN.md"
     )
-    
+
     for file in "${engine_files[@]}"; do
         if [[ -f "$file" ]]; then
             # Check if it's older than 30 days
@@ -131,7 +128,7 @@ check_engine_test_results() {
 # Check for pgadmin-data directory (should be gitignored)
 check_pgadmin_data() {
     info "Checking for pgadmin-data directory..."
-    
+
     if [[ -d "pgadmin-data" ]] && git ls-files pgadmin-data 2>/dev/null | grep -q .; then
         error "Found tracked pgadmin-data directory (should be in .gitignore)"
     fi
@@ -140,7 +137,7 @@ check_pgadmin_data() {
 # Check for log files
 check_log_files() {
     info "Checking for log files..."
-    
+
     # Use glob expansion instead of ls | grep
     local log_files=(logs/*.log)
     if [[ -e "${log_files[0]}" ]]; then
@@ -158,7 +155,7 @@ main() {
     echo "Generated Files Check"
     echo "========================================"
     echo ""
-    
+
     check_gitignore_violations
     check_test_backups
     check_test_results
@@ -166,7 +163,7 @@ main() {
     check_engine_test_results
     check_pgadmin_data
     check_log_files
-    
+
     echo ""
     echo "========================================"
     if [[ $ERRORS -eq 0 ]]; then

--- a/scripts/checks/check-paths.sh
+++ b/scripts/checks/check-paths.sh
@@ -10,44 +10,41 @@ cd "$REPO_ROOT"
 ERRORS=0
 WARNINGS=0
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
 
 error() {
-    echo -e "${RED}ERROR:${NC} $1" >&2
+    echo -e "${RED}${ICON_ERROR:-❌}${NC} $1" >&2
     ((ERRORS++)) || true
 }
 
 warn() {
-    echo -e "${YELLOW}WARN:${NC} $1" >&2
+    echo -e "${YELLOW}${ICON_WARNING:-⚠️}${NC} $1" >&2
     ((WARNINGS++)) || true
 }
 
 info() {
-    echo -e "${GREEN}INFO:${NC} $1"
+    print_info "$1"
 }
 
 # Check for references to non-existent files in markdown
 check_markdown_paths() {
     info "Checking markdown file references..."
-    
+
     local md_files=()
     while IFS= read -r -d '' file; do
         md_files+=("$file")
     done < <(find . -name "*.md" -type f -not -path "./.git/*" -not -path "./.backup/*" -not -path "./node_modules/*" -not -path "./.opencode/node_modules/*" -print0 2>/dev/null || true)
-    
+
     local checked=0
     local issues=0
-    
+
     for md_file in "${md_files[@]}"; do
         # Extract relative paths from markdown links [text](./path) or [text](../path)
         # Using simpler grep pattern and processing
         local links
         links=$(grep -oE '\]\([^)]+\)' "$md_file" 2>/dev/null | tr -d ']()' || true)
-        
+
         for link in $links; do
             # Skip external URLs and anchors
             [[ "$link" =~ ^https?:// ]] && continue
@@ -57,42 +54,42 @@ check_markdown_paths() {
             # Skip template placeholder paths (release notes, templates)
             [[ "$link" =~ vPREVIOUS\.\.\.vX\.Y\.Z ]] && continue
             [[ "$link" =~ \.\.\./\.\./compare/ ]] && continue
-            
+
             # Remove anchor fragments
             local path="${link%%#*}"
-            
+
             # Only check relative paths starting with ./ or ../
             [[ ! "$path" =~ ^\./ ]] && [[ ! "$path" =~ ^\.\./ ]] && continue
-            
+
             # Resolve relative path
             local dir
             dir=$(dirname "$md_file")
             local full_path
             full_path="$dir/$path"
-            
+
             ((checked++)) || true
-            
+
             if [[ ! -e "$full_path" ]]; then
                 error "In $md_file: Referenced path does not exist: $path"
                 ((issues++)) || true
             fi
         done
     done
-    
+
     info "Checked $checked markdown references, found $issues issues"
 }
 
 # Check for common stale path patterns
 check_common_stale_paths() {
     info "Checking for common stale path patterns..."
-    
+
     local stale_patterns=(
         "scripts/check-agents.sh"  # Should be scripts/checks/check-agents.sh
         "ai/skills/"               # Directory does not exist
         "ai/orchestration/registry.yaml"  # File does not exist
         "opencode/cli-ollama.yaml"        # Path changed
     )
-    
+
     for pattern in "${stale_patterns[@]}"; do
         if grep -r "$pattern" --include="*.md" --include="*.yml" --include="*.yaml" --include="*.json" . 2>/dev/null | grep -v ".git/" | head -1 >/dev/null; then
             warn "Found potential stale reference: $pattern"
@@ -104,11 +101,11 @@ check_common_stale_paths() {
 # Check for hardcoded usernames that should be placeholders
 check_hardcoded_usernames() {
     info "Checking for hardcoded usernames..."
-    
+
     local username_pattern="sbadakhc"
     local occurrences
     occurrences=$(grep -rn "$username_pattern" --include="*.md" . 2>/dev/null | grep -v ".git/" | grep -v "CODEOWNERS" || true)
-    
+
     if [[ -n "$occurrences" ]]; then
         warn "Found hardcoded username (should use <assignee> placeholder):"
         echo "$occurrences" | head -5
@@ -118,12 +115,12 @@ check_hardcoded_usernames() {
 # Check for non-existent directories referenced in docs (that SHOULD exist)
 check_directory_references() {
     info "Checking directory references..."
-    
+
     # Only check directories that SHOULD exist (not optional ones like ai/skills)
     local dirs_to_check=(
         ".opencode/agents"   # Should exist
     )
-    
+
     for dir in "${dirs_to_check[@]}"; do
         if [[ ! -d "$dir" ]]; then
             # Check if referenced in documentation
@@ -132,7 +129,7 @@ check_directory_references() {
             fi
         fi
     done
-    
+
     # ai/skills is optional - check it's documented as such
     if [[ ! -d "ai/skills" ]]; then
         # This is expected - it's documented as optional
@@ -146,12 +143,12 @@ main() {
     echo "Documentation Path Validation"
     echo "========================================"
     echo ""
-    
+
     check_markdown_paths
     check_common_stale_paths
     check_hardcoded_usernames
     check_directory_references
-    
+
     echo ""
     echo "========================================"
     if [[ $ERRORS -eq 0 ]]; then

--- a/scripts/checks/check-pr-references.sh
+++ b/scripts/checks/check-pr-references.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
+
 input_file="${1:-/dev/stdin}"
 
 violations=()
@@ -29,11 +33,11 @@ while IFS= read -r line; do
 done < "$input_file"
 
 if [[ "${#violations[@]}" -eq 0 ]]; then
-    echo "OK: no comma-packed issue references found"
+    print_success "no comma-packed issue references found"
     exit 0
 fi
 
-echo "ERROR: each issue/PR reference must be on its own list item line (no comma, slash, or space-separated bunching)"
+print_error "each issue/PR reference must be on its own list item line (no comma, slash, or space-separated bunching)"
 echo "Found ${#violations[@]} violation(s):"
 for v in "${violations[@]}"; do
     echo "  $v"

--- a/scripts/utils/setup-gpg.sh
+++ b/scripts/utils/setup-gpg.sh
@@ -16,12 +16,9 @@ set -euo pipefail
 # No project-relative paths needed for GPG key operations
 # GPG signing test marker: issue-1046
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../../lib/core/color.sh"
 
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
@@ -234,9 +231,9 @@ verify_setup() {
 
   # Check GPG installed
   if command -v gpg >/dev/null 2>&1; then
-    log_info "[OK] GPG installed"
+    log_info "${ICON_SUCCESS:-✅} GPG installed"
   else
-    log_error "[FAIL] GPG not found"
+    log_error "${ICON_ERROR:-❌} GPG not found"
     all_good=false
   fi
 
@@ -244,9 +241,9 @@ verify_setup() {
   local gpg_keys
   gpg_keys=$(gpg --list-secret-keys --keyid-format LONG 2>/dev/null) || true
   if echo "$gpg_keys" | grep -q "^sec"; then
-    log_info "[OK] GPG private key exists"
+    log_info "${ICON_SUCCESS:-✅} GPG private key exists"
   else
-    log_error "[FAIL] No GPG private key found"
+    log_error "${ICON_ERROR:-❌} No GPG private key found"
     all_good=false
   fi
 
@@ -254,17 +251,17 @@ verify_setup() {
   local signing_key
   signing_key=$(git config --global user.signingkey 2>/dev/null || true)
   if [[ -n "$signing_key" ]]; then
-    log_info "[OK] Git signing key configured: $signing_key"
+    log_info "${ICON_SUCCESS:-✅} Git signing key configured: $signing_key"
   else
-    log_error "[FAIL] Git signing key not configured"
+    log_error "${ICON_ERROR:-❌} Git signing key not configured"
     all_good=false
   fi
 
   # Check auto-sign enabled
   if [[ "$(git config --global commit.gpgsign 2>/dev/null)" == "true" ]]; then
-    log_info "[OK] Git auto-sign enabled"
+    log_info "${ICON_SUCCESS:-✅} Git auto-sign enabled"
   else
-    log_warn "[WARN] Git auto-sign not enabled (run: git config --global commit.gpgsign true)"
+    log_warn "${ICON_WARNING:-⚠️} Git auto-sign not enabled (run: git config --global commit.gpgsign true)"
   fi
 
   # Test signing
@@ -274,10 +271,10 @@ verify_setup() {
   echo "test" > "$test_file"
 
   if gpg --detach-sign --armor "$test_file" 2>/dev/null; then
-    log_info "[OK] GPG signing works"
+    log_info "${ICON_SUCCESS:-✅} GPG signing works"
     rm -f "$test_file" "$test_file.asc"
   else
-    log_error "[FAIL] GPG signing test failed"
+    log_error "${ICON_ERROR:-❌} GPG signing test failed"
     rm -f "$test_file"
     all_good=false
   fi

--- a/scripts/utils/setup-podman-rootless.sh
+++ b/scripts/utils/setup-podman-rootless.sh
@@ -17,12 +17,8 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 USER_NAME="$(whoami)"
 USER_ID="$(id -u)"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+# shellcheck disable=SC1091
+source "${PROJECT_ROOT}/lib/core/color.sh"
 
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
@@ -41,7 +37,7 @@ check_not_root() {
 # Check prerequisites
 check_prerequisites() {
   log_step "Checking prerequisites..."
-  
+
   # Check Podman installed
   if ! command -v podman >/dev/null 2>&1; then
     log_error "Podman is not installed"
@@ -51,49 +47,49 @@ check_prerequisites() {
     log_info "  Arch: sudo pacman -S podman"
     exit 1
   fi
-  
+
   # Check podman-compose
   if ! command -v podman-compose >/dev/null 2>&1; then
     log_error "podman-compose is not installed"
     log_info "Install: pip3 install podman-compose"
     exit 1
   fi
-  
+
   # Check newuidmap/newgidmap for rootless
   if ! command -v newuidmap >/dev/null 2>&1; then
     log_error "newuidmap not found (required for rootless)"
     log_info "Install: sudo dnf install shadow-utils"
     exit 1
   fi
-  
+
   log_info "Prerequisites satisfied"
 }
 
 # Configure subordinate UIDs/GIDs
 setup_subuids() {
   log_step "Configuring subordinate UIDs/GIDs..."
-  
+
   # Check if already configured
   if grep -q "^${USER_NAME}:" /etc/subuid 2>/dev/null && \
      grep -q "^${USER_NAME}:" /etc/subgid 2>/dev/null; then
     log_info "Subordinate UIDs/GIDs already configured"
     return 0
   fi
-  
+
   log_warn "Requires sudo to configure subordinate UIDs/GIDs"
-  
+
   # Add subordinate UIDs (100000-165535)
   if ! grep -q "^${USER_NAME}:" /etc/subuid 2>/dev/null; then
     echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subuid >/dev/null
     log_info "Added subordinate UIDs to /etc/subuid"
   fi
-  
+
   # Add subordinate GIDs (100000-165535)
   if ! grep -q "^${USER_NAME}:" /etc/subgid 2>/dev/null; then
     echo "${USER_NAME}:100000:65536" | sudo tee -a /etc/subgid >/dev/null
     log_info "Added subordinate GIDs to /etc/subgid"
   fi
-  
+
   # Verify sysctl settings
   if [[ -f /proc/sys/kernel/unprivileged_userns_clone ]]; then
     local current_val
@@ -104,71 +100,71 @@ setup_subuids() {
       log_info "To enable (permanent): echo 'kernel.unprivileged_userns_clone=1' | sudo tee /etc/sysctl.d/99-userns.conf"
     fi
   fi
-  
+
   log_info "Subordinate UID/GID configuration complete"
 }
 
 # Initialize rootless Podman
 init_rootless() {
   log_step "Initializing rootless Podman..."
-  
+
   # Initialize podman for user
   if ! podman info >/dev/null 2>&1; then
     log_info "Initializing podman storage..."
     podman system migrate || true
   fi
-  
+
   # Check rootless configuration
   local rootless
   rootless="$(podman info --format '{{.Host.ServiceIsRootless}}' 2>/dev/null || echo 'unknown')"
-  
+
   if [[ "$rootless" == "true" ]]; then
     log_info "Rootless mode confirmed"
   else
     log_warn "Rootless mode status: $rootless"
     log_info "Continuing with current configuration"
   fi
-  
+
   log_info "Podman initialized"
 }
 
 # Setup Podman socket for Docker compatibility
 setup_podman_socket() {
   log_step "Setting up Podman socket..."
-  
+
   # Create systemd user directory
   mkdir -p "${HOME}/.config/systemd/user"
-  
+
   # Check if socket is already running
   local socket_path
   socket_path="${XDG_RUNTIME_DIR:-/run/user/${USER_ID}}/podman/podman.sock"
-  
+
   if [[ -S "$socket_path" ]]; then
     log_info "Podman socket already running: $socket_path"
   else
     log_info "Starting Podman socket..."
-    
+
     # Enable and start podman socket
     systemctl --user enable podman.socket 2>/dev/null || true
     systemctl --user start podman.socket 2>/dev/null || {
       log_warn "Could not start podman.socket via systemd"
       log_info "Manual socket start: podman system service --time=0 unix://$socket_path &"
     }
-    
+
     # Wait for socket
     local count=0
     while [[ ! -S "$socket_path" ]] && [[ $count -lt 10 ]]; do
       sleep 1
       count=$((count + 1))
     done
-    
+
     if [[ -S "$socket_path" ]]; then
       log_info "Podman socket ready: $socket_path"
     else
       log_warn "Socket may not be available yet"
     fi
   fi
-  
+
   # Export for Docker compatibility
   export DOCKER_HOST="unix://$socket_path"
   cat > "${PROJECT_ROOT}/.env.podman" << 'ENVEOF'
@@ -186,14 +182,14 @@ ENVEOF
 # Configure volume permissions for rootless
 setup_volume_permissions() {
   log_step "Configuring volume permissions..."
-  
+
   # Create required directories with proper permissions
   local dirs=(
     "${PROJECT_ROOT}/logs"
     "${PROJECT_ROOT}/.security"
     "${PROJECT_ROOT}/.audit"
   )
-  
+
   for dir in "${dirs[@]}"; do
     if [[ ! -d "$dir" ]]; then
       mkdir -p "$dir"
@@ -206,11 +202,11 @@ setup_volume_permissions() {
       chmod u+rwx "$dir"
     fi
   done
-  
+
   # Setup Podman volumes (rootless)
   log_info "Initializing Podman volumes..."
   "${PROJECT_ROOT}/scripts/utils/init-volumes.sh"
-  
+
   log_info "Volume permissions configured"
 }
 
@@ -232,7 +228,7 @@ setup_nvidia_cdi() {
   local cdi_count
   cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
   if [[ "$cdi_count" -gt 0 ]]; then
-    log_info "[OK] NVIDIA CDI already configured ($cdi_count devices)"
+    log_info "${ICON_SUCCESS:-✅} NVIDIA CDI already configured ($cdi_count devices)"
     return 0
   fi
 
@@ -240,12 +236,12 @@ setup_nvidia_cdi() {
 
   # Try system-level CDI spec first, fall back to user-level
   if sudo mkdir -p /etc/cdi && sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>/dev/null; then
-    log_info "[OK] NVIDIA CDI spec written to /etc/cdi/nvidia.yaml"
+    log_info "${ICON_SUCCESS:-✅} NVIDIA CDI spec written to /etc/cdi/nvidia.yaml"
   else
     log_warn "Could not write system CDI spec — trying user-level"
     mkdir -p "${HOME}/.config/cdi"
     if nvidia-ctk cdi generate --output="${HOME}/.config/cdi/nvidia.yaml" 2>/dev/null; then
-      log_info "[OK] NVIDIA CDI spec written to ${HOME}/.config/cdi/nvidia.yaml"
+      log_info "${ICON_SUCCESS:-✅} NVIDIA CDI spec written to ${HOME}/.config/cdi/nvidia.yaml"
     else
       log_error "Failed to generate NVIDIA CDI spec"
       log_info "Run manually: sudo mkdir -p /etc/cdi && sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
@@ -257,7 +253,7 @@ setup_nvidia_cdi() {
   local device_count
   device_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
   if [[ "$device_count" -gt 0 ]]; then
-    log_info "[OK] NVIDIA CDI devices available: $device_count"
+    log_info "${ICON_SUCCESS:-✅} NVIDIA CDI devices available: $device_count"
   else
     log_warn "CDI spec written but no devices visible yet — a re-login may be required"
   fi
@@ -266,10 +262,10 @@ setup_nvidia_cdi() {
 # Create Podman-specific configuration
 create_podman_config() {
   log_step "Creating Podman configuration..."
-  
+
   # Create containers.conf for rootless optimizations
   mkdir -p "${HOME}/.config/containers"
-  
+
   # Auto-detect OCI runtime: prefer crun for rootless, fall back to runc
   local detected_runtime="runc"
   if command -v crun >/dev/null 2>&1; then
@@ -281,7 +277,7 @@ create_podman_config() {
   else
     log_warn "No OCI runtime found (crun or runc). Podman may fail to start containers."
   fi
-  
+
   cat > "${HOME}/.config/containers/containers.conf" << EOF
 # AIXCL Podman Configuration
 # Rootless container optimizations for adversarial environments
@@ -314,9 +310,9 @@ default_network="host"
 # Pull policy for AIXCL images (match Docker behavior)
 pull_policy="if_not_present"
 EOF
-  
+
   log_info "Podman configuration created: ${HOME}/.config/containers/containers.conf"
-  
+
   # Create registries.conf for Docker Hub compatibility
   if [[ ! -f "${HOME}/.config/containers/registries.conf" ]]; then
     cat > "${HOME}/.config/containers/registries.conf" << 'EOF'
@@ -334,7 +330,7 @@ registries = []
 EOF
     log_info "Registries configuration created"
   fi
-  
+
   # Create storage.conf for rootless optimizations
   cat > "${HOME}/.config/containers/storage.conf" << EOF
 # AIXCL Rootless Storage Configuration
@@ -350,73 +346,73 @@ mount_program = "/usr/bin/fuse-overlayfs"
 [storage.options.overlay]
 mountopt = "nodev,metacopy=on"
 EOF
-  
+
   log_info "Storage configuration created"
 }
 
 # Verify rootless setup
 verify_setup() {
   log_step "Verifying rootless Podman setup..."
-  
+
   local all_good=true
-  
+
   # Check Podman version
   if command -v podman >/dev/null 2>&1; then
     local version
     version="$(podman --version | head -1)"
-    log_info "[OK] Podman installed: $version"
+    log_info "${ICON_SUCCESS:-✅} Podman installed: $version"
   else
-    log_error "[FAIL] Podman not found"
+    log_error "${ICON_ERROR:-❌} Podman not found"
     all_good=false
   fi
-  
+
   # Check podman-compose
   if command -v podman-compose >/dev/null 2>&1; then
-    log_info "[OK] podman-compose installed"
+    log_info "${ICON_SUCCESS:-✅} podman-compose installed"
   else
-    log_error "[FAIL] podman-compose not found"
+    log_error "${ICON_ERROR:-❌} podman-compose not found"
     all_good=false
   fi
-  
+
   # Check subordinate UIDs
   if grep -q "^${USER_NAME}:" /etc/subuid 2>/dev/null; then
-    log_info "[OK] Subordinate UIDs configured"
+    log_info "${ICON_SUCCESS:-✅} Subordinate UIDs configured"
   else
-    log_error "[FAIL] Subordinate UIDs not configured"
+    log_error "${ICON_ERROR:-❌} Subordinate UIDs not configured"
     all_good=false
   fi
-  
+
   # Check subordinate GIDs
   if grep -q "^${USER_NAME}:" /etc/subgid 2>/dev/null; then
-    log_info "[OK] Subordinate GIDs configured"
+    log_info "${ICON_SUCCESS:-✅} Subordinate GIDs configured"
   else
-    log_error "[FAIL] Subordinate GIDs not configured"
+    log_error "${ICON_ERROR:-❌} Subordinate GIDs not configured"
     all_good=false
   fi
-  
+
   # Check rootless status
   local rootless
   rootless="$(podman info --format '{{.Host.ServiceIsRootless}}' 2>/dev/null || echo 'unknown')"
   if [[ "$rootless" == "true" ]]; then
-    log_info "[OK] Running in rootless mode"
+    log_info "${ICON_SUCCESS:-✅} Running in rootless mode"
   else
-    log_warn "[WARN] Rootless mode: $rootless"
+    log_warn "${ICON_WARNING:-⚠️} Rootless mode: $rootless"
   fi
-  
+
   # Check socket
   local socket_path
   socket_path="${XDG_RUNTIME_DIR:-/run/user/${USER_ID}}/podman/podman.sock"
   if [[ -S "$socket_path" ]]; then
-    log_info "[OK] Podman socket available: $socket_path"
+    log_info "${ICON_SUCCESS:-✅} Podman socket available: $socket_path"
   else
-    log_warn "[WARN] Podman socket not found"
+    log_warn "${ICON_WARNING:-⚠️} Podman socket not found"
   fi
-  
+
   # Test basic container operation
   if podman run --rm alpine:latest echo "test" >/dev/null 2>&1; then
-    log_info "[OK] Test container ran successfully"
+    log_info "${ICON_SUCCESS:-✅} Test container ran successfully"
   else
-    log_error "[FAIL] Test container failed"
+    log_error "${ICON_ERROR:-❌} Test container failed"
     all_good=false
   fi
 
@@ -425,13 +421,13 @@ verify_setup() {
     local cdi_count
     cdi_count=$(nvidia-ctk cdi list 2>/dev/null | grep -c 'nvidia.com' || echo 0)
     if [[ "$cdi_count" -gt 0 ]]; then
-      log_info "[OK] NVIDIA CDI configured ($cdi_count devices)"
+      log_info "${ICON_SUCCESS:-✅} NVIDIA CDI configured ($cdi_count devices)"
     else
-      log_warn "[WARN] NVIDIA GPU detected but CDI not configured — GPU unavailable in containers"
+      log_warn "${ICON_WARNING:-⚠️} NVIDIA GPU detected but CDI not configured — GPU unavailable in containers"
       log_info "       Run: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
     fi
   fi
-  
+
   if $all_good; then
     log_info ""
     log_info "=== Rootless Podman Setup Complete ==="
@@ -459,23 +455,23 @@ reset_rootless() {
     log_info "Aborted"
     exit 0
   fi
-  
+
   log_step "Resetting Podman..."
-  
+
   # Stop all containers
   podman stop -a 2>/dev/null || true
   podman rm -af 2>/dev/null || true
-  
+
   # Remove images
   podman rmi -af 2>/dev/null || true
-  
+
   # Reset storage
   podman system reset -f
-  
+
   # Remove configuration
   rm -rf "${HOME}/.config/containers"
   rm -f "${PROJECT_ROOT}/.env.podman"
-  
+
   log_info "Podman reset complete. Run setup again to reconfigure."
 }
 


### PR DESCRIPTION
## Summary

Fixes #1581

### Description of Changes

All check scripts and setup utilities now source `lib/core/color.sh` and use the canonical `ICON_SUCCESS`/`ICON_ERROR`/`ICON_WARNING`/`ICON_INFO`/`ICON_SKIP` variables, giving passes, failures, warnings, and skips the same Unicode icons as `stack status` and `utils check-env`.

Also aligns inline bash in `bash-ci.yml` and `pr-validation.yml` with the same icon set so CI log output is consistent with local CLI output.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-1581/align-cli-output-icons`)
- [x] Commit messages follow conventional style
- [x] shellcheck passes on all modified shell scripts
- [x] yamllint passes on all modified YAML files
- [x] `check-ai-elisions.sh --staged` ran clean before each commit

### Files Changed

- `lib/core/color.sh`: add `ICON_SKIP` and `print_skip()`
- `scripts/checks/check-agents.sh`: source color.sh, icon-based error/warn/info
- `scripts/checks/check-ai-elisions.sh`: source color.sh; mass-delete skip uses `print_skip`
- `scripts/checks/check-environment.sh`: source color.sh, icon-based pass/error/warn/info and summary
- `scripts/checks/check-generated-files.sh`: source color.sh, icon-based error/warn/info
- `scripts/checks/check-paths.sh`: source color.sh, icon-based error/warn/info
- `scripts/checks/check-pr-references.sh`: add `REPO_ROOT`, source color.sh, use `print_success`/`print_error`
- `scripts/utils/setup-gpg.sh`: source color.sh; replace `[OK]`/`[FAIL]`/`[WARN]` with `ICON_*` vars
- `scripts/utils/setup-podman-rootless.sh`: source color.sh; replace `[OK]`/`[FAIL]`/`[WARN]` with `ICON_*` vars
- `.github/workflows/bash-ci.yml`: replace `ERROR:`/`[OK]`/`PASS:` with `❌`/`✅`; fix yamllint line-length violation
- `.github/workflows/pr-validation.yml`: replace `ERROR:` with `❌`, add `✅` to pass cases

### Testing Notes

- Ran `bash scripts/checks/check-agents.sh` locally -- output now shows `ℹ️` icons
- Ran `bash scripts/checks/check-environment.sh` locally -- shows `✅` for passes
- `check-ai-elisions.sh --staged` output itself uses `ℹ️` confirming end-to-end consistency
- `yamllint` clean on both workflow files after line-length fix

### Verification

- [x] Behavior works as expected
- [x] No regressions observed in check script output
- [x] CI passes (bash-ci, pr-validation, security workflows)

### Related Issues

- Fixes #1581

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: code change -- sourced lib/core/color.sh in check scripts and setup utilities; updated YAML inline bash
- Scope: scripts/checks/*.sh, scripts/utils/setup-gpg.sh, scripts/utils/setup-podman-rootless.sh, lib/core/color.sh, .github/workflows/bash-ci.yml, .github/workflows/pr-validation.yml
- Confirmation: yes
---