### PR TITLE
Pin docker/setup-buildx-action to v4.1.0 (#1604)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Create minimal .env for validation
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Validate Compose Files
         run: |


### PR DESCRIPTION
Pins docker/setup-buildx-action to the v4.1.0 SHA in both workflow files. The documentation-checks.yml already had the SHA but the comment said v4; integration-tests.yml was unpinned at @v4.

## Changes

- `.github/workflows/documentation-checks.yml`: update comment `# v4` -> `# v4.1.0`
- `.github/workflows/integration-tests.yml`: `@v4` -> `@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0`

## Checklist

- [x] Both workflow files updated to consistent pinned SHA with v4.1.0 comment
- [x] CI green (human verification)

Fixes #1604

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-06-30
- Method: direct file edit, git diff review
- Scope: .github/workflows/documentation-checks.yml, .github/workflows/integration-tests.yml
- Confirmation: yes
---
