### PR TITLE
Add aixcl test command and navigation documentation sweep (#1662)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -61,10 +61,14 @@ gh pr create \
 
 ## Running Checks Locally
 ```bash
-# Full pre-PR check
-bash scripts/checks/check-paths.sh
-bash scripts/checks/check-generated-files.sh
+# Full pre-PR check (paths, mirror parity, elisions, generated files,
+# ASCII, yamllint, compose validation, environment)
+./aixcl checks all
+
+# Shellcheck sweep (not part of checks all -- run before shell changes)
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
-yamllint -c .yamllint.yml .
-./aixcl utils check-env
+
+# Individual checks
+./aixcl checks paths        # or: agents, elisions, generated, ascii, yaml, compose, env
+./aixcl checks pr-refs <body-file>
 ```

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -61,10 +61,14 @@ gh pr create \
 
 ## Running Checks Locally
 ```bash
-# Full pre-PR check
-bash scripts/checks/check-paths.sh
-bash scripts/checks/check-generated-files.sh
+# Full pre-PR check (paths, mirror parity, elisions, generated files,
+# ASCII, yamllint, compose validation, environment)
+./aixcl checks all
+
+# Shellcheck sweep (not part of checks all -- run before shell changes)
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
-yamllint -c .yamllint.yml .
-./aixcl utils check-env
+
+# Individual checks
+./aixcl checks paths        # or: agents, elisions, generated, ascii, yaml, compose, env
+./aixcl checks pr-refs <body-file>
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ AIXCL is client-agnostic above the OpenAI-compatible API layer. OpenCode and Cla
 
 ## 5. Essential Commands
 
+`./aixcl` is the single entry point for both runtime and developer workflow.
+
 ### Stack Operations
 ```bash
 ./aixcl utils check-env               # Validate environment prerequisites
@@ -158,11 +160,13 @@ AIXCL is client-agnostic above the OpenAI-compatible API layer. OpenCode and Cla
 ./aixcl stack stop                    # Stop all services gracefully
 ```
 
-### Validation & Lint
+### Validation, Tests, and Release
 ```bash
-./scripts/checks/check-agents.sh      # Lint agent and skill files
-./scripts/checks/check-environment.sh # Full environment check
-./tests/run-tests.sh                  # Run all platform tests
+./aixcl checks all                    # Full local CI parity sweep (summary table)
+./aixcl checks agents                 # Mirror parity only (.claude/.opencode)
+./aixcl test all                      # Run every test suite
+./aixcl test lib                      # Shell library unit tests (no stack needed)
+./aixcl release status                # Where the current release cycle stands
 ```
 
 ## 6. Self-Verification Checklist

--- a/aixcl
+++ b/aixcl
@@ -71,6 +71,8 @@ source "${SCRIPT_DIR}/lib/aixcl/commands/models.sh"
 source "${SCRIPT_DIR}/lib/aixcl/commands/stack.sh"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/aixcl/commands/checks.sh"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/aixcl/commands/test.sh"
 
 # Vault command module
 # shellcheck disable=SC1091

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -41,7 +41,7 @@ _aixcl_complete() {
     cword=$COMP_CWORD
 
     # List of all possible commands (must stay in sync with lib/aixcl/dispatcher.sh)
-    local commands="app stack service models engine utils vault help restart"
+    local commands="app stack service models engine utils checks test release vault help restart"
 
     # Application names: built-in (apps/*/app.yaml) plus externally registered apps
     _aixcl_app_names() {
@@ -195,6 +195,21 @@ _aixcl_complete() {
         'utils')
             local utils_actions="check-env bash-completion prune"
             mapfile -t COMPREPLY < <(compgen -W "$utils_actions" -- "$cur")
+            return 0
+            ;;
+        'checks')
+            local checks_actions="all paths agents elisions generated ascii yaml compose env pr-refs"
+            mapfile -t COMPREPLY < <(compgen -W "$checks_actions" -- "$cur")
+            return 0
+            ;;
+        'test')
+            local test_suites="all command workflow lib apps security"
+            mapfile -t COMPREPLY < <(compgen -W "$test_suites" -- "$cur")
+            return 0
+            ;;
+        'release')
+            local release_actions="prep tag finish status"
+            mapfile -t COMPREPLY < <(compgen -W "$release_actions" -- "$cur")
             return 0
             ;;
         'prune')

--- a/docs/reference/manpage.txt
+++ b/docs/reference/manpage.txt
@@ -96,6 +96,26 @@ COMMANDS
                The system remains fully operational after this command.
                To also reset Podman storage: podman system reset --force
 
+        checks {all|paths|agents|elisions|generated|ascii|yaml|compose|env|pr-refs <file>}
+               Run local CI parity checks. 'all' runs every check, continues
+               on failure, prints a summary table, and exits non-zero if any
+               check failed. Individual actions front the corresponding
+               scripts in scripts/checks/.
+
+        test {all|command|workflow|lib|apps|security} [--quick|--dry-run]
+               Run the platform test suites. 'all' runs every suite including
+               the security tests. --quick skips slow model-download tests;
+               --dry-run previews discovery without executing.
+
+        release {prep|tag|finish|status}
+               Release process mechanics. 'prep' drafts the changelog and
+               creates the release issue and branch, stopping at the GPG
+               commit. 'tag' tags the merged release on the canonical remote
+               and verifies publication. 'finish' syncs main back into dev
+               and cleans up. 'status' shows the current release cycle state.
+               GPG commits and merge decisions always remain with the human
+               operator.
+
         help
                Show help message
 

--- a/lib/aixcl/cli.sh
+++ b/lib/aixcl/cli.sh
@@ -62,6 +62,14 @@ COMMANDS
         env                                             Environment prerequisites
         pr-refs <file>                                  Issue/PR body reference style
 
+    test <suite> [--quick|--dry-run]
+        all                                             Run every test suite
+        command                                         CLI command validation tests
+        workflow                                        README Quick Start workflow test
+        lib                                             Shell library unit tests
+        apps                                            App layer API tests
+        security                                        Security tests
+
     vault <action>
         start                                           Start Vault container
         stop                                            Stop Vault container

--- a/lib/aixcl/commands/test.sh
+++ b/lib/aixcl/commands/test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Test runner front-end for AIXCL
+# Fronts tests/run-tests.sh and tests/run-security-tests.sh so the test
+# suites share the single ./aixcl entry point with the rest of the platform.
+
+_test_usage() {
+    echo "Usage: $0 test {all|command|workflow|lib|apps|security} [--quick|--dry-run]"
+    echo "  all        Run every suite (command, workflow, lib, apps, then security)"
+    echo "  command    CLI command validation tests (needs a running stack for most)"
+    echo "  workflow   README Quick Start workflow test"
+    echo "  lib        Pure shell library unit tests (no stack required)"
+    echo "  apps       App layer API connectivity tests (skip gracefully if stack down)"
+    echo "  security   Network binding and JSON generation security tests"
+    echo "  Flags: --quick skips slow model-download tests; --dry-run previews"
+}
+
+function test_cmd() {
+    if [[ $# -lt 1 ]]; then
+        _test_usage
+        return 1
+    fi
+
+    local suite="$1"
+    shift
+
+    local runner="${SCRIPT_DIR}/tests/run-tests.sh"
+    local security_runner="${SCRIPT_DIR}/tests/run-security-tests.sh"
+
+    # Pass-through flags accepted by tests/run-tests.sh
+    local flags=()
+    local flag
+    for flag in "$@"; do
+        case "$flag" in
+            --quick|--dry-run)
+                flags+=("$flag")
+                ;;
+            *)
+                echo "Error: Unknown flag '$flag'"
+                _test_usage
+                return 1
+                ;;
+        esac
+    done
+
+    case "$suite" in
+        all)
+            local status=0
+            bash "$runner" "${flags[@]}" || status=1
+            # Security tests have no dry-run mode; skip them when previewing
+            if [[ ! " ${flags[*]} " =~ " --dry-run " ]]; then
+                bash "$security_runner" || status=1
+            fi
+            return $status
+            ;;
+        command|workflow|lib|apps)
+            bash "$runner" --category "$suite" "${flags[@]}"
+            ;;
+        security)
+            bash "$security_runner"
+            ;;
+        *)
+            echo "Error: Unknown test suite '$suite'"
+            _test_usage
+            return 1
+            ;;
+    esac
+}

--- a/lib/aixcl/dispatcher.sh
+++ b/lib/aixcl/dispatcher.sh
@@ -41,6 +41,10 @@ function main() {
             shift
             checks_cmd "$@"
             ;;
+        test)
+            shift
+            test_cmd "$@"
+            ;;
         stack)
             shift
             stack_cmd "$@"

--- a/scripts/utils/CONTEXT.md
+++ b/scripts/utils/CONTEXT.md
@@ -1,0 +1,48 @@
+# CONTEXT: scripts/utils/
+
+Developer and operator tooling: setup scripts, workflow wrappers, and
+maintenance utilities. These run on the HOST (unlike `scripts/runtime/`,
+which runs inside containers).
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `create-issue.sh` | Issue creation wrapper -- targets xencon/aixcl, template-based body, assignee at creation. Required by DEVELOPMENT.md. |
+| `create-pr.sh` | PR creation wrapper -- fork-aware `--head`, title/branch/body validation, assignee and labels at creation time. Required by DEVELOPMENT.md. |
+| `sync-mirrors.sh` | One-command `.claude/` <-> `.opencode/` skills and rules sync, then parity verification. Run after editing either side. |
+| `init-volumes.sh` | Creates the external Docker volumes shared across contexts. |
+| `validate-volume-consistency.sh` | Checks volume declarations across compose files. |
+| `setup-gpg.sh` | One-time GPG signing setup per developer. |
+| `setup-hooks.sh` | Installs the git pre-commit/pre-push hooks. |
+| `setup-podman-rootless.sh` | Podman rootless + CDI GPU setup. |
+| `start-devcontainer-podman.sh` | Devcontainer bring-up under Podman. |
+| `trace-llm-call.sh` | LLM call tracing wrapper for app builders (JSON-lines + optional Loki push). |
+| `cleanup-stale-artifacts.sh` | Removes stale generated artifacts. |
+
+## Key Constraints
+
+- Everything here must be non-interactive safe: agents have no TTY, so
+  prompts (`read -p`) are forbidden -- fail hard with remediation text.
+- GitHub-writing scripts default to the canonical repo
+  (`AIXCL_UPSTREAM_REPO`, default `xencon/aixcl`) and must pass assignee
+  and labels at creation time (PR validation races otherwise).
+- Release mechanics live in `./aixcl release` (lib/aixcl/commands/
+  release.sh), not here -- these scripts are building blocks it composes.
+
+## Agent Guidance
+
+**You MAY:**
+- Add new host-side developer tooling following the non-interactive rule
+- Extend wrappers with validation that mirrors CI checks
+
+**You MUST NOT:**
+- Add interactive prompts
+- Duplicate logic that belongs in `scripts/checks/` (validation) or
+  `lib/aixcl/commands/` (CLI-fronted workflow)
+
+## Cross-References
+
+- `scripts/checks/CONTEXT.md` -- CI validation scripts (fronted by `./aixcl checks`)
+- `lib/aixcl/commands/` -- CLI command modules that compose these tools
+- `DEVELOPMENT.md` -- wrapper usage requirements

--- a/tests/lib/CONTEXT.md
+++ b/tests/lib/CONTEXT.md
@@ -1,0 +1,42 @@
+# CONTEXT: tests/lib/
+
+Shared test framework sourced by every test in the suite, plus the pure
+shell unit tests under `tests/lib/tests/`. Run everything through
+`./aixcl test <suite>` (fronts `tests/run-tests.sh`).
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `test-framework.sh` | Assertions (`assert_*`), logging (`log_test_*`), result tracking, report generation. Must be sourced at the top of every test. |
+| `state-capture.sh` | `capture_state`/`restore_state` -- snapshots `.env`, `opencode.json`, and running containers into `tests/.backup/<name>_<timestamp>/` before a test mutates them. |
+| `cleanup.sh` | Container/model cleanup between tests, port-release polling, `cleanup_old_backups`. |
+| `tests/test-*.sh` | Unit tests for `lib/` shell functions -- no running stack required. |
+
+## Key Constraints
+
+- Tests write reports to `/tmp/aixcl-test-results.md`, never into the repo.
+- `tests/.backup/` is gitignored, but leftover `test-*` directories BLOCK
+  the pre-commit hook (check-generated-files). Clean with:
+  `rm -rf tests/.backup/test-*` before committing.
+- `capture_state` names must match the calling test's filename -- when a
+  test is renamed, update both `log_test_start` and `capture_state` labels.
+- `test-framework.sh` overwrites `SCRIPT_DIR` when sourced; callers that
+  need their own value must save and restore it.
+- Sequential execution is assumed: tests share the stack and port 11434.
+
+## Agent Guidance
+
+**You MAY:**
+- Add assertions to `test-framework.sh` (export them at the bottom)
+- Add unit tests under `tests/lib/tests/` following the numbered convention
+
+**You MUST NOT:**
+- Write test output into the repository tree
+- Remove the state capture/restore pattern from stack-mutating tests
+
+## Cross-References
+
+- `tests/run-tests.sh` -- discovery and sequential runner (via `./aixcl test`)
+- `tests/command-tests/CONTEXT.md` -- ordered integration tests
+- `tests/README.md` -- suite overview and writing guide


### PR DESCRIPTION
Final pass of the CLI alignment initiative: the last non-CLI entry point (test runners) folds into `./aixcl test`, the two highest-traffic undocumented directories get CONTEXT.md coverage, and completion plus documentation are brought up to the full single-entry-point command set.

## Changes

### aixcl test command

- `lib/aixcl/commands/test.sh`: `test {all|command|workflow|lib|apps|security}` with `--quick`/`--dry-run` pass-through, fronting `tests/run-tests.sh` and `tests/run-security-tests.sh`; `all` includes the security suite (skipped under `--dry-run`, which it does not support)
- Dispatcher, help, and entry-point wiring

### Navigation

- `tests/lib/CONTEXT.md`: framework semantics agents need on every test change -- state-capture naming, the `tests/.backup/` pre-commit trap, the SCRIPT_DIR overwrite gotcha, report path in /tmp
- `scripts/utils/CONTEXT.md`: toolbox inventory including the workflow wrappers and sync-mirrors, plus the non-interactive rule for host tooling

### Documentation and completion sweep

- `completion/aixcl.bash`: `checks`, `test`, and `release` commands with their subcommand completion
- `docs/reference/manpage.txt`: entries for all three new commands
- `AGENTS.md` section 5: essential commands now show the single `./aixcl` entry point for validation, tests, and release
- `.claude/` and `.opencode/` `rules/ci-checks.md`: "Running Checks Locally" fronts `./aixcl checks all` (mirrors byte-identical)

## Merge ordering

This PR documents the `release` command from #1665 (reopened after an accidental close) -- merge #1665 first so the docs land accurate. No file conflicts with #1665 or #1666 (wiring placed at non-overlapping locations).

## Testing

- `./aixcl test all --dry-run` discovers all 17 tests; `./aixcl test lib` propagates the runner exit code
- check-paths, check-agents (mirror parity), elision check all pass
- shellcheck and bash -n clean

Fixes #1662

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-02
- Method: new CLI command module, CONTEXT.md authoring, docs and completion updates
- Scope: lib/aixcl/, tests/lib/, scripts/utils/, completion/, docs/reference/, AGENTS.md, rules mirrors
- Confirmation: yes
---
