### PR TITLE
Fix cAdvisor registry migration from gcr.io to ghcr.io (#1637)

### DIFF
--- a/.claude/skills/check-updates/SKILL.md
+++ b/.claude/skills/check-updates/SKILL.md
@@ -45,7 +45,7 @@ grep "image:" services/docker-compose.yml | grep -v "#" | \
 | Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
 | Grafana | `grafana/grafana:<tag>` | GitHub releases |
 | Loki | `grafana/loki:<tag>` | GitHub releases |
-| cAdvisor | `gcr.io/cadvisor/cadvisor:<tag>` | GitHub releases |
+| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
 | Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
 | Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
 | NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |

--- a/.opencode/skills/check-updates/SKILL.md
+++ b/.opencode/skills/check-updates/SKILL.md
@@ -45,7 +45,7 @@ grep "image:" services/docker-compose.yml | grep -v "#" | \
 | Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
 | Grafana | `grafana/grafana:<tag>` | GitHub releases |
 | Loki | `grafana/loki:<tag>` | GitHub releases |
-| cAdvisor | `gcr.io/cadvisor/cadvisor:<tag>` | GitHub releases |
+| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
 | Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
 | Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
 | NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -489,7 +489,7 @@ services:
       retries: 3
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.60.3
+    image: ghcr.io/google/cadvisor:v0.60.3
     container_name: cadvisor
     pull_policy: missing
     volumes:


### PR DESCRIPTION
Fix cAdvisor image pull failure caused by upstream registry migration.

## Root Cause

The cAdvisor project migrated container image publishing from `gcr.io/cadvisor/cadvisor` to `ghcr.io/google/cadvisor` at v0.53.0. The project README states:

```
ghcr.io/google/cadvisor:$VERSION # for versions prior to v0.53.0, use gcr.io/cadvisor/cadvisor instead
```

The `publish-container.yml` workflow in `google/cadvisor` confirms the image is pushed to `ghcr.io/google/cadvisor` using `secrets.GITHUB_TOKEN` -- only the official `google` GitHub org can publish to that namespace. Supply chain verified safe.

Tags v0.53.0+ do not exist on gcr.io, so `gcr.io/cadvisor/cadvisor:v0.60.3` fails with `manifest unknown`.

## Changes

- `services/docker-compose.yml`: image `gcr.io/cadvisor/cadvisor:v0.60.3` -> `ghcr.io/google/cadvisor:v0.60.3`
- `.claude/skills/check-updates/SKILL.md`: update source registry reference
- `.opencode/skills/check-updates/SKILL.md`: mirror update

## Checklist

- [x] Registry migration verified against upstream `publish-container.yml` workflow
- [x] `ghcr.io/google/cadvisor` confirmed published by official `google` GitHub org
- [x] check-updates skill source table updated in both mirrors
- [ ] `./aixcl stack status` shows cAdvisor healthy after merge (human verification)

Fixes #1637

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-07-01
- Method: registry verification via gh CLI (google/cadvisor publish-container.yml workflow inspection)
- Scope: services/docker-compose.yml, .claude/skills/check-updates/SKILL.md, .opencode/skills/check-updates/SKILL.md
- Confirmation: yes
---
