### PR TITLE
Complete docs index and unify cold-start navigation (#1736)

### DIFF
--- a/.opencode/CONTEXT.md
+++ b/.opencode/CONTEXT.md
@@ -1,0 +1,60 @@
+# CONTEXT: .opencode/
+
+OpenCode configuration for the local agent. IMPORTANT: OpenCode derives
+commands and agent IDs from EVERY markdown filename in `commands/` and
+`agents/` -- never place documentation files (CONTEXT.md, README.md,
+notes) inside those two directories, or they register as a bogus
+`/CONTEXT` command or `CONTEXT` agent. Document them here instead.
+
+## Layout
+
+| Directory | Purpose |
+|-----------|---------|
+| `agents/` | Agent definitions; filename = agent ID, `name:` frontmatter MUST NOT be present (enforced by `scripts/checks/check-agents.sh`, issue #1703) |
+| `commands/` | Slash commands; filename = command name; use `` !`cmd` `` shell injection to ground the agent in verified state |
+| `rules/` | Behavioral constraints, byte-identical mirror of `.claude/rules/` (enforced by `check-agents.sh`) |
+| `skills/` | Agent Skills, byte-identical mirror of `.claude/skills/` |
+| `memory/` | Seed memory for the local agent -- PUBLIC repo content, never secrets |
+
+## Agents
+
+| File | Mode | Purpose |
+|------|------|---------|
+| `agents/agent-context.md` | primary | Worker for the `agent:qwen` issue queue -- operational guidance, tool discipline, memory conventions |
+| `agents/reviewer.md` | subagent | Read-only reviewer: `edit` denied, inspection-only bash allowlist |
+
+## Commands
+
+| File | Command | Purpose |
+|------|---------|---------|
+| `commands/next-task.md` | `/next-task` | Injects the single oldest open `agent:qwen` issue as the one and only work item |
+| `commands/pr-ready.md` | `/pr-ready` | Gates PR creation on verified signed commits ahead of `upstream/dev`; hands the commit to the human if none exist |
+| `commands/finish-pr.md` | `/finish-pr` | Verifies a PR is actually MERGED before branch cleanup and issue close |
+
+## Agent Guidance
+
+**You MAY:**
+- Add commands that inject verified state (command output) rather than prose instructions
+- Add read-only subagents; adjust prompts or permissions with maintainer approval
+- Tighten hard gates (empty-state -> STOP conditions)
+
+**You MUST NOT:**
+- Place any non-command markdown in `commands/` or non-agent markdown in `agents/`
+- Add `name:` frontmatter to agent files
+- Remove or soften command hard gates (STOP / END TURN) -- prose alone does not transfer reliably to the local model
+- Grant `reviewer` write access, or point any agent `model` at a non-local provider
+- Edit one side of the `rules/`/`skills/` mirrors without the other
+- Commit secrets or machine-specific paths to `memory/` -- this repo is public
+
+## Runtime Config
+
+`opencode.json` at the repository root is GITIGNORED runtime config. The
+canonical template is `config/opencode.json.example` -- every config change
+goes to BOTH files (edit the template, apply locally).
+
+## Cross-References
+
+- `AGENTS.md` -- operating contract (loaded via the `instructions` array)
+- `config/opencode.json.example` -- provider, model, permissions, instructions
+- `docs/developer/opencode-setup.md` -- human setup guide
+- `.claude/` -- Claude Code counterpart (rules/skills mirrored; commands tool-specific)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,19 @@ Use plain ASCII only. Place the block at the end of the comment or PR body, afte
 
 ## 10. Quick References
 
+### Per-Directory Documentation
+
+- `CONTEXT.md` -- agent-facing directory contract: what the directory
+  contains, what agents MAY and MUST NOT do there. Read it before editing
+  files in a directory that has one.
+- `README.md` -- human-facing overview; used at the repository root and
+  top-level directories only (`config/`, `lib/`, `scripts/`, `tests/`,
+  `docs/`).
+- Not every directory has a `CONTEXT.md`. Absence means no constraints
+  beyond this contract apply -- read the code.
+- `docs/README.md` is the complete index of `docs/`; update it in the
+  same PR that adds, moves, or removes a doc.
+
 ### Tool Usage
 
 - Prefer actually running commands over printing them

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,14 +16,9 @@ It complements `AGENTS.md` (the operating contract) and `.opencode/rules/` (beha
 
 ## 1. Before starting any task
 
-Read the following documents before beginning work:
+Read the four cold-start documents in the order given in **AGENTS.md Section 0** -- that list is canonical and is deliberately not repeated here. For the complete step-by-step workflow beyond this file, see `docs/developer/development-workflow.md`.
 
-1. `AGENTS.md` -- agent operating contract and authority hierarchy
-2. `DEVELOPMENT.md` -- workflow rules, issue and PR templates
-3. `docs/developer/development-workflow.md` -- full workflow guide
-4. `docs/architecture/governance/` -- platform invariants and service contracts
-
-**VALIDATION REQUIRED:** If any documents in #3 or #4 are absent -> **HALT** and ask the human operator directly, per AGENTS.md Section 7 (do not create issues unilaterally). Await human clarification before proceeding.
+**VALIDATION REQUIRED:** If any document referenced by AGENTS.md Section 0 is absent -> **HALT** and ask the human operator directly, per AGENTS.md Section 7 (do not create issues unilaterally). Await human clarification before proceeding.
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,9 +1,0 @@
-# AIXCL Quick Start Guide
-
-> **DEPRECATED:** This guide has been consolidated. Use these canonical sources instead:
->
-> - **Installation and stack setup**: [README.md](/README.md) -- Quick Start section
-> - **Development workflow (Issue-First)**: [DEVELOPMENT.md](/DEVELOPMENT.md) -- Workflow rules and templates
-> - **OpenCode setup**: [docs/developer/opencode-setup.md](docs/developer/opencode-setup.md)
->
-> This file remains as a placeholder to preserve existing links. Do not update it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,15 +2,59 @@
 
 Documentation organized by audience. Keep it lean -- if something can be regenerated or is operator-only, it belongs in the [wiki](https://github.com/xencon/aixcl/wiki), not the repo.
 
-## Structure
+This file is the complete index of `docs/`. Every file under `docs/` must be listed here -- update this index in the same PR that adds, moves, or removes a doc.
 
-| Directory | Audience | Key Files |
-|-----------|----------|-----------|
-| `user/` | End users | [`usage.md`](user/usage.md) - Commands and service URLs, [`apps.md`](user/apps.md) - App framework guide |
-| `developer/` | Contributors | [`development-workflow.md`](developer/development-workflow.md), [`opencode-setup.md`](developer/opencode-setup.md), [`adding-services.md`](developer/adding-services.md), [`adding-apps.md`](developer/adding-apps.md), [`app-builder-guide.md`](developer/app-builder-guide.md) |
-| `architecture/governance/` | Architects | [`00_invariants.md`](architecture/governance/00_invariants.md), [`02_profiles.md`](architecture/governance/02_profiles.md), [`service_contracts/`](architecture/governance/service_contracts/) |
-| `operations/` | Operators | [`security-runbook.md`](operations/security-runbook.md), [`incident-response.md`](operations/incident-response.md) |
-| `reference/` | All | [`manpage.txt`](reference/manpage.txt) |
+## User Guides (`user/`)
+
+- [`usage.md`](user/usage.md) -- Commands and service URLs
+- [`apps.md`](user/apps.md) -- App framework guide
+
+## Developer Guides (`developer/`)
+
+- [`development-workflow.md`](developer/development-workflow.md) -- Full issue-first workflow, step by step
+- [`opencode-setup.md`](developer/opencode-setup.md) -- OpenCode CLI configuration for the local stack
+- [`adding-services.md`](developer/adding-services.md) -- Add a service to the stack
+- [`adding-apps.md`](developer/adding-apps.md) -- Add an app on the app framework
+- [`app-builder-guide.md`](developer/app-builder-guide.md) -- Build apps against the platform contract
+- [`agent-pitfalls.md`](developer/agent-pitfalls.md) -- Known agent failure modes and recovery steps
+- [`ai-file-naming.md`](developer/ai-file-naming.md) -- File naming and metadata conventions
+- [`env-configuration.md`](developer/env-configuration.md) -- Environment variable reference
+- [`gpg-signed-commits.md`](developer/gpg-signed-commits.md) -- GPG signing setup and troubleshooting
+- [`pre-commit-setup.md`](developer/pre-commit-setup.md) -- Pre-commit hook installation
+- [`vault-integration.md`](developer/vault-integration.md) -- Vault secret management for services and apps
+
+## Architecture (`architecture/`)
+
+### Governance (`architecture/governance/`)
+
+- [`00_invariants.md`](architecture/governance/00_invariants.md) -- Platform invariants (non-negotiable)
+- [`01_ai_guidance.md`](architecture/governance/01_ai_guidance.md) -- Agentic behavioral guidance
+- [`02_profiles.md`](architecture/governance/02_profiles.md) -- Stack profile definitions
+- [`03_stack_status.md`](architecture/governance/03_stack_status.md) -- Stack status specification
+- [`service_contracts/`](architecture/governance/service_contracts/) -- Service dependency contracts (runtime and bld profiles)
+
+### Decision Records (`architecture/decisions/`)
+
+- [`001-network-mode-host.md`](architecture/decisions/001-network-mode-host.md) -- Host networking for all services
+- [`002-one-shot-bootstrap.md`](architecture/decisions/002-one-shot-bootstrap.md) -- One-shot bootstrap containers
+- [`003-vault-token-escape-hatch.md`](architecture/decisions/003-vault-token-escape-hatch.md) -- VAULT_TOKEN escape hatch
+- [`004-topological-sort-depends-on.md`](architecture/decisions/004-topological-sort-depends-on.md) -- Topological sort for depends_on
+- [`005-python3-yaml-parser.md`](architecture/decisions/005-python3-yaml-parser.md) -- python3 as the YAML parser
+
+## Security (`security/`)
+
+- [`threat-model.md`](security/threat-model.md) -- Platform threat model
+- [`compensating-controls.md`](security/compensating-controls.md) -- Compensating controls for accepted risks
+
+## Operations (`operations/`)
+
+- [`security-runbook.md`](operations/security-runbook.md) -- Security operations runbook
+- [`incident-response.md`](operations/incident-response.md) -- Incident response procedures
+
+## Reference (`reference/`)
+
+- [`manpage.txt`](reference/manpage.txt) -- Generated CLI man page
+- [`ai-report-structured-knowledge-architectures.md`](reference/ai-report-structured-knowledge-architectures.md) -- Research report on structured knowledge architectures
 
 ## Root-Level Contracts
 

--- a/lib/aixcl/CONTEXT.md
+++ b/lib/aixcl/CONTEXT.md
@@ -1,0 +1,31 @@
+# CONTEXT: lib/aixcl/
+
+CLI entry layer for `./aixcl`: help text, argument dispatch, and the
+command implementations. The `./aixcl` script at the repository root
+sources this layer; it is the single entry point for both runtime and
+developer workflow.
+
+## Contents
+
+| Path | Purpose |
+|------|---------|
+| `cli.sh` | Help menu and CLI surface definition (`help_menu()`); the user-visible command reference |
+| `dispatcher.sh` | `main()` -- routes `<group> <action>` arguments to the command functions |
+| `commands/` | One file per command group (stack, models, checks, release, ...) -- see `commands/CONTEXT.md` |
+
+## Agent Guidance
+
+**You MAY:**
+- Add a new command group: implement it under `commands/`, route it in `dispatcher.sh`, document it in `cli.sh` `help_menu()` and `completion/aixcl.bash` -- all four in the same change
+- Improve help text and CLI ergonomics without changing semantics
+
+**You MUST NOT:**
+- Change command semantics without an issue (CLI is a documented contract)
+- Introduce runtime-core dependencies on operational services (AGENTS.md invariant)
+- Let `help_menu()`, the dispatcher, and bash completion drift apart -- they describe the same surface
+
+## Cross-References
+
+- `lib/aixcl/commands/CONTEXT.md` -- per-command-group contract
+- `lib/cli/CONTEXT.md` -- lower-level profile loading these commands build on
+- `completion/aixcl.bash` -- bash completion that must track the dispatcher

--- a/scripts/hooks/CONTEXT.md
+++ b/scripts/hooks/CONTEXT.md
@@ -1,0 +1,37 @@
+# CONTEXT: scripts/hooks/
+
+Git hooks installed into `.git/hooks/` (see
+`docs/developer/pre-commit-setup.md`). These run on the developer's
+machine before a commit is created.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `pre-commit` | Runs shellcheck (`--severity=warning --exclude=SC1091`, mirroring CI) on staged shell scripts; skips gracefully when shellcheck is not installed |
+
+## Key Facts
+
+- Hooks run BEFORE GPG signing. If a commit fails and GPG never prompted,
+  a hook failed -- it is not a signing problem.
+- The separate `pre-commit` framework (`.pre-commit-config.yaml`) may
+  auto-fix files (e.g. trailing whitespace); fixes land in the worktree,
+  not the index. Re-stage with `git add` and retry the commit.
+- Never bypass a failing hook with `--no-verify` -- fix the finding; CI
+  runs the same checks and will fail anyway.
+
+## Agent Guidance
+
+**You MAY:**
+- Keep hook settings mirroring CI exactly (same shellcheck flags)
+- Add hooks that mirror an existing CI check
+
+**You MUST NOT:**
+- Add a hook check that CI does not enforce (local-only failures confuse contributors)
+- Weaken severity or add exclusions that diverge from `security.yml`
+
+## Cross-References
+
+- `docs/developer/pre-commit-setup.md` -- installation guide
+- `.claude/rules/ci-checks.md` / `.opencode/rules/ci-checks.md` -- the pre-commit checklist agents follow
+- `.github/workflows/security.yml` -- CI shellcheck settings this hook mirrors


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1736

### Description of Changes

Phase 1 of the documentation optimization for agentic use: fixes navigation dead ends so every doc under `docs/` is reachable from the index and agents get exactly one canonical cold-start reading list.

- `docs/README.md` is now the complete index of `docs/`: adds the previously unindexed `docs/security/` directory, all 5 ADRs under `docs/architecture/decisions/`, and 6 unindexed `docs/developer/` files. Adds the rule that the index is updated in the same PR that adds or removes a doc.
- `DEVELOPMENT.md` Section 1 defers to AGENTS.md Section 0 as the single canonical cold-start list, removing the second, divergent required-reading list.
- `AGENTS.md` documents the per-directory documentation convention (CONTEXT.md = agent-facing contract, README.md = human-facing top-level overview).
- New directory contracts: `.opencode/CONTEXT.md`, `lib/aixcl/CONTEXT.md`, `scripts/hooks/CONTEXT.md`. The `.opencode/` one deliberately lives at the `.opencode/` root, NOT inside `commands/` or `agents/`, because OpenCode registers every markdown file in those directories as a command or agent; the file documents that trap.
- `QUICKSTART.md` deleted per lean repository policy (deprecated tombstone; only remaining references are CHANGELOG history).

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- `./aixcl checks all` green (paths, agents mirror parity, elisions, generated, ascii, pins, yaml, compose, env)
- `./scripts/checks/check-ai-elisions.sh --staged` clean
- Verified only CHANGELOG.md references QUICKSTART.md before deletion

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- Every file under docs/ is reachable from docs/README.md

### Related Issues

- Closes #1736

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-06
- Method: repository markdown audit, doc edits, local CI parity checks
- Scope: docs/README.md, AGENTS.md, DEVELOPMENT.md, QUICKSTART.md, new CONTEXT.md files
- Confirmation: yes
---
