### PR TITLE
Update gitleaks from v8.21.2 to v8.30.1 (#1603)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 1
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION="8.21.2"
+          GITLEAKS_VERSION="8.30.1"
           curl -sSfL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: ['-c', '.yamllint.yml']
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.30.1
     hooks:
       - id: gitleaks
         args: ['--config', '.gitleaks.toml']


### PR DESCRIPTION
Updates gitleaks from v8.21.2 to v8.30.1 in both the pre-commit hook and the CI workflow.

## Changes

- `.pre-commit-config.yaml`: gitleaks `v8.21.2` -> `v8.30.1`
- `.github/workflows/security.yml`: `GITLEAKS_VERSION="8.21.2"` -> `"8.30.1"`

## Checklist

- [x] Version bumped in .pre-commit-config.yaml
- [x] Version bumped in security.yml CI workflow
- [x] CI green (human verification)

Fixes #1603

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: direct file edit, git diff review
- Scope: .pre-commit-config.yaml, .github/workflows/security.yml
- Confirmation: yes
---
