### PR TITLE
Fix vault wipe-and-reinit compose restart (#1686)

### DIFF
--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -845,17 +845,30 @@ vault_wipe_and_reinit() {
     # Clear any stale artefacts so operator init starts clean
     rm -f "$VAULT_KEYS_FILE" "$VAULT_TOKEN_FILE"
 
-    # Restart vault via compose so it picks up a fresh empty volume
+    # Recreate the data volume -- it is declared external in the compose
+    # file, so compose will not create it and `up` fails without this.
+    log_info "Recreating vault data volume (aixcl-vault-data)..."
+    if ! "$docker_bin" volume create aixcl-vault-data > /dev/null; then
+        log_error "Failed to recreate aixcl-vault-data volume."
+        return 1
+    fi
+
+    # Restart vault via compose so it picks up the fresh empty volume.
+    # Run from the repo root with the stack project name (-p aixcl) so the
+    # container lands in the same compose project as the rest of the stack,
+    # and surface compose output on failure instead of discarding it.
     log_info "Restarting vault container..."
     local compose_file="${SCRIPT_DIR}/services/docker-compose.yml"
-    if [ -f "$compose_file" ]; then
-        "$docker_bin" compose -f "$compose_file" up -d vault 2>/dev/null || {
-            log_error "Failed to restart vault container via compose."
-            log_error "  Run: ./aixcl stack start --profile sys"
-            return 1
-        }
-    else
+    if [ ! -f "$compose_file" ]; then
         log_error "Compose file not found at ${compose_file}"
+        return 1
+    fi
+    local compose_out
+    if ! compose_out=$(cd "${SCRIPT_DIR}" && \
+            "$docker_bin" compose -p aixcl -f "$compose_file" up -d vault 2>&1); then
+        log_error "Failed to restart vault container via compose."
+        log_error "  ${compose_out}"
+        log_error "  Run: ./aixcl stack start --profile sys"
         return 1
     fi
 


### PR DESCRIPTION
## Summary

Fixes the Vault split-state recovery path. `vault_wipe_and_reinit()` removed the `aixcl-vault-data` volume and then tried `compose up -d vault` -- but the volume is declared `external: true`, so compose never recreates it and the restart fails. The failure was invisible because the invocation discarded stderr. This re-lands and extends the intent of orphaned commit `80c2b6a` from the pre-v1.1.40 `issue-1557` branch, which was pushed after PR #1558 merged and never landed.

## Changes

- `lib/aixcl/commands/vault-init.sh` (`vault_wipe_and_reinit`):
  - Recreate `aixcl-vault-data` with `volume create` before the compose restart (external volumes are never created by compose)
  - Capture compose output and log it on failure instead of `2>/dev/null`
  - Run compose from the repo root with `-p aixcl` so the restarted container joins the same compose project as the rest of the stack

## Verification

- [x] `bash -n` and shellcheck (warning, no SC1091) clean
- [x] Exact compose invocation tested live against a stopped stack: vault started under the `aixcl` project, answered on `:8200`, then stopped/removed to restore prior state
- [x] Destructive wipe path deliberately not exercised against real Vault data
- [ ] Human: optional end-to-end wipe test on a disposable environment

Fixes #1686

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-02
- Method: re-land of orphaned branch fix with external-volume defect analysis
- Scope: lib/aixcl/commands/vault-init.sh, services/docker-compose.yml (read-only)
- Confirmation: yes
---
