### PR TITLE
Release v1.1.43 (#1633)

### DIFF
--- a/.claude/skills/check-updates/SKILL.md
+++ b/.claude/skills/check-updates/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: check-updates
+description: Audit all versioned platform components and manage the update process following issue-first workflow
+version: 1.0
+compatibility: OpenCode, Claude Code
+metadata:
+  category: maintenance
+  version: "1.0"
+---
+
+# Skill: check-updates
+
+Audit every versioned component in the AIXCL platform and produce an
+actionable update report. For each outdated component, open a GitHub issue
+and apply the update following the issue-first workflow.
+
+Run this skill before a release cycle or after a long gap between releases.
+
+---
+
+## Component Inventory
+
+The platform versions four categories of components. Every line below is a
+canonical version source -- do not check anywhere else.
+
+### Category 1 -- Stack Services (services/docker-compose.yml)
+
+Extract all pinned image tags:
+
+```bash
+grep "image:" services/docker-compose.yml | grep -v "#" | \
+  sed 's/.*image: //' | sort
+```
+
+| Service | Compose key | Registry |
+|---------|------------|---------|
+| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
+| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
+| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
+| vLLM | `vllm/vllm-openai:<tag>` | hub.docker.com |
+| llama.cpp | `ghcr.io/ggml-org/llama.cpp:<tag>` | ghcr.io |
+| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
+| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
+| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
+| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
+| Grafana | `grafana/grafana:<tag>` | GitHub releases |
+| Loki | `grafana/loki:<tag>` | GitHub releases |
+| cAdvisor | `gcr.io/cadvisor/cadvisor:<tag>` | GitHub releases |
+| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
+| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
+| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
+
+### Category 2 -- Pre-commit Hooks (.pre-commit-config.yaml)
+
+```bash
+grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
+```
+
+| Hook | GitHub repo | Rev field |
+|------|-------------|-----------|
+| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
+| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
+| yamllint | adrienverge/yamllint | `rev:` |
+| gitleaks | gitleaks/gitleaks | `rev:` |
+
+### Category 3 -- GitHub Actions (.github/workflows/*.yml)
+
+```bash
+grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
+  sed 's/.*uses: //' | sort -u
+```
+
+| Action | Pinned in |
+|--------|-----------|
+| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
+| actions/dependency-review-action | dependency-review.yml |
+| docker/setup-buildx-action | bash-ci.yml |
+| github/codeql-action/init | codeql.yml |
+| github/codeql-action/analyze | codeql.yml |
+
+### Category 4 -- Developer CLI Tools (README.md + CI)
+
+Versions are pinned in two places that must stay in sync:
+
+| Tool | README.md install | CI workflow |
+|------|------------------|-------------|
+| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
+| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
+| git-cliff | README.md curl install | not used in CI |
+| yamllint | README.md pip install | documentation-checks.yml pip install |
+
+---
+
+## Step 1 -- Check Latest Versions
+
+Run these commands to look up the latest stable release for each component.
+Use GitHub releases (more reliable) wherever available; fall back to Docker Hub.
+
+```bash
+# Stack services -- GitHub releases
+for repo in \
+  "ollama/ollama" \
+  "open-webui/open-webui" \
+  "google/cadvisor" \
+  "vllm-project/vllm" \
+  "ggml-org/llama.cpp" \
+  "grafana/loki" \
+  "prometheus/prometheus" \
+  "prometheus/alertmanager" \
+  "grafana/grafana" \
+  "prometheus/node_exporter" \
+  "prometheus-community/postgres_exporter" \
+  "utkuozdemir/nvidia_gpu_exporter"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+
+# Stack services -- Docker Hub (for images without GitHub releases)
+for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
+  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
+    python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
+print(tags[0] if tags else 'check manually')
+" 2>/dev/null)
+  echo "$image: $latest"
+done
+
+# Pre-commit hooks and CLI tools
+for repo in \
+  "pre-commit/pre-commit-hooks" \
+  "shellcheck-py/shellcheck-py" \
+  "adrienverge/yamllint" \
+  "gitleaks/gitleaks" \
+  "orhun/git-cliff" \
+  "koalaman/shellcheck" \
+  "actions/checkout" \
+  "actions/dependency-review-action" \
+  "docker/setup-buildx-action" \
+  "github/codeql-action"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+```
+
+---
+
+## Step 2 -- Build the Update Table
+
+Produce a table with four columns: Component, Category, Pinned, Latest.
+
+Mark each row:
+
+| Symbol | Meaning |
+|--------|---------|
+| current | Pinned == Latest |
+| UPDATE | Newer version available |
+| check | Could not determine latest (check manually) |
+
+Example output:
+
+```
+| Component          | Category       | Pinned   | Latest   | Status  |
+|--------------------|----------------|----------|----------|---------|
+| ollama             | stack-service  | 0.30.7   | 0.31.1   | UPDATE  |
+| prometheus         | stack-service  | v3.12.0  | v3.12.0  | current |
+```
+
+---
+
+## Step 3 -- Triage Updates
+
+Before opening issues, classify each update:
+
+**Routine (open one issue per component):**
+- Patch version bumps (x.y.Z -> x.y.Z+1)
+- Minor version bumps with no breaking changes noted in release notes
+
+**Review required (open issue, flag for human review):**
+- Major version bumps (X.y.z -> X+1.y.z)
+- Any bump for a component listed in `docs/architecture/governance/00_invariants.md`
+  as a runtime core invariant (currently: Ollama)
+- Any bump where the release notes mention breaking API changes or schema migrations
+
+**Skip (do not open an issue):**
+- Pre-release tags (alpha, beta, rc, dev)
+- Architecture-specific tags (rocm, cuda, distroless suffixes)
+- Tags that differ only in suffix from the currently pinned version
+
+---
+
+## Step 4 -- Open Issues (issue-first workflow)
+
+Open one issue per component that needs updating. Batch minor patch bumps
+across the same category into a single issue if there are more than three.
+
+```bash
+# Example: single component update
+gh issue create --repo xencon/aixcl \
+  --title "[TASK] Update <component> from <old> to <new>" \
+  --body "## Update
+
+- Component: \`<component>\`
+- Current: \`<old>\`
+- Latest: \`<new>\`
+- Release notes: <URL>
+
+## Checklist
+
+- [ ] Image tag updated in \`services/docker-compose.yml\`
+- [ ] Version updated in README.md install section (if CLI tool)
+- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
+- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
+- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
+- [ ] \`./aixcl stack status\` shows all services healthy" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+For Ollama (runtime core invariant), add to the issue body:
+
+```
+> [!WARNING]
+> Ollama is a runtime core invariant. Test inference with at least one
+> model before merging. Confirm the OpenAI-compatible API endpoint
+> (/v1/chat/completions) responds correctly after the upgrade.
+```
+
+---
+
+## Step 5 -- Apply Updates
+
+Create a branch per issue:
+
+```bash
+git checkout dev
+git checkout -b issue-<N>/update-<component>-<new-version>
+```
+
+### Update locations by category
+
+**Stack service (docker-compose.yml):**
+```bash
+# Replace the image tag -- edit services/docker-compose.yml
+# For services with multiple instances (e.g. vault), update all occurrences
+grep -n "image:.*<component>" services/docker-compose.yml
+# Edit each line, then validate
+docker compose -f services/docker-compose.yml config > /dev/null
+```
+
+**Pre-commit hook (.pre-commit-config.yaml):**
+```bash
+# Update the rev: field for the relevant repo entry
+# Then run pre-commit to verify
+pre-commit autoupdate --repo https://github.com/<owner>/<repo>
+# Or edit manually, then:
+pre-commit run --all-files
+```
+
+**GitHub Action (.github/workflows/*.yml):**
+```bash
+# Update the uses: line in every workflow that references the action
+grep -rn "uses:.*<action>" .github/workflows/
+# Edit each file, then validate YAML
+yamllint -c .yamllint.yml .github/workflows/
+```
+
+**CLI tool (README.md + CI workflow):**
+```bash
+# Must update both locations atomically:
+# 1. README.md -- curl install URL and version comment
+# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
+#    or documentation-checks.yml pip install line (for yamllint)
+grep -n "<tool>" README.md
+grep -rn "<tool>" .github/workflows/
+```
+
+---
+
+## Step 6 -- Validate and Commit
+
+```bash
+# Run pre-commit checks
+bash scripts/checks/check-ai-elisions.sh --staged
+shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
+yamllint -c .yamllint.yml .
+
+# Validate compose
+docker compose -f services/docker-compose.yml config > /dev/null
+
+# Stage and commit (GPG -- user must run)
+git add <changed files>
+# Provide commit message:
+# "chore: update <component> from <old> to <new>
+#
+# Fixes #<issue>"
+```
+
+---
+
+## Step 7 -- PR and CI
+
+```bash
+git push origin issue-<N>/update-<component>-<new-version>
+
+gh pr create \
+  --repo xencon/aixcl \
+  --base dev \
+  --title "Update <component> from <old> to <new> (#<N>)" \
+  --body "$(cat /tmp/update-pr-body.md)" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+Verify PR body with `check-pr-references.sh` before creating.
+
+---
+
+## Dependabot Coverage Note
+
+`.github/dependabot.yml` automatically opens PRs for:
+- Docker images in `/services` (weekly, Mondays)
+- GitHub Actions in `/.github/workflows` (weekly, Mondays)
+
+This skill covers the gaps Dependabot does not handle:
+- Pre-commit hook versions (`.pre-commit-config.yaml`)
+- CLI tool versions in `README.md` install instructions
+- Tool versions hard-coded in CI workflow `run:` steps (not `uses:`)
+- Cross-checking that Dependabot PRs have not stalled or been missed
+
+When Dependabot opens a PR for a component in this inventory, close the
+corresponding issue from this skill if one was opened for the same version bump.
+
+---
+
+## Common Mistakes
+
+- Updating docker-compose.yml but not README.md for the same tool version
+- Updating pre-commit rev but not the matching CI workflow pin (yamllint, gitleaks)
+- Pulling an RC or architecture-specific tag (check for `-rc`, `-rocm`, `-cuda` suffixes)
+- Updating Ollama without testing model inference after restart
+- Batching too many updates in one PR -- prefer one component per PR so
+  regressions are easy to bisect

--- a/.claude/skills/workflow-guard/SKILL.md
+++ b/.claude/skills/workflow-guard/SKILL.md
@@ -44,6 +44,10 @@ Validates that all actions comply with the Issue-First development workflow befo
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
 - [ ] All CI checks pass (validate this with @verify agent)
+- [ ] Agent identification block present in PR body (agent-authored PRs only)
+  ```bash
+  echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
+  ```
 
 ### 5. Security Requirements
 - [ ] Security-gate agent has scanned changes

--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Install yamllint
-        run: pip install yamllint==1.35.1
+        run: pip install yamllint==1.38.0
 
       - name: Validate YAML files
         run: |

--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Create minimal .env for validation
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Validate Compose Files
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 1
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION="8.21.2"
+          GITLEAKS_VERSION="8.30.1"
           curl -sSfL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | tar -xz -C /usr/local/bin gitleaks

--- a/.opencode/skills/check-updates/SKILL.md
+++ b/.opencode/skills/check-updates/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: check-updates
+description: Audit all versioned platform components and manage the update process following issue-first workflow
+version: 1.0
+compatibility: OpenCode, Claude Code
+metadata:
+  category: maintenance
+  version: "1.0"
+---
+
+# Skill: check-updates
+
+Audit every versioned component in the AIXCL platform and produce an
+actionable update report. For each outdated component, open a GitHub issue
+and apply the update following the issue-first workflow.
+
+Run this skill before a release cycle or after a long gap between releases.
+
+---
+
+## Component Inventory
+
+The platform versions four categories of components. Every line below is a
+canonical version source -- do not check anywhere else.
+
+### Category 1 -- Stack Services (services/docker-compose.yml)
+
+Extract all pinned image tags:
+
+```bash
+grep "image:" services/docker-compose.yml | grep -v "#" | \
+  sed 's/.*image: //' | sort
+```
+
+| Service | Compose key | Registry |
+|---------|------------|---------|
+| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
+| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
+| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
+| vLLM | `vllm/vllm-openai:<tag>` | hub.docker.com |
+| llama.cpp | `ghcr.io/ggml-org/llama.cpp:<tag>` | ghcr.io |
+| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
+| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
+| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
+| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
+| Grafana | `grafana/grafana:<tag>` | GitHub releases |
+| Loki | `grafana/loki:<tag>` | GitHub releases |
+| cAdvisor | `gcr.io/cadvisor/cadvisor:<tag>` | GitHub releases |
+| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
+| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
+| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
+
+### Category 2 -- Pre-commit Hooks (.pre-commit-config.yaml)
+
+```bash
+grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
+```
+
+| Hook | GitHub repo | Rev field |
+|------|-------------|-----------|
+| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
+| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
+| yamllint | adrienverge/yamllint | `rev:` |
+| gitleaks | gitleaks/gitleaks | `rev:` |
+
+### Category 3 -- GitHub Actions (.github/workflows/*.yml)
+
+```bash
+grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
+  sed 's/.*uses: //' | sort -u
+```
+
+| Action | Pinned in |
+|--------|-----------|
+| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
+| actions/dependency-review-action | dependency-review.yml |
+| docker/setup-buildx-action | bash-ci.yml |
+| github/codeql-action/init | codeql.yml |
+| github/codeql-action/analyze | codeql.yml |
+
+### Category 4 -- Developer CLI Tools (README.md + CI)
+
+Versions are pinned in two places that must stay in sync:
+
+| Tool | README.md install | CI workflow |
+|------|------------------|-------------|
+| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
+| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
+| git-cliff | README.md curl install | not used in CI |
+| yamllint | README.md pip install | documentation-checks.yml pip install |
+
+---
+
+## Step 1 -- Check Latest Versions
+
+Run these commands to look up the latest stable release for each component.
+Use GitHub releases (more reliable) wherever available; fall back to Docker Hub.
+
+```bash
+# Stack services -- GitHub releases
+for repo in \
+  "ollama/ollama" \
+  "open-webui/open-webui" \
+  "google/cadvisor" \
+  "vllm-project/vllm" \
+  "ggml-org/llama.cpp" \
+  "grafana/loki" \
+  "prometheus/prometheus" \
+  "prometheus/alertmanager" \
+  "grafana/grafana" \
+  "prometheus/node_exporter" \
+  "prometheus-community/postgres_exporter" \
+  "utkuozdemir/nvidia_gpu_exporter"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+
+# Stack services -- Docker Hub (for images without GitHub releases)
+for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
+  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
+    python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
+print(tags[0] if tags else 'check manually')
+" 2>/dev/null)
+  echo "$image: $latest"
+done
+
+# Pre-commit hooks and CLI tools
+for repo in \
+  "pre-commit/pre-commit-hooks" \
+  "shellcheck-py/shellcheck-py" \
+  "adrienverge/yamllint" \
+  "gitleaks/gitleaks" \
+  "orhun/git-cliff" \
+  "koalaman/shellcheck" \
+  "actions/checkout" \
+  "actions/dependency-review-action" \
+  "docker/setup-buildx-action" \
+  "github/codeql-action"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+```
+
+---
+
+## Step 2 -- Build the Update Table
+
+Produce a table with four columns: Component, Category, Pinned, Latest.
+
+Mark each row:
+
+| Symbol | Meaning |
+|--------|---------|
+| current | Pinned == Latest |
+| UPDATE | Newer version available |
+| check | Could not determine latest (check manually) |
+
+Example output:
+
+```
+| Component          | Category       | Pinned   | Latest   | Status  |
+|--------------------|----------------|----------|----------|---------|
+| ollama             | stack-service  | 0.30.7   | 0.31.1   | UPDATE  |
+| prometheus         | stack-service  | v3.12.0  | v3.12.0  | current |
+```
+
+---
+
+## Step 3 -- Triage Updates
+
+Before opening issues, classify each update:
+
+**Routine (open one issue per component):**
+- Patch version bumps (x.y.Z -> x.y.Z+1)
+- Minor version bumps with no breaking changes noted in release notes
+
+**Review required (open issue, flag for human review):**
+- Major version bumps (X.y.z -> X+1.y.z)
+- Any bump for a component listed in `docs/architecture/governance/00_invariants.md`
+  as a runtime core invariant (currently: Ollama)
+- Any bump where the release notes mention breaking API changes or schema migrations
+
+**Skip (do not open an issue):**
+- Pre-release tags (alpha, beta, rc, dev)
+- Architecture-specific tags (rocm, cuda, distroless suffixes)
+- Tags that differ only in suffix from the currently pinned version
+
+---
+
+## Step 4 -- Open Issues (issue-first workflow)
+
+Open one issue per component that needs updating. Batch minor patch bumps
+across the same category into a single issue if there are more than three.
+
+```bash
+# Example: single component update
+gh issue create --repo xencon/aixcl \
+  --title "[TASK] Update <component> from <old> to <new>" \
+  --body "## Update
+
+- Component: \`<component>\`
+- Current: \`<old>\`
+- Latest: \`<new>\`
+- Release notes: <URL>
+
+## Checklist
+
+- [ ] Image tag updated in \`services/docker-compose.yml\`
+- [ ] Version updated in README.md install section (if CLI tool)
+- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
+- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
+- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
+- [ ] \`./aixcl stack status\` shows all services healthy" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+For Ollama (runtime core invariant), add to the issue body:
+
+```
+> [!WARNING]
+> Ollama is a runtime core invariant. Test inference with at least one
+> model before merging. Confirm the OpenAI-compatible API endpoint
+> (/v1/chat/completions) responds correctly after the upgrade.
+```
+
+---
+
+## Step 5 -- Apply Updates
+
+Create a branch per issue:
+
+```bash
+git checkout dev
+git checkout -b issue-<N>/update-<component>-<new-version>
+```
+
+### Update locations by category
+
+**Stack service (docker-compose.yml):**
+```bash
+# Replace the image tag -- edit services/docker-compose.yml
+# For services with multiple instances (e.g. vault), update all occurrences
+grep -n "image:.*<component>" services/docker-compose.yml
+# Edit each line, then validate
+docker compose -f services/docker-compose.yml config > /dev/null
+```
+
+**Pre-commit hook (.pre-commit-config.yaml):**
+```bash
+# Update the rev: field for the relevant repo entry
+# Then run pre-commit to verify
+pre-commit autoupdate --repo https://github.com/<owner>/<repo>
+# Or edit manually, then:
+pre-commit run --all-files
+```
+
+**GitHub Action (.github/workflows/*.yml):**
+```bash
+# Update the uses: line in every workflow that references the action
+grep -rn "uses:.*<action>" .github/workflows/
+# Edit each file, then validate YAML
+yamllint -c .yamllint.yml .github/workflows/
+```
+
+**CLI tool (README.md + CI workflow):**
+```bash
+# Must update both locations atomically:
+# 1. README.md -- curl install URL and version comment
+# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
+#    or documentation-checks.yml pip install line (for yamllint)
+grep -n "<tool>" README.md
+grep -rn "<tool>" .github/workflows/
+```
+
+---
+
+## Step 6 -- Validate and Commit
+
+```bash
+# Run pre-commit checks
+bash scripts/checks/check-ai-elisions.sh --staged
+shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
+yamllint -c .yamllint.yml .
+
+# Validate compose
+docker compose -f services/docker-compose.yml config > /dev/null
+
+# Stage and commit (GPG -- user must run)
+git add <changed files>
+# Provide commit message:
+# "chore: update <component> from <old> to <new>
+#
+# Fixes #<issue>"
+```
+
+---
+
+## Step 7 -- PR and CI
+
+```bash
+git push origin issue-<N>/update-<component>-<new-version>
+
+gh pr create \
+  --repo xencon/aixcl \
+  --base dev \
+  --title "Update <component> from <old> to <new> (#<N>)" \
+  --body "$(cat /tmp/update-pr-body.md)" \
+  --assignee sbadakhc \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+Verify PR body with `check-pr-references.sh` before creating.
+
+---
+
+## Dependabot Coverage Note
+
+`.github/dependabot.yml` automatically opens PRs for:
+- Docker images in `/services` (weekly, Mondays)
+- GitHub Actions in `/.github/workflows` (weekly, Mondays)
+
+This skill covers the gaps Dependabot does not handle:
+- Pre-commit hook versions (`.pre-commit-config.yaml`)
+- CLI tool versions in `README.md` install instructions
+- Tool versions hard-coded in CI workflow `run:` steps (not `uses:`)
+- Cross-checking that Dependabot PRs have not stalled or been missed
+
+When Dependabot opens a PR for a component in this inventory, close the
+corresponding issue from this skill if one was opened for the same version bump.
+
+---
+
+## Common Mistakes
+
+- Updating docker-compose.yml but not README.md for the same tool version
+- Updating pre-commit rev but not the matching CI workflow pin (yamllint, gitleaks)
+- Pulling an RC or architecture-specific tag (check for `-rc`, `-rocm`, `-cuda` suffixes)
+- Updating Ollama without testing model inference after restart
+- Batching too many updates in one PR -- prefer one component per PR so
+  regressions are easy to bisect

--- a/.opencode/skills/workflow-guard/SKILL.md
+++ b/.opencode/skills/workflow-guard/SKILL.md
@@ -44,6 +44,10 @@ Validates that all actions comply with the Issue-First development workflow befo
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
 - [ ] All CI checks pass (validate this with @verify agent)
+- [ ] Agent identification block present in PR body (agent-authored PRs only)
+  ```bash
+  echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
+  ```
 
 ### 5. Security Requirements
 - [ ] Security-gate agent has scanned changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         args: ['-c', '.yamllint.yml']
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.30.1
     hooks:
       - id: gitleaks
         args: ['--config', '.gitleaks.toml']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ['--severity=warning', '--exclude=SC1091']
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args: ['-c', '.yamllint.yml']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '\.md$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to the AIXCL project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.1.43] - 2026-07-01
+
+### Summary
+
+Release v1.1.43 -- Agentic orientation, app alert wiring, and component updates. Fixes agent-pitfalls remote naming, adds Prometheus alert rules scaffolding for apps, adds optional Loki push to the LLM tracing wrapper, introduces a check-agent-id-block script, and updates 13 platform components.
+
+### Added
+
+- [x] **Prometheus Alert Rules Wiring for Apps**: `_app_wire_alerts()` function in `lib/aixcl/commands/app.sh` copies `apps/<name>/prometheus/alert-rules.yml` to `prometheus/app-alerts/<name>.yml` on start and removes it on stop/remove. Platform now loads `app-alerts/*.yml` via `rule_files` in `prometheus/prometheus.yml`. Starter template at `etc/app-scaffold/prometheus/alert-rules.yml` with three example alerts (AppDown, AppHighErrorRate, AppHighLatency). Closes #1630.
+- [x] **Agent ID Block Check Script**: New `scripts/checks/check-agent-id-block.sh` validates that agent-authored PR bodies and issue comments include the required identification block (AGENTS.md section 9.5). Referenced in both `workflow-guard` skill mirrors. Closes #1630.
+- [x] **Optional Loki Push in LLM Tracer**: `scripts/utils/trace-llm-call.sh` now pushes the latest trace entry to Loki when `LOKI_ENABLED=true`. Push is best-effort -- failures are suppressed so the JSON-lines trace file remains the reliable primary store. Closes #1630.
+- [x] **Starter Grafana App Dashboard**: New `etc/app-scaffold/grafana/dashboards/app-overview.json` provides a four-panel starter dashboard (request rate, error rate, latency percentiles, LLM calls) templated on an `$app` variable. Closes #1630.
+- [x] **check-updates Skill**: New skill for auditing platform component versions against upstream releases. Closes #1605.
+
+### Changed
+
+- [x] **Open WebUI v0.9.6 -> v0.10.1**: Closes #1595.
+- [x] **Ollama 0.30.7 -> 0.31.1**: Closes #1592.
+- [x] **Grafana 13.0.2 -> 13.0.3**: Closes #1597.
+- [x] **Loki 3.7.2 -> 3.7.3**: Closes #1596.
+- [x] **Alertmanager v0.32.2 -> v0.33.0**: Closes #1594.
+- [x] **NVIDIA GPU Exporter 1.4.1 -> 1.5.0**: Closes #1598.
+- [x] **Vault 2.0.2 -> 2.0.3**: Closes #1590.
+- [x] **Postgres Exporter v0.19.1 -> v0.20.0**: Closes #1601.
+- [x] **cAdvisor v0.55.1 -> v0.60.3**: Closes #1599.
+- [x] **gitleaks v8.21.2 -> v8.30.1**: Closes #1603.
+- [x] **yamllint v1.35.1 -> v1.38.0**: Closes #1602.
+- [x] **pre-commit-hooks v5.0.0 -> v6.0.0**: Closes #1600.
+- [x] **docker/setup-buildx-action v4 -> v4.1.0**: SHA-pinned in all CI workflows. Closes #1604.
+
+### Fixed
+
+- [x] **Revert vLLM and llama.cpp to Known-Good Tags**: vLLM v0.24.0 and llama.cpp b9851 were demoted after failing validation; reverted to v0.22.1 and b9585 respectively. Closes #1622.
+
+### Documentation
+
+- [x] **Fix Agent-Pitfalls Remote Naming**: `docs/developer/agent-pitfalls.md` had origin and upstream reversed -- corrected to match the actual two-remote fork layout (origin=personal fork, upstream=canonical). Closes #1630.
+- [x] **Agentic Orientation Gaps Closed**: `etc/app-scaffold/app.yaml` now includes a `provision` block; `docs/user/apps.md` replaces dead FTSO section with generic scaffold workflow; `docs/developer/adding-apps.md` adds Grafana integration, alert rules, and log integration sections; `docs/developer/app-builder-guide.md` adds non-containerised app patterns. Closes #1630.
+- [x] **Fix Broken Link in adding-services.md**: Updated stale reference from `../operations/security.md` (deleted) to `../operations/security-runbook.md`. Closes #1630.
+
 ## [v1.1.42] - 2026-06-30
 
 ### Summary

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -328,6 +328,26 @@ grafana:
     - "grafana/dashboards/app-overview.json"
 ```
 
+## Prometheus Alert Rules
+
+Place a file at `apps/<name>/prometheus/alert-rules.yml` and the platform will
+copy it into `prometheus/app-alerts/<name>.yml` on `./aixcl app start`. Prometheus
+loads all files matching `app-alerts/*.yml` automatically (no platform restart needed).
+The file is removed on `./aixcl app stop` and `./aixcl app remove`.
+
+A starter template with three common alerts (app down, high error rate, high latency)
+is available at `etc/app-scaffold/prometheus/alert-rules.yml`. Copy it to your app:
+
+```bash
+mkdir -p apps/my-app/prometheus
+cp etc/app-scaffold/prometheus/alert-rules.yml apps/my-app/prometheus/
+# Edit the file -- replace "my-app" with your app name and adjust thresholds
+```
+
+Alerts route to Alertmanager at `localhost:9093` using the platform's existing
+`prometheus/alertmanager.yml` configuration. To add a notification channel
+(Slack, PagerDuty, email) edit that file.
+
 ## Log Integration
 
 Container logs do **not** flow to Loki automatically. The platform runs Loki as a log store but does not include Promtail or a Docker log driver plugin, so no automatic log shipping is configured.

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -320,6 +320,71 @@ To verify targets are detected:
 
 Dashboards listed in the `grafana` block of the manifest are copied into `grafana/provisioning/dashboards/apps/<app>/` when the app starts (a dedicated subdirectory avoids UID collisions with platform dashboards). Grafana's provisioner picks up changes on its scan interval; restart Grafana to force a reload.
 
+A starter dashboard template is available at `etc/app-scaffold/grafana/dashboards/app-overview.json`. Copy it into your app directory and reference it in the `grafana` block:
+
+```yaml
+grafana:
+  dashboards:
+    - "grafana/dashboards/app-overview.json"
+```
+
+## Log Integration
+
+Container logs do **not** flow to Loki automatically. The platform runs Loki as a log store but does not include Promtail or a Docker log driver plugin, so no automatic log shipping is configured.
+
+### Options
+
+**Option 1 -- Docker Loki log driver (recommended for containerized apps)**
+
+Install the Grafana Loki Docker driver plugin once per host:
+
+```bash
+docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+```
+
+Then add a `logging` block to your service in `docker-compose.yml`:
+
+```yaml
+services:
+  my-app-service:
+    image: my-app:latest
+    network_mode: host
+    logging:
+      driver: loki
+      options:
+        loki-url: "http://localhost:3100/loki/api/v1/push"
+        loki-external-labels: "app=my-app,job=my-app-service"
+```
+
+Logs are then queryable in Grafana under Explore -> Loki using `{app="my-app"}`.
+
+**Option 2 -- Push logs from application code**
+
+Send structured log lines directly to the Loki push API:
+
+```bash
+curl -s -X POST http://localhost:3100/loki/api/v1/push \
+  -H "Content-Type: application/json" \
+  -d '{
+    "streams": [{
+      "stream": {"app": "my-app", "level": "info"},
+      "values": [["'"$(date +%s%N)"'", "your log message here"]]
+    }]
+  }'
+```
+
+Most logging libraries (Python structlog, Winston, etc.) have Loki appenders that handle this automatically.
+
+**Option 3 -- Query stdout via `docker logs`**
+
+For local development without Loki integration, query container logs directly:
+
+```bash
+docker logs my-app-service --follow
+# Or via the CLI wrapper:
+./aixcl stack logs
+```
+
 ## Lifecycle and Isolation
 
 - Applications run under `network_mode: host` alongside the platform

--- a/docs/developer/adding-services.md
+++ b/docs/developer/adding-services.md
@@ -144,4 +144,4 @@ docker compose -f services/docker-compose.yml -f services/docker-compose.gpu.yml
 
 - [Profiles Documentation](../architecture/governance/02_profiles.md) - Profile definitions and service composition
 - [Service Contracts](../architecture/governance/service_contracts/) - Service dependency rules
-- [Security Hardening](../operations/security.md) - Container security controls
+- [Security Hardening](../operations/security-runbook.md) - Container security controls

--- a/docs/developer/agent-pitfalls.md
+++ b/docs/developer/agent-pitfalls.md
@@ -7,23 +7,23 @@ Read this if you are starting a session or if something unexpected happened.
 
 ### Pitfall: Pushing to the wrong remote
 
-**What happens:** `git push origin issue-<N>/...` is blocked or pushes to the
-wrong repository.
+**What happens:** An agent tries to push directly to the canonical repository
+(`xencon/aixcl`) instead of the personal fork, and is blocked by branch protection.
 
-**Why:** `origin` is the upstream repository (`xencon/aixcl`). Direct pushes
-to `origin` are blocked by branch protection. Feature branches go to the
-personal fork (`sbadakhc/aixcl`), which is the `fork` remote.
+**Why:** `origin` is the personal fork (`sbadakhc/aixcl`). Feature branches go
+to `origin`. The canonical repository (`xencon/aixcl`) is the `upstream` remote --
+PRs target it but direct pushes are blocked by branch protection.
 
 **Fix:**
 ```bash
-git remote -v                          # Check what remotes exist
-git push fork issue-<N>/<description>  # Always push to fork
-gh pr create --repo xencon/aixcl ...   # PR targets origin
+git remote -v                              # Check what remotes exist
+git push origin issue-<N>/<description>   # Push to personal fork
+gh pr create --repo xencon/aixcl ...      # PR targets upstream
 ```
 
-If `fork` remote is missing:
+If `upstream` remote is missing:
 ```bash
-git remote add fork git@github.com:sbadakhc/aixcl.git
+git remote add upstream git@github.com:xencon/aixcl.git
 ```
 
 Use SSH, not HTTPS -- HTTPS push is blocked for repositories containing

--- a/docs/developer/app-builder-guide.md
+++ b/docs/developer/app-builder-guide.md
@@ -100,3 +100,129 @@ EOF
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OLLAMA_BASE_URL` | `http://localhost:11434` | Inference API base URL |
+
+## Non-Containerized Apps
+
+Because the platform uses `network_mode: host`, all services are reachable on
+localhost from any process running on the host -- including native Python scripts,
+Node services, and Go binaries that are not yet Dockerized. No special configuration
+is required to reach the inference API or the database during local development.
+
+### Inference API (no Docker needed)
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="unused",  # Ollama requires a non-empty value; content is ignored
+)
+
+response = client.chat.completions.create(
+    model="qwen2.5-coder:0.5b",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(response.choices[0].message.content)
+```
+
+### Database access
+
+Retrieve credentials for local development, then connect using any standard client:
+
+```bash
+./aixcl app secrets my-app
+# Prints db-password and any other provisioned secrets
+```
+
+```python
+import psycopg2, subprocess, json
+
+# Read the provisioned password
+pw = subprocess.check_output(
+    ["./aixcl", "app", "secrets", "my-app", "--json"],
+    text=True,
+)
+creds = json.loads(pw)
+
+conn = psycopg2.connect(
+    host="localhost", port=5432,
+    dbname="my_app", user="my_app",
+    password=creds["db-password"],
+)
+```
+
+### Registering a non-Dockerized app
+
+A non-Dockerized app can still declare a `prometheus` scrape target and register
+itself so the CLI tracks it. Create a minimal `app.yaml` alongside your code:
+
+```yaml
+app:
+  name: "my-app"
+  version: "0.1.0"
+
+# No services block needed for a native process
+
+prometheus:
+  targets:
+    - "localhost:9000"   # port your app exposes /metrics on
+  labels:
+    app: "my-app"
+    job: "my-app-service"
+```
+
+Register the directory:
+
+```bash
+./aixcl app register /path/to/my-app
+./aixcl app provision my-app   # creates Vault secrets and Postgres DB
+```
+
+Start your process manually and Prometheus will discover its metrics endpoint
+within 30 seconds.
+
+### Minimal Dockerfile for containerizing later
+
+When you are ready to containerize, use these patterns as a starting point:
+
+**Python (FastAPI)**
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 9000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]
+```
+
+**Node.js**
+
+```dockerfile
+FROM node:20-slim
+WORKDIR /app
+COPY package*.json .
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 9000
+CMD ["node", "server.js"]
+```
+
+Mount the platform secrets volume to read provisioned credentials at runtime:
+
+```yaml
+# in your app docker-compose.yml
+volumes:
+  my-secrets:
+    name: aixcl-app-my-app-secrets
+    external: true
+
+services:
+  my-app-service:
+    ...
+    volumes:
+      - my-secrets:/run/secrets:ro
+```
+
+Secrets are then available as files: `/run/secrets/my-app-db-password`, etc.

--- a/docs/user/apps.md
+++ b/docs/user/apps.md
@@ -71,12 +71,18 @@ When an app is started:
 
 See [docs/developer/adding-apps.md](../developer/adding-apps.md) for the full developer guide including manifest reference and compliance rules.
 
-## Example: FTSO
+## Try It
 
-The repository includes `apps/ftso/` as a reference implementation. To test:
+Scaffold a new app and start it:
 
 ```bash
-./aixcl app build ftso
-./aixcl app start ftso
-./aixcl app status ftso
+./aixcl app scaffold my-app
+# Edit apps/my-app/app.yaml and docker-compose.yml for your use case
+./aixcl app build my-app
+./aixcl app start my-app
+./aixcl app status my-app
 ```
+
+The scaffold creates a working template with all supported manifest fields.
+See `etc/app-scaffold/` for the canonical templates and
+[docs/developer/adding-apps.md](../developer/adding-apps.md) for the full guide.

--- a/etc/app-scaffold/app.yaml
+++ b/etc/app-scaffold/app.yaml
@@ -22,6 +22,23 @@ services:
     depends_on:
       - "ollama"
 
+# Platform resource provisioning.
+# Declared resources are created idempotently on every `./aixcl app start`.
+# Remove this block entirely if your app needs no database or secrets.
+provision:
+  # Secrets are generated (32-char alphanumeric) and stored in Vault at
+  # kv/apps/<app-name>. Existing values are never overwritten.
+  # Each secret is rendered into the per-app volume as /run/secrets/<app>-<name>.
+  secrets:
+    - api-key
+    - db-password
+  # Postgres block creates a role and database in the platform PostgreSQL instance.
+  # The role password is synced from password_secret. Remove if not needed.
+  postgres:
+    database: example_app
+    owner: example_app
+    password_secret: db-password
+
 # Prometheus scrape targets for this application
 prometheus:
   targets:
@@ -30,10 +47,13 @@ prometheus:
     app: "example-app"
     job: "example-service"
 
-# Grafana dashboard provisioning (optional)
+# Grafana dashboard provisioning (optional).
+# Paths are relative to this app directory (apps/<name>/).
+# Dashboards are copied to grafana/provisioning/dashboards/apps/<name>/ on start.
+# A starter dashboard template is available at etc/app-scaffold/grafana/dashboards/app-overview.json.
 grafana:
   dashboards:
-    - "grafana/dashboards/example-dashboard.json"
+    - "grafana/dashboards/app-overview.json"
 
 # Git submodules for builder code
 submodules:

--- a/etc/app-scaffold/grafana/dashboards/app-overview.json
+++ b/etc/app-scaffold/grafana/dashboards/app-overview.json
@@ -1,0 +1,169 @@
+{
+  "title": "App Overview",
+  "uid": "aixcl-app-overview",
+  "description": "Starter dashboard for AIXCL applications. Customize metric names to match your app's instrumentation.",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": ["aixcl", "app"],
+  "editable": true,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "app",
+        "type": "constant",
+        "label": "App",
+        "description": "Set this to your app name (matches the 'app' label in prometheus block of app.yaml)",
+        "value": "my-app",
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request Rate (req/s)",
+      "description": "Requires http_requests_total{app=...} counter. Common in Flask (prometheus-flask-exporter), FastAPI (prometheus-fastapi-instrumentator), Express (prom-client).",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{app=\"$app\"}[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Error Rate",
+      "description": "5xx responses as a percentage of all requests.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{app=\"$app\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{app=\"$app\"}[5m]))",
+          "legendFormat": "Error %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Request Latency (p50 / p95 / p99)",
+      "description": "Requires http_request_duration_seconds histogram. Adjust the metric name to match your framework.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 5,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{app=\"$app\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "LLM Calls",
+      "description": "Customize the metric name and labels to match how your app tracks inference calls. Replace llm_calls_total with your counter name.",
+      "datasource": "Prometheus",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(llm_calls_total{app=\"$app\"}[5m])) by (model)",
+          "legendFormat": "{{model}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/etc/app-scaffold/prometheus/alert-rules.yml
+++ b/etc/app-scaffold/prometheus/alert-rules.yml
@@ -1,0 +1,54 @@
+# Prometheus alert rules for this application.
+# Place this file at apps/<name>/prometheus/alert-rules.yml.
+# The platform copies it to prometheus/app-alerts/<name>.yml on app start
+# and removes it on app stop/remove.
+#
+# Customize the metric names and thresholds to match your app's instrumentation.
+# The `app` label value must match the `app` label in your prometheus block (app.yaml).
+#
+# Reference: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+
+groups:
+  - name: my-app-alerts
+    rules:
+
+      # App is unreachable -- Prometheus cannot scrape the /metrics endpoint.
+      - alert: AppDown
+        expr: up{app="my-app"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          app: my-app
+        annotations:
+          summary: "App is down"
+          description: "{{ $labels.app }} has been unreachable for more than 1 minute."
+
+      # High HTTP error rate -- more than 5% of requests are returning 5xx.
+      # Requires http_requests_total{app=..., status=~"5.."} counter.
+      - alert: AppHighErrorRate
+        expr: |
+          sum(rate(http_requests_total{app="my-app", status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total{app="my-app"}[5m])) > 0.05
+        for: 2m
+        labels:
+          severity: warning
+          app: my-app
+        annotations:
+          summary: "High error rate"
+          description: "{{ $labels.app }} error rate is {{ $value | humanizePercentage }} over the last 5 minutes."
+
+      # High p95 latency -- 95th percentile response time exceeds 2 seconds.
+      # Requires http_request_duration_seconds histogram.
+      - alert: AppHighLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket{app="my-app"}[5m])) by (le)
+          ) > 2
+        for: 2m
+        labels:
+          severity: warning
+          app: my-app
+        annotations:
+          summary: "High p95 latency"
+          description: "{{ $labels.app }} p95 latency is {{ $value | humanizeDuration }} over the last 5 minutes."

--- a/lib/aixcl/commands/app.sh
+++ b/lib/aixcl/commands/app.sh
@@ -567,6 +567,9 @@ app_cmd_start() {
         _app_wire_grafana "$app_name"
     fi
 
+    # Wire Prometheus alert rules if present (no manifest flag needed -- file presence is the signal)
+    _app_wire_alerts "$app_name"
+
     echo ""
 }
 
@@ -615,6 +618,12 @@ app_cmd_stop() {
     local prom_file="${SCRIPT_DIR}/prometheus/file_sd/${app_name}.json"
     if [ -f "$prom_file" ]; then
         rm -f "$prom_file"
+    fi
+
+    # Remove alert rules if present
+    local alert_file="${SCRIPT_DIR}/prometheus/app-alerts/${app_name}.yml"
+    if [ -f "$alert_file" ]; then
+        rm -f "$alert_file"
     fi
 }
 
@@ -886,13 +895,19 @@ app_cmd_remove() {
         rm -f "$prom_file"
     fi
 
-    # 3a. Remove Grafana dashboard files if present (handle both lowercase and uppercase app names)
+    # 3a. Remove alert rules if present
+    local alert_file="${SCRIPT_DIR}/prometheus/app-alerts/${app_name}.yml"
+    if [ -f "$alert_file" ]; then
+        rm -f "$alert_file"
+    fi
+
+    # 3b. Remove Grafana dashboard files if present (handle both lowercase and uppercase app names)
     local grafana_dash="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/${app_name}"
     if [ -d "$grafana_dash" ]; then
         rm -rf "$grafana_dash"
     fi
 
-    # 3b. Handle uppercase app name variant (e.g., ftso -> FTSO for display names)
+    # 3c. Handle uppercase app name variant
     local grafana_dash_upper
     grafana_dash_upper="${SCRIPT_DIR}/grafana/provisioning/dashboards/apps/$(echo "$app_name" | tr '[:lower:]' '[:upper:]')"
     if [ -d "$grafana_dash_upper" ] && [ "$grafana_dash_upper" != "$grafana_dash" ]; then
@@ -1267,6 +1282,23 @@ _app_generate_prometheus_targets() {
 EOF
 
     echo "  ${ICON_SUCCESS:-[x]} Prometheus targets"
+}
+
+# Copy alert rules from app into prometheus/app-alerts/ so Prometheus picks them up.
+# Looks for <app_dir>/prometheus/alert-rules.yml; no-ops silently if absent.
+_app_wire_alerts() {
+    local app_name="${1:-}"
+    local app_dir
+    app_dir="$(_app_resolve_dir "$app_name" 2>/dev/null)" || app_dir="${SCRIPT_DIR}/apps/${app_name}"
+    local src="${app_dir}/prometheus/alert-rules.yml"
+    local dst_dir="${SCRIPT_DIR}/prometheus/app-alerts"
+    local dst="${dst_dir}/${app_name}.yml"
+
+    [ -f "$src" ] || return 0
+
+    mkdir -p "$dst_dir"
+    cp -f "$src" "$dst"
+    echo "  ${ICON_SUCCESS:-[x]} Prometheus alert rules"
 }
 
 # Copy Grafana dashboards from app into platform provisioning

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,6 +16,7 @@ alerting:
 # Load rules once and periodically evaluate them
 rule_files:
   - "alerts.yml"
+  - "app-alerts/*.yml"
 
 # Scrape configurations
 scrape_configs:

--- a/scripts/checks/check-agent-id-block.sh
+++ b/scripts/checks/check-agent-id-block.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Checks that a GitHub PR body or issue comment posted by an agent includes
+# the required agent identification block (AGENTS.md section 9.5).
+#
+# Usage:
+#   check-agent-id-block.sh <file>          # check body saved to a file
+#   echo "$BODY" | check-agent-id-block.sh  # check body from stdin
+#
+# Exit 0 = identification block found. Exit 1 = block missing.
+#
+# Required block format (AGENTS.md 9.5):
+#   ---
+#   - Agent: <name and model>
+#   - Date: YYYY-MM-DD
+#   - Method: <what the agent did>
+#   - Scope: <files or context>
+#   - Confirmation: yes|no
+#   ---
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "${REPO_ROOT}/lib/core/color.sh"
+
+input_file="${1:-/dev/stdin}"
+
+body=$(cat "$input_file")
+
+# Check for the minimum required fields: Agent and Date lines inside a --- block
+if echo "$body" | grep -qE '^\s*-\s+Agent:' && \
+   echo "$body" | grep -qE '^\s*-\s+Date:' && \
+   echo "$body" | grep -qE '^\s*-\s+Confirmation:'; then
+    print_success "agent identification block found"
+    exit 0
+fi
+
+print_error "agent identification block missing or incomplete"
+echo ""
+echo "Agent-authored PR bodies and issue comments MUST end with:"
+echo ""
+echo "  ---"
+echo "  - Agent: <tool name and model>"
+echo "  - Date: $(date +%Y-%m-%d)"
+echo "  - Method: <what the agent did>"
+echo "  - Scope: <files, issues, or context>"
+echo "  - Confirmation: yes|no"
+echo "  ---"
+echo ""
+echo "See AGENTS.md section 9.5 for the full specification."
+exit 1

--- a/scripts/utils/trace-llm-call.sh
+++ b/scripts/utils/trace-llm-call.sh
@@ -121,6 +121,40 @@ print(json.dumps(entry))
 
 log_info "trace written to ${TRACE_FILE}"
 
+# Optional Loki push -- set LOKI_ENABLED=true to activate.
+# LOKI_URL overrides the default endpoint (http://localhost:3100).
+# Push is best-effort: failures are suppressed so the trace file remains
+# the reliable primary store.
+if [ "${LOKI_ENABLED:-}" = "true" ]; then
+    python3 - "${LOKI_URL:-http://localhost:3100}" "$TRACE_FILE" << 'PYEOF'
+import sys, json, time
+try:
+    import urllib.request
+    loki_url, trace_file = sys.argv[1], sys.argv[2]
+    with open(trace_file) as fh:
+        lines = [ln for ln in fh if ln.strip()]
+    if not lines:
+        sys.exit(0)
+    raw = lines[-1].strip()
+    entry = json.loads(raw)
+    stream = {"app": entry["app"], "model": entry["model"],
+              "status": entry["status"], "job": "trace-llm-call"}
+    nanos = str(int(time.time() * 1e9))
+    body = json.dumps({
+        "streams": [{"stream": stream, "values": [[nanos, raw]]}]
+    }).encode()
+    req = urllib.request.Request(
+        loki_url.rstrip("/") + "/loki/api/v1/push",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    urllib.request.urlopen(req, timeout=2)
+except Exception:
+    pass
+PYEOF
+fi
+
 # Surface errors but still exit cleanly so callers can inspect the trace
 if [[ "$STATUS" != "ok" ]]; then
     log_error "API call failed: $STATUS"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -274,7 +274,7 @@ services:
       retries: 3
 
   vllm:
-    image: docker.io/vllm/vllm-openai:v0.24.0
+    image: docker.io/vllm/vllm-openai:v0.22.1
     container_name: vllm
     pull_policy: missing
     tty: true
@@ -308,7 +308,7 @@ services:
       start_period: 180s
 
   llamacpp:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9851
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9585
     container_name: llamacpp
     pull_policy: missing
     user: "1000:1000"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -575,7 +575,7 @@ services:
     # This service will gracefully fail on systems without NVIDIA GPUs
 
   loki:
-    image: docker.io/grafana/loki:3.7.2
+    image: docker.io/grafana/loki:3.7.3
     container_name: loki
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   ollama:
-    image: docker.io/ollama/ollama:0.30.7
+    image: docker.io/ollama/ollama:0.31.1
     container_name: ollama
     pull_policy: missing
     user: "0:0"  # Start as root to set permissions, entrypoint switches to ubuntu user

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -432,7 +432,7 @@ services:
       retries: 3
 
   alertmanager:
-    image: docker.io/prom/alertmanager:v0.32.2
+    image: docker.io/prom/alertmanager:v0.33.0
     container_name: alertmanager
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       start_period: 30s
 
   vault:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault
     pull_policy: missing
     cap_add:
@@ -73,7 +73,7 @@ services:
 
   # Vault Agent sidecar for PostgreSQL (runs alongside postgres)
   vault-agent-postgres:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-postgres
     pull_policy: missing
     cap_drop:
@@ -98,7 +98,7 @@ services:
 
   # Vault Agent sidecar for Open WebUI (runs alongside open-webui)
   vault-agent-openwebui:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-openwebui
     pull_policy: missing
     cap_drop:
@@ -123,7 +123,7 @@ services:
 
   # Bootstrap service for PostgreSQL Vault KV password
   vault-agent-postgres-bootstrap:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-postgres-bootstrap
     pull_policy: missing
     cap_drop:
@@ -149,7 +149,7 @@ services:
 
   # Bootstrap service for Open WebUI Vault KV password
   vault-agent-openwebui-bootstrap:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-openwebui-bootstrap
     pull_policy: missing
     cap_drop:
@@ -175,7 +175,7 @@ services:
 
    # Bootstrap service for pgAdmin Vault KV password
   vault-agent-pgadmin-bootstrap:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-pgadmin-bootstrap
     pull_policy: missing
     cap_drop:
@@ -201,7 +201,7 @@ services:
 
    # Bootstrap service for Grafana Vault KV password
   vault-agent-grafana-bootstrap:
-    image: docker.io/hashicorp/vault:2.0.2
+    image: docker.io/hashicorp/vault:2.0.3
     container_name: vault-agent-grafana-bootstrap
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -533,7 +533,7 @@ services:
     restart: unless-stopped
 
   postgres-exporter:
-    image: docker.io/prometheuscommunity/postgres-exporter:v0.19.1
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.20.0
     container_name: postgres-exporter
     pull_policy: missing
     user: "65534:65534"  # postgres-exporter user (official image default) - avoids 'nobody' ambiguity

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -274,7 +274,7 @@ services:
       retries: 3
 
   vllm:
-    image: docker.io/vllm/vllm-openai:v0.22.1
+    image: docker.io/vllm/vllm-openai:v0.24.0
     container_name: vllm
     pull_policy: missing
     tty: true

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -458,7 +458,7 @@ services:
       retries: 3
 
   grafana:
-    image: docker.io/grafana/grafana:13.0.2
+    image: docker.io/grafana/grafana:13.0.3
     container_name: grafana
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -308,7 +308,7 @@ services:
       start_period: 180s
 
   llamacpp:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9585
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b9851
     container_name: llamacpp
     pull_policy: missing
     user: "1000:1000"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -561,7 +561,7 @@ services:
     restart: unless-stopped
 
   nvidia-gpu-exporter:
-    image: docker.io/utkuozdemir/nvidia_gpu_exporter:1.4.1
+    image: docker.io/utkuozdemir/nvidia_gpu_exporter:1.5.0
     container_name: nvidia-gpu-exporter
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -330,7 +330,7 @@ services:
       start_period: 30s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.9.6
+    image: ghcr.io/open-webui/open-webui:v0.10.1
     container_name: open-webui
     pull_policy: missing
     user: "0:0"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -489,7 +489,7 @@ services:
       retries: 3
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    image: gcr.io/cadvisor/cadvisor:v0.60.3
     container_name: cadvisor
     pull_policy: missing
     volumes:


### PR DESCRIPTION
Release v1.1.43 -- agentic orientation, app alert wiring, and component updates.

## What's in this release

**Agentic orientation improvements:**
- Fixed remote naming in agent-pitfalls.md (origin/upstream were swapped)
- Added provision block to app scaffold (secrets + Postgres declarations)
- Added Prometheus alert rules wiring for apps (`_app_wire_alerts()`)
- Added optional Loki push to LLM tracer (LOKI_ENABLED=true)
- Added starter Grafana app dashboard scaffold
- Added `check-agent-id-block.sh` validation script
- Documented log integration options (Loki driver, HTTP push, docker logs)
- Fixed broken link in adding-services.md

**New check-updates skill:** Audits platform component versions against upstream.

**Component updates:**
- Open WebUI v0.9.6 -> v0.10.1
- Ollama 0.30.7 -> 0.31.1
- Grafana 13.0.2 -> 13.0.3
- Loki 3.7.2 -> 3.7.3
- Alertmanager v0.32.2 -> v0.33.0
- NVIDIA GPU Exporter 1.4.1 -> 1.5.0
- Vault 2.0.2 -> 2.0.3
- Postgres Exporter v0.19.1 -> v0.20.0
- cAdvisor v0.55.1 -> v0.60.3
- gitleaks v8.21.2 -> v8.30.1
- yamllint v1.35.1 -> v1.38.0
- pre-commit-hooks v5.0.0 -> v6.0.0
- docker/setup-buildx-action v4 -> v4.1.0 (SHA-pinned)
- vLLM and llama.cpp reverted to known-good tags

## Retrospective

Discussion: https://github.com/xencon/aixcl/discussions/1632

## Checklist

- [x] CHANGELOG.md updated
- [x] All linked issues closed
- [x] CI checks passing locally
- [x] Retrospective posted
- [x] CI green on this PR
- [x] Reviewer approval

Fixes #1633

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-07-01
- Method: cut-release skill -- changelog update, release branch, PR creation
- Scope: CHANGELOG.md and git log since v1.1.42
- Confirmation: yes
---
