### PR TITLE
Add aixcl checks command for local CI parity (#1658)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -69,6 +69,8 @@ source "${SCRIPT_DIR}/lib/aixcl/commands/engine.sh"
 source "${SCRIPT_DIR}/lib/aixcl/commands/models.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/aixcl/commands/stack.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/aixcl/commands/checks.sh"
 
 # Vault command module
 # shellcheck disable=SC1091

--- a/lib/aixcl/cli.sh
+++ b/lib/aixcl/cli.sh
@@ -50,6 +50,18 @@ COMMANDS
         prune                                           Clean Docker resources (keeps images)
         prune --all                                     Full wipe including images
 
+    checks <action>
+        all                                             Run every local CI check with summary
+        paths                                           Documentation links and stale paths
+        agents                                          .claude/.opencode mirror parity
+        elisions                                        AI-elision placeholders, mass deletions
+        generated                                       Tracked generated files
+        ascii                                           Non-ASCII punctuation in markdown
+        yaml                                            yamllint over the repository
+        compose                                         Compose file validation
+        env                                             Environment prerequisites
+        pr-refs <file>                                  Issue/PR body reference style
+
     vault <action>
         start                                           Start Vault container
         stop                                            Stop Vault container

--- a/lib/aixcl/commands/checks.sh
+++ b/lib/aixcl/commands/checks.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Local CI parity checks for AIXCL
+# Fronts scripts/checks/* and inline CI checks so contributors and agents
+# have one entry point for pre-push validation: ./aixcl checks all
+
+# Track results for the summary table in `checks all`
+CHECKS_PASSED=()
+CHECKS_FAILED=()
+CHECKS_SKIPPED=()
+
+_checks_usage() {
+    echo "Usage: $0 checks {all|paths|agents|elisions|generated|ascii|yaml|compose|env|pr-refs <file>}"
+    echo "  all              Run every check below (continues on failure, prints summary)"
+    echo "  paths            Documentation relative links and stale path patterns"
+    echo "  agents           .claude/ vs .opencode/ rules and skills mirror parity"
+    echo "  elisions         AI-elision placeholders and suspicious mass deletions"
+    echo "  generated        Tracked generated files and stale artifacts"
+    echo "  ascii            Non-ASCII punctuation in markdown files"
+    echo "  yaml             yamllint over the repository"
+    echo "  compose          docker compose config validation (main + overrides)"
+    echo "  env              Environment prerequisites (same as utils check-env)"
+    echo "  pr-refs <file>   Issue/PR body reference style (one reference per line)"
+}
+
+_check_run() {
+    local name="$1"
+    shift
+    echo ""
+    echo "--- checks: $name ---"
+    if "$@"; then
+        CHECKS_PASSED+=("$name")
+        return 0
+    else
+        CHECKS_FAILED+=("$name")
+        return 1
+    fi
+}
+
+_check_skip() {
+    local name="$1"
+    local reason="$2"
+    echo ""
+    echo "--- checks: $name ---"
+    echo "   Skipped: $reason"
+    CHECKS_SKIPPED+=("$name")
+}
+
+_check_ascii() {
+    # Mirror of the bash-ci.yml ASCII markdown check
+    local matches
+    matches=$(grep -rlP "[\x{2013}\x{2014}\x{2018}\x{2019}\x{201C}\x{201D}\x{2026}\x{00A0}]" \
+        --include="*.md" --exclude-dir=.git "${SCRIPT_DIR}" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        echo "Non-ASCII punctuation found in:"
+        echo "$matches"
+        return 1
+    fi
+    echo "All markdown files use ASCII-only punctuation"
+    return 0
+}
+
+_check_compose() {
+    local main_compose="${SCRIPT_DIR}/services/docker-compose.yml"
+    "${DOCKER_BIN:-docker}" compose -f "$main_compose" config > /dev/null 2>&1 || {
+        echo "Main compose file invalid: $main_compose"
+        return 1
+    }
+    echo "Main compose file valid"
+
+    local override
+    for override in "${SCRIPT_DIR}"/services/docker-compose.*.yml; do
+        [ -f "$override" ] || continue
+        if "${DOCKER_BIN:-docker}" compose -f "$main_compose" -f "$override" config > /dev/null 2>&1; then
+            echo "Override valid: $(basename "$override")"
+        else
+            echo "Override invalid: $(basename "$override")"
+            return 1
+        fi
+    done
+    return 0
+}
+
+_checks_summary() {
+    echo ""
+    echo "========================================"
+    echo "Checks Summary"
+    echo "========================================"
+    local name
+    for name in "${CHECKS_PASSED[@]}"; do
+        echo "  ${ICON_SUCCESS:-[x]} $name"
+    done
+    for name in "${CHECKS_SKIPPED[@]}"; do
+        echo "  ${ICON_WARNING:-[!]} $name (skipped)"
+    done
+    for name in "${CHECKS_FAILED[@]}"; do
+        echo "  ${ICON_ERROR:-[ ]} $name FAILED"
+    done
+    echo ""
+    if [ "${#CHECKS_FAILED[@]}" -gt 0 ]; then
+        echo "${#CHECKS_FAILED[@]} check(s) failed"
+        return 1
+    fi
+    echo "All checks passed"
+    return 0
+}
+
+function checks_cmd() {
+    if [[ $# -lt 1 ]]; then
+        _checks_usage
+        return 1
+    fi
+
+    local action="$1"
+    shift
+
+    local checks_dir="${SCRIPT_DIR}/scripts/checks"
+
+    case "$action" in
+        paths)
+            bash "${checks_dir}/check-paths.sh"
+            ;;
+        agents)
+            bash "${checks_dir}/check-agents.sh"
+            ;;
+        elisions)
+            bash "${checks_dir}/check-ai-elisions.sh" "$@"
+            ;;
+        generated)
+            bash "${checks_dir}/check-generated-files.sh"
+            ;;
+        ascii)
+            _check_ascii
+            ;;
+        yaml)
+            if ! command -v yamllint > /dev/null 2>&1; then
+                echo "yamllint not installed (pip install yamllint)"
+                return 1
+            fi
+            yamllint -c "${SCRIPT_DIR}/.yamllint.yml" "${SCRIPT_DIR}"
+            ;;
+        compose)
+            _check_compose
+            ;;
+        env)
+            check_env
+            ;;
+        pr-refs)
+            local body_file="${1:-}"
+            if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
+                echo "Usage: $0 checks pr-refs <body-file>"
+                return 1
+            fi
+            bash "${checks_dir}/check-pr-references.sh" < "$body_file"
+            ;;
+        all)
+            CHECKS_PASSED=()
+            CHECKS_FAILED=()
+            CHECKS_SKIPPED=()
+
+            _check_run "paths" bash "${checks_dir}/check-paths.sh" || true
+            _check_run "agents" bash "${checks_dir}/check-agents.sh" || true
+            _check_run "elisions" bash "${checks_dir}/check-ai-elisions.sh" || true
+            _check_run "generated" bash "${checks_dir}/check-generated-files.sh" || true
+            _check_run "ascii" _check_ascii || true
+
+            if command -v yamllint > /dev/null 2>&1; then
+                _check_run "yaml" yamllint -c "${SCRIPT_DIR}/.yamllint.yml" "${SCRIPT_DIR}" || true
+            else
+                _check_skip "yaml" "yamllint not installed"
+            fi
+
+            if "${DOCKER_BIN:-docker}" info > /dev/null 2>&1; then
+                _check_run "compose" _check_compose || true
+            else
+                _check_skip "compose" "container engine not available"
+            fi
+
+            _check_run "env" check_env || true
+
+            _checks_summary
+            ;;
+        *)
+            echo "Error: Unknown checks action '$action'"
+            _checks_usage
+            return 1
+            ;;
+    esac
+}

