### PR TITLE
Make issue and PR wrapper scripts fork-aware and non-interactive (#1660)

### DIFF
--- a/scripts/utils/create-issue.sh
+++ b/scripts/utils/create-issue.sh
@@ -3,6 +3,7 @@
 # Usage: ./scripts/utils/create-issue.sh "[TASK] Title" "task" "component:cli" "<github-username>"
 #
 # Benefits over manual gh issue create:
+# - Targets the canonical repo regardless of which clone you run from
 # - Uses /tmp for body files (never touches repo)
 # - Always uses --body-file (no backtick injection risk)
 # - Always sets --assignee (no PR validation race condition)
@@ -11,6 +12,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+
+# Canonical repository issues are filed against (override for forks of the fork)
+UPSTREAM_REPO="${AIXCL_UPSTREAM_REPO:-xencon/aixcl}"
 
 # Arguments
 TITLE="${1:-}"
@@ -69,6 +73,7 @@ echo "  Assignee: $ASSIGNEE"
 
 # Create the issue
 gh issue create \
+    --repo "$UPSTREAM_REPO" \
     --title "$TITLE" \
     --body-file "$BODY_FILE" \
     ${LABELS:+--label "$LABELS"} \

--- a/scripts/utils/create-pr.sh
+++ b/scripts/utils/create-pr.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # create-pr.sh — Safe pull request creation wrapper
-# Usage: ./scripts/utils/create-pr.sh "Title (#42)" "Fixes #42" "component:cli" "<github-username>"
+# Usage: ./scripts/utils/create-pr.sh "Title (#42)" "Fixes #42" "component:cli" "<github-username>" [base]
 #
 # Benefits over manual gh pr create:
+# - Targets the canonical repo and passes fork-aware --head automatically
 # - Always passes --assignee at creation time (no PR validation race condition)
 # - Always uses --body-file with /tmp (no backtick injection)
-# - Validates title format before creation
-# - Validates branch name format before creation
+# - Validates title format, branch name, and body reference style before creation
+# - Non-interactive safe: fails hard instead of prompting (agent-friendly)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+
+# Canonical repository PRs target (override for forks of the fork)
+UPSTREAM_REPO="${AIXCL_UPSTREAM_REPO:-xencon/aixcl}"
 
 # Arguments
 TITLE="${1:-}"
@@ -40,20 +44,28 @@ fi
 # Extract issue number from title (e.g. "Description (#42)" => 42)
 ISSUE_NUM=$(echo "$TITLE" | grep -oE '#[0-9]+' | tr -d '#' | tail -1)
 
-# Validate branch name
+# Validate branch name (hard error -- no interactive prompt, agents have no TTY)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ ! "$BRANCH" =~ ^issue-[0-9]+/ ]] && [[ ! "$BRANCH" =~ ^(dev|main)$ ]]; then
-    echo "WARNING: Branch '$BRANCH' does not follow 'issue-N/description' format"
-    read -p "Continue anyway? [y/N] " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
+    echo "ERROR: Branch '$BRANCH' does not follow 'issue-N/description' format"
+    echo "  Rename it (git branch -m issue-N/description) or create the PR manually."
+    exit 1
 fi
 
 if [[ -z "$ASSIGNEE" ]]; then
     echo "ERROR: Assignee required. Set GITHUB_USER or pass as 4th argument."
     exit 1
+fi
+
+# Fork-aware head: if origin is a fork of the canonical repo, gh needs
+# --head <fork-owner>:<branch> or PR creation fails from a fork clone.
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null || echo "")
+ORIGIN_OWNER=$(echo "$ORIGIN_URL" | sed -E 's#(git@github\.com:|https://github\.com/)([^/]+)/.*#\2#')
+UPSTREAM_OWNER="${UPSTREAM_REPO%%/*}"
+
+HEAD_REF="$BRANCH"
+if [[ -n "$ORIGIN_OWNER" ]] && [[ "$ORIGIN_OWNER" != "$UPSTREAM_OWNER" ]]; then
+    HEAD_REF="${ORIGIN_OWNER}:${BRANCH}"
 fi
 
 # Read PR template and substitute issue number
@@ -77,14 +89,25 @@ ${BODY}
 EOF
 fi
 
+# Validate body reference style before creation (same check CI enforces)
+if [[ -f "${SCRIPT_DIR}/scripts/checks/check-pr-references.sh" ]]; then
+    if ! bash "${SCRIPT_DIR}/scripts/checks/check-pr-references.sh" < "$BODY_FILE"; then
+        echo "ERROR: PR body failed reference style check (one reference per line)"
+        exit 1
+    fi
+fi
+
 echo "Creating PR: $TITLE"
-echo "  Branch: $BRANCH → $BASE"
+echo "  Repo:   $UPSTREAM_REPO"
+echo "  Head:   $HEAD_REF → $BASE"
 echo "  Labels: $LABELS"
 echo "  Assignee: $ASSIGNEE"
 
 # CRITICAL: --assignee passed at creation time (not edit afterward)
 # This prevents the PR validation race condition
 gh pr create \
+    --repo "$UPSTREAM_REPO" \
+    --head "$HEAD_REF" \
     --title "$TITLE" \
     --body-file "$BODY_FILE" \
     --base "$BASE" \


### PR DESCRIPTION
Makes the issue and PR wrapper scripts work from a fork clone and in non-interactive (agent) contexts, so the "Required: use the wrapper" rule in DEVELOPMENT.md is actually followable. Until now `create-pr.sh` hung on a TTY prompt and neither script targeted the canonical repo, which is why agents bypassed them with raw `gh`.

## Changes

- `scripts/utils/create-pr.sh`:
  - Targets `xencon/aixcl` (`AIXCL_UPSTREAM_REPO` override available)
  - Derives fork-aware `--head <owner>:<branch>` from the origin remote; plain branch name when running in a canonical clone
  - Interactive branch-format prompt replaced with a hard error and remediation hint
  - Composed body validated with `check-pr-references.sh` before creation (same check CI enforces)
- `scripts/utils/create-issue.sh`: targets `xencon/aixcl` via `--repo`

## Testing

- Title-with-colon rejected; comma-packed body references rejected by the new pre-creation check
- No prompt in non-interactive runs (stdin from /dev/null, hard error paths verified)
- Fork owner derivation verified against this clone's origin remote
- shellcheck and bash -n clean

Fixes #1660

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-02
- Method: script edits with negative-path local testing
- Scope: scripts/utils/create-pr.sh, scripts/utils/create-issue.sh
- Confirmation: yes
---
