### PR TITLE
Update yamllint from v1.35.1 to v1.38.0 (#1602)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Install yamllint
-        run: pip install yamllint==1.35.1
+        run: pip install yamllint==1.38.0
 
       - name: Validate YAML files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ['--severity=warning', '--exclude=SC1091']
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: ['-c', '.yamllint.yml']


### PR DESCRIPTION
Updates yamllint from v1.35.1 to v1.38.0 in both the pre-commit hook and the CI workflow.

## Changes

- `.pre-commit-config.yaml`: yamllint `v1.35.1` -> `v1.38.0`
- `.github/workflows/documentation-checks.yml`: `pip install yamllint==1.35.1` -> `==1.38.0`

## Checklist

- [x] Version bumped in .pre-commit-config.yaml
- [x] Version bumped in documentation-checks.yml CI workflow
- [x] CI green (human verification)

Fixes #1602

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: direct file edit, git diff review
- Scope: .pre-commit-config.yaml, .github/workflows/documentation-checks.yml
- Confirmation: yes
---