--- a/lib/aixcl/dispatcher.sh
+++ b/lib/aixcl/dispatcher.sh
@@ -37,6 +37,10 @@ function main() {
             shift
             utils_cmd "$@"
             ;;
+        checks)
+            shift
+            checks_cmd "$@"
+            ;;
         stack)
             shift
             stack_cmd "$@"


### PR DESCRIPTION
Adds `./aixcl checks` -- a single CLI entry point for local CI parity, replacing seven memorized script paths. Part of the CLI alignment initiative: skills front CLI commands, CLI fronts scripts.

## Changes

- `lib/aixcl/commands/checks.sh` (new): `checks_cmd` dispatching to `scripts/checks/*` plus inline checks that previously lived only in CI workflow YAML:
  - `paths`, `agents`, `elisions`, `generated` -- front the existing check scripts
  - `ascii` -- non-ASCII punctuation in markdown (mirror of bash-ci.yml)
  - `yaml` -- yamllint over the repo
  - `compose` -- main compose plus every override combination
  - `env` -- existing `check_env` (same as `utils check-env`)
  - `pr-refs <file>` -- body reference style validation
  - `all` -- runs everything, continues on failure, prints a summary table, exits non-zero if any check failed; `yaml`/`compose` degrade to skipped when tooling is unavailable
- `lib/aixcl/dispatcher.sh`, `lib/aixcl/cli.sh`, `aixcl`: wiring and help text

## Testing

- `./aixcl checks all` runs the full sweep with correct summary and exit code (verified locally; the one failure it found was a genuine local `.env` gap, correctly reported)
- Individual subcommands map to their scripts and propagate exit codes
- shellcheck and `bash -n` clean

Completion and manpage updates for the new command land in the navigation sweep (#1662).

Fixes #1658

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-02
- Method: new CLI command module with local smoke testing
- Scope: aixcl entry point, lib/aixcl/, scripts/checks/ (read-only)
- Confirmation: yes
---
