### PR TITLE
Remove stale OpenCode references from workflow docs and watcher template (#1698)

### DIFF
--- a/config/opencode.json.example
+++ b/config/opencode.json.example
@@ -12,7 +12,6 @@
       "*.log",
       "volumes/",
       "pgadmin-data/",
-      "tests/test-results.md",
       "tests/*.backup",
       "*.tmp",
       "*.swp",

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -212,7 +212,7 @@ GitHub provides native issue types that must be set for each issue. These are se
 Labels are organized into categories using prefixes:
 
 #### Component Labels (Select All That Apply)
-- `component:runtime-core` - Runtime core services (Ollama, OpenCode)
+- `component:runtime-core` - Runtime core services (Ollama)
 - `component:ollama` - Ollama LLM inference engine
 - `component:persistence` - Database and persistence services
 - `component:observability` - Monitoring and observability (Prometheus, Grafana, Loki)
@@ -428,4 +428,3 @@ If you're unsure about the workflow, check:
 - This document (`development-workflow.md`)
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) for general contribution guidelines
 - Existing issues and PRs for examples
-


### PR DESCRIPTION
Fixes #1698

- Updated `docs/developer/development-workflow.md` to correctly describe `component:runtime-core` as Ollama only (removing the erroneous OpenCode reference)
- Removed the stale `tests/test-results.md` watcher entry from `config/opencode.json.example` (test results now go to /tmp)

## Follow-up (senior agent review)

The original submission edited and force-added the gitignored local `opencode.json` instead of the tracked template, and the branch was a stale copy of dev with the fix uncommitted (see the review comment). Salvage: kept the docs edit, redirected the watcher fix to `config/opencode.json.example`, rebased the branch onto current dev, dropped the force-added runtime config from the index.

## Verification

- [x] Both JSON files parse (jq)
- [x] ASCII and elision checks pass
- [x] `grep test-results config/opencode.json.example` returns nothing

---
- Agent: OpenCode (aixcl-local/qwen3-coder:30b-32k), original docs fix and body
- Date: 2026-07-02
- Method: issue-driven documentation fix
- Scope: docs/developer/development-workflow.md
- Confirmation: yes
---
---
- Agent: Claude Code (claude-fable-5), review, salvage, and PR repair
- Date: 2026-07-02
- Method: branch rebase, template fix redirection, PR metadata repair
- Scope: config/opencode.json.example, docs/developer/development-workflow.md, PR #1710
- Confirmation: yes
---
