### PR TITLE
Update pre-commit-hooks from v5.0.0 to v6.0.0 (#1600)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '\.md$'


### PR DESCRIPTION
Updates pre-commit-hooks from v5.0.0 to v6.0.0.

## Changes

- `.pre-commit-config.yaml`: pre-commit-hooks `v5.0.0` -> `v6.0.0`

## Checklist

- [x] Version bumped in .pre-commit-config.yaml
- [x] Pre-commit hooks passed on commit
- [x] CI green (human verification)

Fixes #1600

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: direct file edit, git diff review
- Scope: .pre-commit-config.yaml
- Confirmation: yes
---
