### PR TITLE
Update cAdvisor from v0.55.1 to v0.60.3 (#1599)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -489,7 +489,7 @@ services:
       retries: 3
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    image: gcr.io/cadvisor/cadvisor:v0.60.3
     container_name: cadvisor
     pull_policy: missing
     volumes:


### PR DESCRIPTION
Updates cAdvisor from v0.55.1 to v0.60.3 in the operational services stack.

## Changes

- `services/docker-compose.yml`: cadvisor `v0.55.1` -> `v0.60.3`

## Checklist

- [x] Image tag updated in docker-compose.yml
- [x] Change is a single-line version bump, no config changes required
- [x] Stack restarts cleanly with new image (human verification)

Fixes #1599

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: direct file edit, git diff review
- Scope: services/docker-compose.yml
- Confirmation: yes
---
