### PR TITLE
Extend image pin check to lib and scripts (#1728)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -69,6 +69,6 @@ gh pr create \
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 
 # Individual checks
-./aixcl checks paths        # or: agents, elisions, generated, ascii, yaml, compose, env
+./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, yaml, compose, env
 ./aixcl checks pr-refs <body-file>
 ```

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -165,15 +165,19 @@ fi
 - [ ] If gitleaks not installed, note it as a tooling gap
 - [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
 
-### Step 8 -- Docker Image Pin Hygiene
+### Step 8 -- Container Image Pin Hygiene
+
+Covers compose files AND shell code under `lib/` and `scripts/` -- four
+unpinned alpine references hid in shell code because the old sweep only
+scanned compose (issue #1726). Legitimate `:latest` uses (locally built
+`localhost/` images, ollama model tags) are exempted via `localhost/`
+detection or an inline `pin-waiver:` comment.
 
 ```bash
-grep -hn "image:" services/docker-compose*.yml | grep -v "#" | \
-  grep -E "image:\s+(\S+:latest\s*$|\S*/[^:]+\s*$|[^/:]+\s*$)" \
-  && echo "FAIL: unpinned image tags found above" || echo "ok: all images pinned"
+./aixcl checks pins
 ```
 
-- [ ] All images in all compose files use pinned version tags (no `latest`, no bare image names)
+- [ ] All container image references are pinned (no `latest`, no bare image names), or carry an explicit `pin-waiver:` comment with a reason
 
 ### Step 9 -- Shellcheck Sweep (All Scripts)
 

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -69,6 +69,6 @@ gh pr create \
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 
 # Individual checks
-./aixcl checks paths        # or: agents, elisions, generated, ascii, yaml, compose, env
+./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, yaml, compose, env
 ./aixcl checks pr-refs <body-file>
 ```

--- a/.opencode/skills/housekeeping/SKILL.md
+++ b/.opencode/skills/housekeeping/SKILL.md
@@ -165,15 +165,19 @@ fi
 - [ ] If gitleaks not installed, note it as a tooling gap
 - [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
 
-### Step 8 -- Docker Image Pin Hygiene
+### Step 8 -- Container Image Pin Hygiene
+
+Covers compose files AND shell code under `lib/` and `scripts/` -- four
+unpinned alpine references hid in shell code because the old sweep only
+scanned compose (issue #1726). Legitimate `:latest` uses (locally built
+`localhost/` images, ollama model tags) are exempted via `localhost/`
+detection or an inline `pin-waiver:` comment.
 
 ```bash
-grep -hn "image:" services/docker-compose*.yml | grep -v "#" | \
-  grep -E "image:\s+(\S+:latest\s*$|\S*/[^:]+\s*$|[^/:]+\s*$)" \
-  && echo "FAIL: unpinned image tags found above" || echo "ok: all images pinned"
+./aixcl checks pins
 ```
 
-- [ ] All images in all compose files use pinned version tags (no `latest`, no bare image names)
+- [ ] All container image references are pinned (no `latest`, no bare image names), or carry an explicit `pin-waiver:` comment with a reason
 
 ### Step 9 -- Shellcheck Sweep (All Scripts)
 

--- a/completion/aixcl.bash
+++ b/completion/aixcl.bash
@@ -198,7 +198,7 @@ _aixcl_complete() {
             return 0
             ;;
         'checks')
-            local checks_actions="all paths agents elisions generated ascii yaml compose env pr-refs"
+            local checks_actions="all paths agents elisions generated ascii pins yaml compose env pr-refs"
             mapfile -t COMPREPLY < <(compgen -W "$checks_actions" -- "$cur")
             return 0
             ;;

--- a/lib/aixcl/commands/checks.sh
+++ b/lib/aixcl/commands/checks.sh
@@ -9,12 +9,13 @@ CHECKS_FAILED=()
 CHECKS_SKIPPED=()
 
 _checks_usage() {
-    echo "Usage: $0 checks {all|paths|agents|elisions|generated|ascii|yaml|compose|env|pr-refs <file>}"
+    echo "Usage: $0 checks {all|paths|agents|elisions|generated|ascii|pins|yaml|compose|env|pr-refs <file>}"
     echo "  all              Run every check below (continues on failure, prints summary)"
     echo "  paths            Documentation relative links and stale path patterns"
     echo "  agents           .claude/ vs .opencode/ rules and skills mirror parity"
     echo "  elisions         AI-elision placeholders and suspicious mass deletions"
     echo "  generated        Tracked generated files and stale artifacts"
+    echo "  pins             Container image references pinned (compose + shell code)"
     echo "  ascii            Non-ASCII punctuation in markdown files"
     echo "  yaml             yamllint over the repository"
     echo "  compose          docker compose config validation (main + overrides)"
@@ -140,6 +141,9 @@ function checks_cmd() {
         elisions)
             bash "${checks_dir}/check-ai-elisions.sh" "$@"
             ;;
+        pins)
+            bash "${checks_dir}/check-image-pins.sh"
+            ;;
         generated)
             bash "${checks_dir}/check-generated-files.sh"
             ;;
@@ -177,6 +181,7 @@ function checks_cmd() {
             _check_run "elisions" bash "${checks_dir}/check-ai-elisions.sh" || true
             _check_run "generated" bash "${checks_dir}/check-generated-files.sh" || true
             _check_run "ascii" _check_ascii || true
+            _check_run "pins" bash "${checks_dir}/check-image-pins.sh" || true
 
             if command -v yamllint > /dev/null 2>&1; then
                 _check_run "yaml" yamllint -c "${SCRIPT_DIR}/.yamllint.yml" "${SCRIPT_DIR}" || true

--- a/lib/aixcl/commands/models.sh
+++ b/lib/aixcl/commands/models.sh
@@ -9,9 +9,11 @@ is_model_installed() {
 
     case "$engine" in
         ollama)
-            # Ollama list shows models. We need to match the name exactly, or with :latest if missing tag
+            # Ollama list shows models. Match the name exactly, or with the
+            # default tag appended when the name carries none.
+            # (pin-waiver: ollama MODEL tags are not container images)
             local model_with_tag="$model"
-            [[ ! "$model" =~ : ]] && model_with_tag="${model}:latest"
+            [[ ! "$model" =~ : ]] && model_with_tag="${model}:latest"  # pin-waiver: ollama model tag
             "${DOCKER_BIN:-docker}" exec "$container" ollama list 2>/dev/null | awk '{print $1}' | grep -qE "^${model_with_tag}$"
             return $?
             ;;

--- a/scripts/checks/check-image-pins.sh
+++ b/scripts/checks/check-image-pins.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# check-image-pins.sh -- verify container image references are pinned
+#
+# Scans compose files AND shell code under lib/ and scripts/ for container
+# image references that use :latest or no tag at all. The compose-only
+# sweep missed four unpinned alpine references in shell code (issue #1726);
+# this check closes that gap (issue #1728).
+#
+# Rules:
+#   1. compose image: lines must carry a version tag (no :latest, no bare name)
+#   2. no :latest anywhere in *.sh / *.yml under lib/, scripts/, services/
+#      Exempt: localhost/ images (built locally from source, never pulled)
+#      and lines carrying an explicit "pin-waiver:" comment with a reason
+#      (e.g. ollama MODEL tags, which are not container images)
+#   3. FROM lines in heredoc Dockerfile templates must carry a non-latest tag
+#   4. registry-prefixed references (docker.io, ghcr.io, quay.io) in shell
+#      code must carry a tag
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SELF="scripts/checks/check-image-pins.sh"
+fail=0
+
+report() {
+    echo "UNPINNED ($1): $2"
+    fail=1
+}
+
+# 1. Compose files: image: lines with :latest or no tag at all
+while IFS= read -r match; do
+    report "compose" "$match"
+done < <(grep -Hn "image:" services/docker-compose*.yml 2>/dev/null \
+    | grep -v "#" \
+    | grep -E "image:[[:space:]]+(\S+:latest[[:space:]]*$|\S*/[^:]+[[:space:]]*$|[^/:]+[[:space:]]*$)" || true)
+
+# 2. :latest anywhere in shell or yaml under lib/, scripts/, services/
+while IFS= read -r match; do
+    report ":latest" "$match"
+done < <(grep -rn ":latest" lib/ scripts/ services/ \
+    --include="*.sh" --include="*.yml" 2>/dev/null \
+    | grep -v "^${SELF}:" \
+    | grep -v "localhost/" \
+    | grep -v "pin-waiver:" || true)
+
+# 3. FROM lines in heredoc Dockerfile templates without a version tag
+while IFS= read -r match; do
+    report "FROM" "$match"
+done < <(grep -rn "^FROM " lib/ scripts/ --include="*.sh" 2>/dev/null \
+    | grep -vE "^[^:]+:[0-9]+:FROM [^ ]+:[A-Za-z0-9][A-Za-z0-9._-]*([[:space:]]|$)" \
+    | grep -v "^${SELF}:" || true)
+
+# 4. Registry-prefixed references in shell code without a tag
+while IFS= read -r match; do
+    report "no tag" "$match"
+done < <(grep -rnE "(docker\.io|ghcr\.io|quay\.io)/[A-Za-z0-9._/-]+" \
+    lib/ scripts/ --include="*.sh" 2>/dev/null \
+    | grep -vE "(docker\.io|ghcr\.io|quay\.io)/[A-Za-z0-9._/-]+:[A-Za-z0-9]" \
+    | grep -v "^${SELF}:" || true)
+
+if [ "$fail" -eq 1 ]; then
+    echo "FAIL: unpinned container image references found"
+    exit 1
+fi
+
+echo "All container image references are pinned"
+exit 0


### PR DESCRIPTION
# Pull Request

## Summary
Fixes 1728

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes 1728

## Additional Notes

Fixes #1728

The housekeeping image-pin check only scanned compose files, which is how four unpinned alpine references hid in shell code until #1726. This adds a comprehensive check and wires it into every validation surface.

## Changes

- `scripts/checks/check-image-pins.sh` (new): compose `image:` pin validation plus shell-code sweeps under lib/ and scripts/ -- `:latest` occurrences, untagged `FROM` lines in heredoc Dockerfile templates, and untagged registry-prefixed references. Exemptions by design: `localhost/` images (built locally from source, never pulled) and explicit inline `pin-waiver:` comments with a reason.
- `lib/aixcl/commands/checks.sh`, `completion/aixcl.bash`: new `./aixcl checks pins` subcommand, included in `checks all`.
- `lib/aixcl/commands/models.sh`: pin-waiver annotation for ollama MODEL tags (not container images).
- Housekeeping skill pin-hygiene step now runs the new check (both mirrors, parity synced); `ci-checks.md` mirrors list the subcommand.

## Verification

- [x] Clean tree passes; `checks all` shows 9 green including pins
- [x] Negative test: a planted unpinned `docker.io/library/busybox` reference was caught with file:line and reverted
- [x] shellcheck and bash -n clean on all touched shell files
- [x] Mirror parity verified

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-03
- Method: detection-gap mechanization with positive and negative testing
- Scope: scripts/checks/, lib/aixcl/commands/, completion/, rules and skills mirrors
- Confirmation: yes
---
