### PR TITLE
Fix agentic orientation gaps -- docs, alerts, Loki tracing, agent ID check (#1630)

### DIFF
--- a/.claude/skills/workflow-guard/SKILL.md
+++ b/.claude/skills/workflow-guard/SKILL.md
@@ -44,6 +44,10 @@ Validates that all actions comply with the Issue-First development workflow befo
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
 - [ ] All CI checks pass (validate this with @verify agent)
+- [ ] Agent identification block present in PR body (agent-authored PRs only)
+  ```bash
+  echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
+  ```
 
 ### 5. Security Requirements
 - [ ] Security-gate agent has scanned changes

--- a/.opencode/skills/workflow-guard/SKILL.md
+++ b/.opencode/skills/workflow-guard/SKILL.md
@@ -44,6 +44,10 @@ Validates that all actions comply with the Issue-First development workflow befo
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
 - [ ] All CI checks pass (validate this with @verify agent)
+- [ ] Agent identification block present in PR body (agent-authored PRs only)
+  ```bash
+  echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
+  ```
 
 ### 5. Security Requirements
 - [ ] Security-gate agent has scanned changes

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -328,6 +328,26 @@ grafana:
     - "grafana/dashboards/app-overview.json"
 ```
 
+## Prometheus Alert Rules
+
+Place a file at `apps/<name>/prometheus/alert-rules.yml` and the platform will
+copy it into `prometheus/app-alerts/<name>.yml` on `./aixcl app start`. Prometheus
+loads all files matching `app-alerts/*.yml` automatically (no platform restart needed).
+The file is removed on `./aixcl app stop` and `./aixcl app remove`.
+
+A starter template with three common alerts (app down, high error rate, high latency)
+is available at `etc/app-scaffold/prometheus/alert-rules.yml`. Copy it to your app:
+
+```bash
+mkdir -p apps/my-app/prometheus
+cp etc/app-scaffold/prometheus/alert-rules.yml apps/my-app/prometheus/
+# Edit the file -- replace "my-app" with your app name and adjust thresholds
+```
+
+Alerts route to Alertmanager at `localhost:9093` using the platform's existing
+`prometheus/alertmanager.yml` configuration. To add a notification channel
+(Slack, PagerDuty, email) edit that file.
+
 ## Log Integration
 
 Container logs do **not** flow to Loki automatically. The platform runs Loki as a log store but does not include Promtail or a Docker log driver plugin, so no automatic log shipping is configured.

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -320,6 +320,71 @@ To verify targets are detected:
 
 Dashboards listed in the `grafana` block of the manifest are copied into `grafana/provisioning/dashboards/apps/<app>/` when the app starts (a dedicated subdirectory avoids UID collisions with platform dashboards). Grafana's provisioner picks up changes on its scan interval; restart Grafana to force a reload.
 
+A starter dashboard template is available at `etc/app-scaffold/grafana/dashboards/app-overview.json`. Copy it into your app directory and reference it in the `grafana` block:
+
+```yaml
+grafana:
+  dashboards:
+    - "grafana/dashboards/app-overview.json"
+```
+
+## Log Integration
+
+Container logs do **not** flow to Loki automatically. The platform runs Loki as a log store but does not include Promtail or a Docker log driver plugin, so no automatic log shipping is configured.
+
+### Options
+
+**Option 1 -- Docker Loki log driver (recommended for containerized apps)**
+
+Install the Grafana Loki Docker driver plugin once per host:
+
+```bash
+docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+```
+
+Then add a `logging` block to your service in `docker-compose.yml`:
+
+```yaml
+services:
+  my-app-service:
+    image: my-app:latest
+    network_mode: host
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://localhost:3100/loki/api/v1/push"
+        loki-external-labels: "app=my-app,job=my-app-service"
+```
+
+Logs are then queryable in Grafana under Explore -> Loki using `{app="my-app"}`.
+
+**Option 2 -- Push logs from application code**
+
+Send structured log lines directly to the Loki push API:
+
+```bash
+curl -s -X POST http://localhost:3100/loki/api/v1/push \
+  -H "Content-Type: application/json" \
+  -d '{
+    "streams": [{
+      "stream": {"app": "my-app", "level": "info"},
+      "values": [["'"$(date +%s%N)"'", "your log message here"]]
+    }]
+  }'
+```
+
+Most logging libraries (Python structlog, Winston, etc.) have Loki appenders that handle this automatically.
+
+**Option 3 -- Query stdout via `docker logs`**
+
+For local development without Loki integration, query container logs directly:
+
+```bash
+docker logs my-app-service --follow
+# Or via the CLI wrapper:
+./aixcl stack logs
+```
+
 ## Lifecycle and Isolation
 
 - Applications run under `network_mode: host` alongside the platform

--- a/docs/developer/agent-pitfalls.md
+++ b/docs/developer/agent-pitfalls.md
@@ -7,23 +7,23 @@ Read this if you are starting a session or if something unexpected happened.
 
 ### Pitfall: Pushing to the wrong remote
 
-**What happens:** `git push origin issue-<N>/...` is blocked or pushes to the
-wrong repository.
+**What happens:** An agent tries to push directly to the canonical repository
+(`xencon/aixcl`) instead of the personal fork, and is blocked by branch protection.
 
-**Why:** `origin` is the upstream repository (`xencon/aixcl`). Direct pushes
-to `origin` are blocked by branch protection. Feature branches go to the
-personal fork (`sbadakhc/aixcl`), which is the `fork` remote.
+**Why:** `origin` is the personal fork (`sbadakhc/aixcl`). Feature branches go
+to `origin`. The canonical repository (`xencon/aixcl`) is the `upstream` remote --
+PRs target it but direct pushes are blocked by branch protection.
 
 **Fix:**
 ```bash
-git remote -v                          # Check what remotes exist
-git push fork issue-<N>/<description>  # Always push to fork
-gh pr create --repo xencon/aixcl ...   # PR targets origin
+git remote -v                              # Check what remotes exist
+git push origin issue-<N>/<description>   # Push to personal fork
+gh pr create --repo xencon/aixcl ...      # PR targets upstream
 ```
 
-If `fork` remote is missing:
+If `upstream` remote is missing:
 ```bash
-git remote add fork git@github.com:sbadakhc/aixcl.git
+git remote add upstream git@github.com:xencon/aixcl.git
 ```
 
 Use SSH, not HTTPS -- HTTPS push is blocked for repositories containing

--- a/docs/developer/app-builder-guide.md
+++ b/docs/developer/app-builder-guide.md
@@ -100,3 +100,129 @@ EOF
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Inference API base URL |
+
+## Non-Containerized Apps
+
+Because the platform uses `network_mode: host`, all services are reachable on
+localhost from any process running on the host -- including native Python scripts,
+Node services, and Go binaries that are not yet Dockerized. No special configuration
+is required to reach the inference API or the database during local development.
+
+### Inference API (no Docker needed)
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="unused",  # Ollama requires a non-empty value; content is ignored
+)
+
+response = client.chat.completions.create(
+    model="qwen2.5-coder:0.5b",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(response.choices[0].message.content)
+```
+
+### Database access
+
+Retrieve credentials for local development, then connect using any standard client:
+
+```bash
+./aixcl app secrets my-app
+# Prints db-password and any other provisioned secrets
+```
+
+```python
+import psycopg2, subprocess, json
+
+# Read the provisioned password
+pw = subprocess.check_output(
+    ["./aixcl", "app", "secrets", "my-app", "--json"],
+    text=True,
+)
+creds = json.loads(pw)
+
+conn = psycopg2.connect(
+    host="localhost", port=5432,
+    dbname="my_app", user="my_app",
+    password=creds["db-password"],
+)
+```
+
+### Registering a non-Dockerized app
+
+A non-Dockerized app can still declare a `prometheus` scrape target and register
+itself so the CLI tracks it. Create a minimal `app.yaml` alongside your code:
+
+```yaml
+app:
+  name: "my-app"
+  version: "0.1.0"
+
+# No services block needed for a native process
+
+prometheus:
+  targets:
+    - "localhost:9000"   # port your app exposes /metrics on
+  labels:
+    app: "my-app"
+    job: "my-app-service"
+```
+
+Register the directory:
+
+```bash
+./aixcl app register /path/to/my-app
+./aixcl app provision my-app   # creates Vault secrets and Postgres DB
+```
+
+Start your process manually and Prometheus will discover its metrics endpoint
+within 30 seconds.
+
+### Minimal Dockerfile for containerizing later
+
+When you are ready to containerize, use these patterns as a starting point:
+
+**Python (FastAPI)**
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 9000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]
+```
+
+**Node.js**
+
+```dockerfile
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 9000
+CMD ["node", "server.js"]
+```
+
+Mount the platform secrets volume to read provisioned credentials at runtime:
+
+```yaml
+# in your app docker-compose.yml
+volumes:
+  my-secrets:
+    name: aixcl-app-my-app-secrets
+    external: true
+
+services:
+  my-app-service:
+    ...
+    volumes:
+      - my-secrets:/run/secrets:ro
+```
+
+Secrets are then available as files: `/run/secrets/my-app-db-password`, etc.

--- a/docs/user/apps.md
+++ b/docs/user/apps.md
@@ -71,12 +71,18 @@ When an app is started:
 
 See [docs/developer/adding-apps.md](../developer/adding-apps.md) for the full developer guide including manifest reference and compliance rules.
 
-## Example: FTSO
+## Try It
 
-The repository includes `apps/ftso/` as a reference implementation. To test:
+Scaffold a new app and start it:
 
 ```bash
-./aixcl app build ftso
-./aixcl app start ftso
-./aixcl app status ftso
+./aixcl app scaffold my-app
+# Edit apps/my-app/app.yaml and docker-compose.yml for your use case
+./aixcl app build my-app
+./aixcl app start my-app
+./aixcl app status my-app
 ```
+
+The scaffold creates a working template with all supported manifest fields.
+See `etc/app-scaffold/` for the canonical templates and
+[docs/developer/adding-apps.md](../developer/adding-apps.md) for the full guide.

--- a/etc/app-scaffold/app.yaml
+++ b/etc/app-scaffold/app.yaml
@@ -22,6 +22,23 @@ services:
     depends_on:
       - "ollama"
 
+# Platform resource provisioning.
+# Declared resources are created idempotently on every `./aixcl app start`.
+# Remove this block entirely if your app needs no database or secrets.
+provision:
+  # Secrets are generated (32-char alphanumeric) and stored in Vault at
+  # kv/apps/<app-name>. Existing values are never overwritten.
+  # Each secret is rendered into the per-app volume as /run/secrets/<app>-<name>.
+  secrets:
+    - api-key
+    - db-password
+  # Postgres block creates a role and database in the platform PostgreSQL instance.
+  # The role password is synced from password_secret. Remove if not needed.
+  postgres:
+    database: example_app
+    owner: example_app
+    password_secret: db-password
+
 # Prometheus scrape targets for this application
 prometheus:
   targets:
@@ -30,10 +47,13 @@ prometheus:
     app: "example-app"
     job: "example-service"
 
-# Grafana dashboard provisioning (optional)
+# Grafana dashboard provisioning (optional).
+# Paths are relative to this app directory (apps/<name>/).
+# Dashboards are copied to grafana/provisioning/dashboards/apps/<name>/ on start.
+# A starter dashboard template is available at etc/app-scaffold/grafana/dashboards/app-overview.json.
 grafana:
   dashboards:
-    - "grafana/dashboards/example-dashboard.json"
+    - "grafana/dashboards/app-overview.json"
 
 # Git submodules for builder code
 submodules:

--- a/etc/app-scaffold/grafana/dashboards/app-overview.json
+++ b/etc/app-scaffold/grafana/dashboards/app-overview.json
@@ -1,0 +1,169 @@
+{
+  "title": "App Overview",
+  "uid": "aixcl-app-overview",
+  "description": "Starter dashboard for AIXCL applications. Customize metric names to match your app's instrumentation.",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": ["aixcl", "app"],
+  "editable": true,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "type": "constant",
+        "label": "App",
+        "description": "Set this to your app name (matches the 'app' label in prometheus block of app.yaml)",
+        "value": "my-app",
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request Rate (req/s)",
+      "description": "Requires http_requests_total{app=...} counter. Common in Flask (prometheus-flask-exporter), FastAPI (prometheus-fastapi-instrumentator), Express (prom-client).",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{app=\"$app\"}[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Error Rate",
+      "description": "5xx responses as a percentage of all requests.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{app=\"$app\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{app=\"$app\"}[5m]))",
+          "legendFormat": "Error %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Request Latency (p50 / p95 / p99)",
+      "description": "Requires http_request_duration_seconds histogram. Adjust the metric name to match your framework.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "LLM Calls",
+      "description": "Customize the metric name and labels to match how your app tracks inference calls. Replace llm_calls_total with your counter name.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(llm_calls_total{app=\"$app\"}[5m])) by (model)",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/etc/app-scaffold/prometheus/alert-rules.yml
+++ b/etc/app-scaffold/prometheus/alert-rules.yml
@@ -1,0 +1,54 @@
+# Prometheus alert rules for this application.
+# Place this file at apps/<name>/prometheus/alert-rules.yml.
+# The platform copies it to prometheus/app-alerts/<name>.yml on app start
+# and removes it on app stop/remove.
+#
+# Customize the metric names and thresholds to match your app's instrumentation.
+# The `app` label value must match the `app` label in your prometheus block (app.yaml).
+#
+# Reference: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+groups:
+  - name: my-app-alerts
+    rules:
+
+      # App is unreachable -- Prometheus cannot scrape the /metrics endpoint.
+      - alert: AppDown
+        expr: up{app="my-app"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          app: my-app
+        annotations:
+          summary: "App is down"
+          description: "{{ $labels.app }} has been unreachable for more than 1 minute."
+
+      # High HTTP error rate -- more than 5% of requests are returning 5xx.
+      # Requires http_requests_total{app=..., status=~"5.."} counter.
+      - alert: AppHighErrorRate
+        expr: |
+          sum(rate(http_requests_total{app="my-app", status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{app="my-app"}[5m])) > 0.05
+        for: 2m
+        labels:
+          severity: warning
+          app: my-app
+        annotations:
+          summary: "High error rate"
+          description: "{{ $labels.app }} error rate is {{ $value | humanizePercentage }} over the last 5 minutes."
+
+      # High p95 latency -- 95th percentile response time exceeds 2 seconds.
+      # Requires http_request_duration_seconds histogram.
+      - alert: AppHighLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket{app="my-app"}[5m])) by (le)
+          ) > 2
+        for: 2m
+        labels:
+          severity: warning
+          app: my-app
+        annotations:
+          summary: "High p95 latency"
+          description: "{{ $labels.app }} p95 latency is {{ $value | humanizeDuration }} over the last 5 minutes."

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -567,6 +567,9 @@ app_cmd_start() {
         _app_wire_grafana "$app_name"
     fi
 
+    # Wire Prometheus alert rules if present (no manifest flag needed -- file presence is the signal)
+    _app_wire_alerts "$app_name"
+
     echo ""
 }
 
@@ -615,6 +618,12 @@ app_cmd_stop() {
     local prom_file="${SCRIPT_DIR}/prometheus/file_sd/${app_name}.json"
     if [ -f "$prom_file" ]; then
         rm -f "$prom_file"
+    fi
+
+    # Remove alert rules if present
+    local alert_file="${SCRIPT_DIR}/prometheus/app-alerts/${app_name}.yml"
+    if [ -f "$alert_file" ]; then
+        rm -f "$alert_file"
     fi
 }
 
@@ -886,13 +895,19 @@ app_cmd_remove() {
         rm -f "$prom_file"
     fi
 
-    # 3a. Remove Grafana dashboard files if present (handle both lowercase and uppercase app names)
+    # 3a. Remove alert rules if present
+    local alert_file="${SCRIPT_DIR}/prometheus/app-alerts/${app_name}.yml"
+    if [ -f "$alert_file" ]; then
+        rm -f "$alert_file"
+    fi
+
+    # 3b. Remove Grafana dashboard files if present (handle both lowercase and uppercase app names)
     local grafana_dash="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/${app_name}"
     if [ -d "$grafana_dash" ]; then
         rm -rf "$grafana_dash"
     fi
 
-    # 3b. Handle uppercase app name variant (e.g., ftso -> FTSO for display names)
+    # 3c. Handle uppercase app name variant
     local grafana_dash_upper
     grafana_dash_upper="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/$(echo "$app_name" | tr '[:lower:]' '[:upper:]')"
     if [ -d "$grafana_dash_upper" ] && [ "$grafana_dash_upper" != "$grafana_dash" ]; then
@@ -1267,6 +1282,23 @@ _app_generate_prometheus_targets() {
 EOF
 
     echo "  ${ICON_SUCCESS:-[x]} Prometheus targets"
+}
+
+# Copy alert rules from app into prometheus/app-alerts/ so Prometheus picks them up.
+# Looks for <app_dir>/prometheus/alert-rules.yml; no-ops silently if absent.
+_app_wire_alerts() {
+    local app_name="${1:-}"
+    local app_dir
+    app_dir="$(_app_resolve_dir "$app_name" 2>/dev/null)" || app_dir="${SCRIPT_DIR}/apps/${app_name}"
+    local src="${app_dir}/prometheus/alert-rules.yml"
+    local dst_dir="${SCRIPT_DIR}/prometheus/app-alerts"
+    local dst="${dst_dir}/${app_name}.yml"
+
+    [ -f "$src" ] || return 0
+
+    mkdir -p "$dst_dir"
+    cp -f "$src" "$dst"
+    echo "  ${ICON_SUCCESS:-[x]} Prometheus alert rules"
 }
 
 # Copy Grafana dashboards from app into platform provisioning

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,6 +16,7 @@ alerting:
 # Load rules once and periodically evaluate them
 rule_files:
   - "alerts.yml"
+  - "app-alerts/*.yml"
 
 # Scrape configurations
 scrape_configs:

--- a/scripts/checks/check-agent-id-block.sh
+++ b/scripts/checks/check-agent-id-block.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Checks that a GitHub PR body or issue comment posted by an agent includes
+# the required agent identification block (AGENTS.md section 9.5).
+#
+# Usage:
+#   check-agent-id-block.sh <file>          # check body saved to a file
+#   echo "$BODY" | check-agent-id-block.sh  # check body from stdin
+#
+# Exit 0 = identification block found. Exit 1 = block missing.
+#
+# Required block format (AGENTS.md 9.5):
+#   ---
+#   - Agent: <name and model>
+#   - Date: YYYY-MM-DD
+#   - Method: <what the agent did>
+#   - Scope: <files or context>
+#   - Confirmation: yes|no
+#   ---
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
+
+input_file="${1:-/dev/stdin}"
+
+body=$(cat "$input_file")
+
+# Check for the minimum required fields: Agent and Date lines inside a --- block
+if echo "$body" | grep -qE '^\s*-\s+Agent:' && \
+   echo "$body" | grep -qE '^\s*-\s+Date:' && \
+   echo "$body" | grep -qE '^\s*-\s+Confirmation:'; then
+    print_success "agent identification block found"
+    exit 0
+fi
+
+print_error "agent identification block missing or incomplete"
+echo ""
+echo "Agent-authored PR bodies and issue comments MUST end with:"
+echo ""
+echo "  ---"
+echo "  - Agent: <tool name and model>"
+echo "  - Date: $(date +%Y-%m-%d)"
+echo "  - Method: <what the agent did>"
+echo "  - Scope: <files, issues, or context>"
+echo "  - Confirmation: yes|no"
+echo "  ---"
+echo ""
+echo "See AGENTS.md section 9.5 for the full specification."
+exit 1

--- a/scripts/utils/trace-llm-call.sh
+++ b/scripts/utils/trace-llm-call.sh
@@ -121,6 +121,40 @@ print(json.dumps(entry))
 
 log_info "trace written to ${TRACE_FILE}"
 
+# Optional Loki push -- set LOKI_ENABLED=true to activate.
+# LOKI_URL overrides the default endpoint (http://localhost:3100).
+# Push is best-effort: failures are suppressed so the trace file remains
+# the reliable primary store.
+if [ "${LOKI_ENABLED:-}" = "true" ]; then
+    python3 - "${LOKI_URL:-http://localhost:3100}" "$TRACE_FILE" << 'PYEOF'
+import sys, json, time
+try:
+    import urllib.request
+    loki_url, trace_file = sys.argv[1], sys.argv[2]
+    with open(trace_file) as fh:
+        lines = [ln for ln in fh if ln.strip()]
+    if not lines:
+        sys.exit(0)
+    raw = lines[-1].strip()
+    entry = json.loads(raw)
+    stream = {"app": entry["app"], "model": entry["model"],
+              "status": entry["status"], "job": "trace-llm-call"}
+    nanos = str(int(time.time() * 1e9))
+    body = json.dumps({
+        "streams": [{"stream": stream, "values": [[nanos, raw]]}]
+    }).encode()
+    req = urllib.request.Request(
+        loki_url.rstrip("/") + "/loki/api/v1/push",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+PYEOF
+fi
+
 # Surface errors but still exit cleanly so callers can inspect the trace
 if [[ "$STATUS" != "ok" ]]; then
     log_error "API call failed: $STATUS"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1630

Three commits addressing gaps identified in an agentic orientation assessment of the repository.

### Description of Changes

**Commit 1 -- docs/developer/agent-pitfalls.md**

Correct the "Pushing to the wrong remote" pitfall to match the two-remote layout in AGENTS.md. The old text named a non-existent `fork` remote and stated `origin` was the canonical repo. AGENTS.md defines `origin` as the personal fork and `upstream` as the canonical repo.

**Commit 2 -- App integration documentation gaps**

- `etc/app-scaffold/app.yaml`: add `provision` block (secrets + postgres)
- `etc/app-scaffold/grafana/dashboards/app-overview.json`: add starter Grafana dashboard template
- `docs/developer/adding-apps.md`: add Loki log integration section and Grafana starter note
- `docs/developer/app-builder-guide.md`: add non-containerized app guide
- `docs/user/apps.md`: replace dead `apps/ftso/` reference with generic scaffold workflow

**Commit 3 -- Platform features and checks**

- `prometheus/prometheus.yml`: add `app-alerts/*.yml` to `rule_files`
- `lib/aixcl/commands/app.sh`: add `_app_wire_alerts()` -- copies `apps/<name>/prometheus/alert-rules.yml` to `prometheus/app-alerts/` on start; removes on stop and remove
- `etc/app-scaffold/prometheus/alert-rules.yml`: starter alert rules template (AppDown, AppHighErrorRate, AppHighLatency)
- `docs/developer/adding-apps.md`: add Prometheus Alert Rules section
- `scripts/utils/trace-llm-call.sh`: add optional Loki push (LOKI_ENABLED=true / LOKI_URL)
- `scripts/checks/check-agent-id-block.sh`: new check -- validates agent identification block in agent-authored PR and issue bodies
- `.claude/skills/workflow-guard/SKILL.md`: reference new check in PR requirements
- `.opencode/skills/workflow-guard/SKILL.md`: mirror parity

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] ShellCheck clean (all modified .sh files)
- [x] ASCII clean (all modified .md and .yml files)
- [x] Dashboard JSON validated
- [x] Mirror parity maintained (.claude/skills/ == .opencode/skills/)
- [x] pre-commit hooks passed on all commits
- [x] All tests run and pass

### Testing Notes

Commits 1 and 2 are documentation and template changes only. Commit 3: `prometheus.yml` glob is backward-compatible; `app.sh` additions are no-ops when no alert-rules.yml is present; Loki push in `trace-llm-call.sh` is opt-in (off by default); `check-agent-id-block.sh` is a standalone check script.

### Verification

- [x] `docs/developer/agent-pitfalls.md` remote layout matches `AGENTS.md`
- [x] `etc/app-scaffold/app.yaml` includes a `provision` block
- [x] `docs/user/apps.md` contains no reference to `apps/ftso/`
- [x] `docs/developer/adding-apps.md` has Log Integration and Alert Rules sections
- [x] `docs/developer/app-builder-guide.md` has a Non-Containerized Apps section
- [x] `prometheus/prometheus.yml` loads `app-alerts/*.yml`
- [x] `./aixcl app start <app>` copies alert-rules.yml if present; removes on stop
- [x] `trace-llm-call.sh` pushes to Loki when `LOKI_ENABLED=true`

### Related Issues

- Fixes #1630

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-07-01
- Method: Documentation edits and platform feature additions based on agentic orientation assessment
- Scope: etc/app-scaffold/, docs/developer/, docs/user/, lib/aixcl/commands/app.sh, scripts/, prometheus/, .claude/skills/, .opencode/skills/
- Confirmation: yes
---
