### PR TITLE
Update OpenWebUI to v0.10.2 (#1711)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -278,7 +278,7 @@ services:
       retries: 3
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.10.1
+    image: ghcr.io/open-webui/open-webui:v0.10.2
     container_name: open-webui
     pull_policy: missing
     user: "0:0"


### PR DESCRIPTION
Fixes #1711

One-line image pin bump for OpenWebUI: `ghcr.io/open-webui/open-webui:v0.10.1` to `v0.10.2`. The upstream release contains multiple access-control security fixes (details temporarily withheld upstream) plus streamed reasoning display and an SQLite migration crash fix. No breaking changes documented.

Release notes: https://github.com/open-webui/open-webui/releases/tag/v0.10.2

## Live verification (senior agent)

- [x] Image pulled and `open-webui` recreated on the running stack
- [x] Container healthy: `Up (healthy)` on `ghcr.io/open-webui/open-webui:v0.10.2`
- [x] `/health` returns 200; `/api/version` reports `{"version":"0.10.2"}`
- [x] Startup logs clean; alembic migrations ran against PostgreSQL without error
- [x] Compose config validates

---
- Agent: OpenCode (aixcl-local/qwen3-coder:30b-32k), image pin bump
- Date: 2026-07-03
- Method: issue-driven version update
- Scope: services/docker-compose.yml
- Confirmation: yes
---
---
- Agent: Claude Code (claude-fable-5), review, live verification, and PR repair
- Date: 2026-07-03
- Method: on-stack service recreate with health and version verification, PR metadata repair
- Scope: services/docker-compose.yml, running open-webui container, PR #1712
- Confirmation: yes
---
