### PR TITLE
Clean stack stop output with wait timer (#1682)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -1033,15 +1033,21 @@ function stop() {
     # Allow down to fail (containers may not exist) - we check status after
     run_compose down --remove-orphans || true
 
-    echo "Waiting for containers to stop..."
-    for i in {1..30}; do
+    # Single-line timer (same style as the startup health-wait and Vault
+    # settle timers) until all profile containers are gone.
+    local st_attempt=0
+    local st_max=30  # 60 seconds at 2s intervals
+    while [ $st_attempt -lt $st_max ]; do
         if ! "${DOCKER_BIN:-docker}" ps --format "{{.Names}}" | grep -qE "$CONTAINER_NAME|$all_services_pattern"; then
+            [ $st_attempt -gt 0 ] && echo ""
             _print_stopped_status "$profile"
             return 0
         fi
-        echo "Waiting for services to stop... ($i/15)"
+        printf "  Waiting for containers to stop... (%ds/%ds)\r" "$((st_attempt * 2))" "$((st_max * 2))"
         sleep 2
+        st_attempt=$((st_attempt + 1))
     done
+    echo ""
 
     echo "Warning: Services did not stop gracefully. Forcing shutdown..."
     # NOTE: deliberately no -v here. Volume removal is a destructive,

--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -163,6 +163,15 @@ run_compose() {
             if ($0 == pending_start) { pending_start=""; next }
             pending_start=""
         }
+        # -- Stateful: teardown command echoes ------------------------------
+        # podman-compose echoes "podman stop -t N NAME" / "podman rm NAME"
+        # and podman prints NAME on success. Suppress both; a failed
+        # stop/rm prints an Error line instead of NAME, which passes through.
+        /^podman (stop -t [0-9]+|rm) [A-Za-z0-9._-]+$/ { pending_teardown=$NF; next }
+        pending_teardown != "" {
+            if ($0 == pending_teardown) { pending_teardown=""; next }
+            pending_teardown=""
+        }
         # -- Image pull noise -> concise progress ---------------------------
         /^podman pull / { print "  Pulling " $3; next }
         /^Trying to pull / { next }


### PR DESCRIPTION
## Summary

Cleans `./aixcl stack stop` output under podman-compose. Previously every container produced two noise lines (the echoed `podman stop -t 10 <name>` / `podman rm <name>` command followed by the container name on success), around 75 lines for a 19-service stack. This is the stop-side counterpart of the startup output cleanup shipped in v1.1.47.

## Changes

- `lib/core/docker_utils.sh`: the `run_compose` awk filter now suppresses the benign `podman stop`/`podman rm` command-echo pairs, using the same stateful pattern as the existing `podman start` fallback suppression. A failed stop prints an `Error:` line instead of the container name, which still passes through.
- `lib/aixcl/commands/stack.sh`: the stop wait loop is now a single-line carriage-return timer matching the startup health-wait and Vault settle style. Also fixes the old `($i/15)` progress label on what was a 30-iteration loop.

## Verification

- [x] Fixture test: benign stop/rm pairs suppressed, genuine `Error:` lines pass through
- [x] Regression fixture: startup-path filtering (pull noise, name-collision fallback, bare container IDs) unchanged
- [x] shellcheck and `bash -n` clean on both files
- [ ] Human: live `stack start` / `stack stop` cycle shows clean output

Fixes #1682

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-02
- Method: implementation with fixture-based filter testing
- Scope: lib/aixcl/commands/stack.sh, lib/core/docker_utils.sh
- Confirmation: yes
---
