### PR TITLE
Make ascii check scan only tracked markdown files (#1699)

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,11 @@
 extends: default
 
+# Local sweeps run yamllint over the whole working tree; keep third-party
+# and generated trees out (CI checks out tracked files only, so no change).
+ignore: |
+  node_modules/
+  .git/
+
 rules:
   line-length:
     max: 160

--- a/lib/aixcl/commands/checks.sh
+++ b/lib/aixcl/commands/checks.sh
@@ -47,12 +47,27 @@ _check_skip() {
 
 _check_ascii() {
     # Mirror of the bash-ci.yml ASCII markdown check
-    local matches
-    matches=$(grep -rlP "[\x{2013}\x{2014}\x{2018}\x{2019}\x{201C}\x{201D}\x{2026}\x{00A0}]" \
-        --include="*.md" --exclude-dir=.git "${SCRIPT_DIR}" 2>/dev/null || true)
-    if [ -n "$matches" ]; then
-        echo "Non-ASCII punctuation found in:"
-        echo "$matches"
+    # Only check git-tracked markdown files to avoid gitignored third-party files (like node_modules)
+    local file
+    local found_issues=false
+
+    # Iterate over only tracked markdown files. Paths from git ls-files are
+    # repo-root relative, so anchor them to SCRIPT_DIR or the check passes
+    # vacuously when run from another working directory.
+    while IFS= read -r -d '' file; do
+        if [ -f "${SCRIPT_DIR}/${file}" ]; then
+            # Check for non-ASCII punctuation in each tracked file
+            if grep -qP "[\x{2013}\x{2014}\x{2018}\x{2019}\x{201C}\x{201D}\x{2026}\x{00A0}]" "${SCRIPT_DIR}/${file}" 2>/dev/null; then
+                if [ "$found_issues" = false ]; then
+                    echo "Non-ASCII punctuation found in:"
+                    found_issues=true
+                fi
+                echo "  $file"
+            fi
+        fi
+    done < <(git -C "${SCRIPT_DIR}" ls-files "*.md" | tr '\n' '\0')
+
+    if [ "$found_issues" = true ]; then
         return 1
     fi
     echo "All markdown files use ASCII-only punctuation"


### PR DESCRIPTION
Fixes #1699

This change modifies the ascii check in `./aixcl checks` to only scan git-tracked markdown files instead of the entire working tree.

This addresses an inconsistency where the ascii check would fail on developer machines due to scanning git-ignored third-party dependencies (like node_modules) while passing CI because CI only scans tracked files.

## Follow-up (senior agent review)

The original staged diff was kept as the base; the review (see PR comment) added:

- Anchor `git ls-files` paths to `SCRIPT_DIR` so the check is not vacuous when run from another working directory
- `.yamllint.yml` ignore block for `node_modules/` and `.git/` -- the yaml sweep had the same class of bug (issue deliverable 2)

## Verification

- [x] Planted smart quote detected from repo root and from a foreign cwd; clean tree passes; node_modules ignored
- [x] shellcheck, `bash -n`, yamllint, and elision checks clean

---
- Agent: OpenCode (aixcl-local/qwen3-coder:30b-32k), original implementation and body
- Date: 2026-07-02
- Method: issue-driven fix of the ascii check
- Scope: lib/aixcl/commands/checks.sh
- Confirmation: yes
---
---
- Agent: Claude Code (claude-fable-5), review, completion, and PR repair
- Date: 2026-07-02
- Method: code review, path-anchoring fix, yamllint ignore, PR metadata repair
- Scope: lib/aixcl/commands/checks.sh, .yamllint.yml, PR #1709
- Confirmation: yes
---
