### PR TITLE
Revert vLLM and llama.cpp to known-good tags (#1622)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -274,7 +274,7 @@ services:
       retries: 3
 
   vllm:
-    image: docker.io/vllm/vllm-openai:v0.24.0
+    image: docker.io/vllm/vllm-openai:v0.22.1
     container_name: vllm
     pull_policy: missing
     tty: true
@@ -308,7 +308,7 @@ services:
       start_period: 180s
 
   llamacpp:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9851
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9585
     container_name: llamacpp
     pull_policy: missing
     user: "1000:1000"


### PR DESCRIPTION
Reverts vLLM and llama.cpp image tags to their last known-good versions.

Both services are demoted and not run under the sys profile. The llama.cpp tag `server-cuda-b9851` does not exist in the ghcr.io registry (manifest unknown), which caused `docker compose pull` to abort and interrupt all other image pulls.

## Changes

- `services/docker-compose.yml`: revert vLLM from `v0.24.0` to `v0.22.1`
- `services/docker-compose.yml`: revert llama.cpp from `server-cuda-b9851` to `server-cuda-b9585`

## Checklist

- [x] llama.cpp tag reverted to a valid registry tag
- [x] vLLM tag reverted to v0.22.1
- [x] `docker compose pull` completes without manifest errors (human verification)

Fixes #1622

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: docker manifest inspect, git diff review
- Scope: services/docker-compose.yml
- Confirmation: yes
---
