### PR TITLE
Fix engine auto missing INFERENCE_ENGINE write and test-02 label (#1639)

### DIFF
--- a/lib/aixcl/commands/engine.sh
+++ b/lib/aixcl/commands/engine.sh
@@ -119,6 +119,14 @@ function engine() {
 
         echo "Auto-detected engine: $engine"
 
+        # Write detected engine to .env
+        if grep -qE "^[[:space:]]*#?INFERENCE_ENGINE=" "${SCRIPT_DIR}/.env" 2>/dev/null; then
+            sed -i "s/^[[:space:]]*#*INFERENCE_ENGINE=.*/INFERENCE_ENGINE=$engine/" "${SCRIPT_DIR}/.env"
+        else
+            echo "INFERENCE_ENGINE=$engine" >> "${SCRIPT_DIR}/.env"
+        fi
+        echo "[x] Inference engine set to: $engine"
+
         # Configure Open WebUI Ollama API setting based on auto-detected engine
         if [ "$engine" = "ollama" ]; then
             local enable_ollama="true"

--- a/tests/command-tests/test-02-stack-status.sh
+++ b/tests/command-tests/test-02-stack-status.sh
@@ -30,7 +30,7 @@ if echo "$STATUS_OUTPUT" | grep -q "Status: Running"; then
     log_info "Stack is running -- asserting bootstrap container health"
 
     for bootstrap in \
-        "Vault Agent Bootstrap (PostgreSQL)" \
+        "Vault Agent Bootstrap (Postgres)" \
         "Vault Agent Bootstrap (Open WebUI)" \
         "Vault Agent Bootstrap (pgAdmin)" \
         "Vault Agent Bootstrap (Grafana)"; do


### PR DESCRIPTION
Fix two bugs found during test parity run against the live stack.

## Changes

**Bug 1 -- engine auto missing INFERENCE_ENGINE write (lib/aixcl/commands/engine.sh):**
The `auto` action detected the optimal engine but never wrote `INFERENCE_ENGINE` to `.env`. It only wrote `ENABLE_OLLAMA_API`. The `set` action includes this write; `auto` did not. Added the missing block mirroring `set`.

**Bug 2 -- test-02 bootstrap label mismatch (tests/command-tests/test-02-stack-status.sh):**
Test expected `Vault Agent Bootstrap (PostgreSQL)` but stack status emits `Vault Agent Bootstrap (Postgres)` (derived from container name `vault-agent-postgres-bootstrap` via title-case). Updated test string to match actual output.

## How bugs were found

Discovered during live stack test parity run (test suite run against running stack with vLLM/llama.cpp excluded).

## Checklist

- [x] `./aixcl engine auto` now writes `INFERENCE_ENGINE=<engine>` to `.env`
- [x] test-02 bootstrap label updated to match actual stack status output
- [x] shellcheck passed
- [ ] test-06-engine-auto.sh passes (human verification)
- [ ] test-02-stack-status.sh passes (human verification)

Fixes #1639

---
- Agent: Claude Code (claude-sonnet-4-6)
- Date: 2026-07-01
- Method: live test run, source code inspection of lib/aixcl/commands/engine.sh
- Scope: lib/aixcl/commands/engine.sh, tests/command-tests/test-02-stack-status.sh
- Confirmation: yes
---
