### PR TITLE
Honor mass-deletion bypass token in CI elision check (#1650)

### DIFF
--- a/scripts/checks/check-ai-elisions.sh
+++ b/scripts/checks/check-ai-elisions.sh
@@ -16,6 +16,10 @@
 # check has no bypass -- reword the text instead):
 #   AIXCL_ALLOW_MASS_DELETE=1 check-ai-elisions.sh --staged
 #
+# In --range mode (CI), the deletion check is also skipped when a commit
+# message in the range contains the token AIXCL_ALLOW_MASS_DELETE. State
+# the intent in the commit message and CI will honor it.
+#
 # Markdown files are exempt: documentation legitimately discusses these
 # phrases, and elision damage matters most in source files.
 #
@@ -172,6 +176,14 @@ check_mass_deletions() {
 
     if [ "${AIXCL_ALLOW_MASS_DELETE:-}" = "1" ]; then
         print_skip "Mass-deletion check skipped (AIXCL_ALLOW_MASS_DELETE=1)"
+        return 0
+    fi
+
+    # Range mode (CI): honor the bypass token when it is spelled out in a
+    # commit message within the range. Same trust model as the env var --
+    # the author must state the intent, and it stays auditable in review.
+    if [ "$MODE" = "range" ] && git log --format=%B "${RANGE_A}..${RANGE_B}" 2>/dev/null | grep -q "AIXCL_ALLOW_MASS_DELETE"; then
+        print_skip "Mass-deletion check skipped (AIXCL_ALLOW_MASS_DELETE token in commit message)"
         return 0
     fi
 


### PR DESCRIPTION
The mass-deletion check in `scripts/checks/check-ai-elisions.sh` supports a local bypass (`AIXCL_ALLOW_MASS_DELETE=1`) for intentional rewrites, and its error text instructs the author to state the intent in the commit message. But the CI job runs the script in `--range` mode with no way to honor that, so a legitimately committed intentional rewrite fails CI permanently. This first surfaced on PR #1649, where the intentional rewrite of `lib/aixcl/commands/engine.sh` trips the check.

## Change

In `--range` mode (used by CI), the mass-deletion check is now skipped when a commit message in the range contains the explicit token `AIXCL_ALLOW_MASS_DELETE`. This mirrors the trust model of the local env var bypass: the author must spell out the token, making the intent auditable in review. The local env var bypass is unchanged, and the placeholder-text check remains non-bypassable.

## Verification

- [x] shellcheck and bash -n pass
- [x] Range without token still fails on a mass deletion (tested against the PR #1649 diff)
- [x] Range whose commit message contains the token skips the deletion check and passes
- [x] Placeholder-text check still runs in both cases

Fixes #1650

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-01
- Method: script edit with positive and negative local testing
- Scope: scripts/checks/check-ai-elisions.sh
- Confirmation: yes
---
