### PR TITLE
Deduplicate policy docs to single source of truth (#1737)

### DIFF
--- a/.claude/commands/finish-pr.md
+++ b/.claude/commands/finish-pr.md
@@ -2,16 +2,18 @@
 description: Post-merge cleanup -- verify merge state, sync dev, delete branch, close issue
 ---
 
-The human says a PR is merged. VERIFY IT FIRST -- a PR can be CLOSED
-without being merged, and humans are sometimes mistaken:
+The human says a PR is merged. VERIFY IT FIRST -- humans are sometimes mistaken, and a PR can be CLOSED without being merged:
 
 !`gh pr list --repo xencon/aixcl --state all --limit 5 --json number,state,title --jq '.[] | "#\(.number) \(.state) \(.title)"'`
 
-For the PR in question (from $ARGUMENTS, or ask if ambiguous):
+For the PR in question (ask which one if ambiguous, or take it from $ARGUMENTS):
 
-1. Confirm state is exactly `MERGED`: `gh pr view <N> --repo xencon/aixcl --json state`
-   - If `OPEN` or `CLOSED`, STOP and report -- do not delete anything
+1. Confirm the state is exactly `MERGED`: `gh pr view <N> --repo xencon/aixcl --json state`
+   - If it is `OPEN` or `CLOSED`, STOP and report -- do not delete anything
 2. Sync: `git checkout dev && git pull upstream dev && git push origin dev`
-3. Delete the branch locally and on the fork (fork copy may already be auto-deleted)
-4. Close the linked issue with a comment referencing the PR, ending with the agent identification block
-5. Verify final state: clean tree, dev in sync, no leftover branches
+3. Delete the branch locally (`git branch -D <branch>`) and on the fork (`git push origin --delete <branch>`) -- the fork copy may already be auto-deleted, which is fine
+4. Close the linked issue with a comment referencing the PR, ending with your agent identification block:
+   `gh issue close <N> --repo xencon/aixcl --comment "Resolved by PR #<PR>, merged to dev. ..."`
+5. Verify final state: clean working tree, `dev` in sync, no leftover branches
+
+Report what was done and the final state.

--- a/.claude/rules/CONTEXT.md
+++ b/.claude/rules/CONTEXT.md
@@ -9,8 +9,8 @@ workflow, and Discussions.
 | File | What it constrains |
 |------|-------------------|
 | `ci-checks.md` | Pre-commit checklist, elision guard, CI workflow summary, ShellCheck flags |
-| `formatting.md` | Title formats (no colons), ASCII mandate, label taxonomy, commit types |
-| `security.md` | Runtime core invariants, safe vs prohibited areas for agents |
+| `formatting.md` | Title formats (no colons), ASCII mandate, commit types; labels point to AGENTS.md |
+| `security.md` | Invariants and escalation summary; canonical text is AGENTS.md Sections 3-4 and 7 |
 | `workflow.md` | Issue-first step-by-step, branch strategy, PR requirements |
 | `discussions.md` | GitHub Discussions policy -- secret handling, untrusted-input treatment, advisory-only status |
 

--- a/.claude/rules/formatting.md
+++ b/.claude/rules/formatting.md
@@ -19,12 +19,10 @@ provided every glyph has an ASCII fallback (the `${ICON_*:-[x]}` pattern
 in lib/) so non-UTF-8 terminals degrade gracefully.
 
 ## Labels
-**Issue Types** (select exactly one): `Bug`, `Feature`, `Task`
-**Component Labels** (required): `component:runtime-core`, `component:ollama`, `component:persistence`, `component:observability`, `component:ui`, `component:cli`, `component:infrastructure`, `component:testing`
-**Priority** (optional): `P1`, `P2`, `P3`
-**Profile** (optional): `profile:bld`, `profile:sys`
-**Category** (optional): `Fix`, `Enhancement`, `Refactor`, `Maintenance`
-**Agent queue** (optional): `agent:qwen` -- marks an issue as queued for a named agent
+The label taxonomy is defined once, in **AGENTS.md Section 3 (Label
+Taxonomy)** -- that list is canonical; do not restate or extend it here.
+In short: exactly one type label, at least one `component:*` label,
+optional priority/profile/category/agent-queue labels.
 
 ## Commits
 - Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,36 +1,24 @@
 # Security and Architecture Policy
 
-## Fixed Core Runtime (Non-Negotiable)
-- **Inference Engine** (Ollama) -- Docker-managed, always enabled
-- Never remove, replace, or conditionally disable the Inference Engine
+**Canonical text: AGENTS.md** -- Section 3 (Platform Invariants), Section 4
+(Safe Areas), Section 7 (Escalation Procedures). This file is a summary for
+the rules set; it adds no policy of its own. If this summary and AGENTS.md
+ever disagree, AGENTS.md wins.
 
-## Supported AI Coding Clients (Non-Exclusive)
-- AIXCL is client-agnostic above the OpenAI-compatible API layer
-- OpenCode and Claude Code are documented clients; others are equally valid
-- Do not treat any specific AI coding client as a platform invariant
+## Hard Invariants (summary)
 
-## Runtime vs Operational Services Boundary
-- Runtime core must be runnable **without** any operational services
-- Operational services may depend on runtime core
-- Runtime core must **never** depend on operational services
+- **Inference Engine** (Ollama) is fixed core runtime -- never remove,
+  replace, or conditionally disable it
+- Runtime core must never depend on operational services; operational
+  services may depend on runtime core
+- AIXCL is client-agnostic above the OpenAI-compatible API layer -- no
+  specific AI coding client is a platform invariant
+- No external libraries, cloud services, telemetry, or analytics without
+  explicit approval
 
-## Safe Areas for AI Contribution
-**You MAY:**
-- Modify operational services (monitoring, logging, automation)
-- Improve documentation
-- Adjust CLI ergonomics (without changing semantics)
-- Organize Compose files (if invariants are preserved)
-- Add new operational profiles or tooling
+## Escalation (summary)
 
-**You MUST NOT:**
-- Remove/replace/disable runtime core components
-- Introduce runtime core -> operational service dependencies
-- Merge runtime logic with monitoring/admin tooling
-- Collapse service boundaries
-- Add external libraries, cloud services, telemetry, or analytics without explicit approval
-
-## Escalation
-1. If working on an issue -> Post clarification as issue comment
-2. If no issue exists -> Ask human operator directly; do not create issue unilaterally
-3. If security concern -> Flag with `[SECURITY]` prefix and await explicit approval
-4. If authority conflict -> Document override request and obtain explicit confirmation
+- Security concern -> flag with `[SECURITY]` prefix and await explicit
+  approval
+- No issue exists -> ask the human operator directly; do not create issues
+  unilaterally

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -7,23 +7,18 @@ mode: primary
 
 You are the primary AI assistant for the AIXCL AI development platform.
 
-## Cold Start -- Read These First
-
-If you are starting a new session, read exactly these four files in order:
-
-| Order | File | What it gives you |
-|-------|------|------------------|
-| 1 | `AGENTS.md` | Operating contract, authority hierarchy, constraints |
-| 2 | `DEVELOPMENT.md` | Workflow rules, issue/PR templates, commit format |
-| 3 | `docs/architecture/governance/00_invariants.md` | Non-negotiable platform invariants |
-| 4 | `docs/architecture/governance/01_ai_guidance.md` | Agentic behavioral guidance |
-
-After reading those four files you are fully oriented. Begin work.
+Your operating contract is `AGENTS.md`, which is auto-loaded into your
+context together with `.opencode/rules/` -- do not re-read them, and do
+not look for policy anywhere else first. Everything there binds you:
+cold-start reading order (Section 0), fork remotes and push rules,
+authority hierarchy, platform invariants, Issue-First workflow,
+escalation, and the agent identification block. This file adds only what
+is specific to this agent.
 
 ## Finding Your Work
 
-Issues queued for this agent carry the `agent:qwen` label. At session start,
-or whenever the human asks what to work on next, list the queue:
+Issues queued for this agent carry the `agent:qwen` label. At session
+start, or whenever the human asks what to work on next, list the queue:
 
 ```bash
 gh issue list --repo xencon/aixcl --label agent:qwen --state open
@@ -73,171 +68,8 @@ in this list.
   same goal, and continue the task
 - Ask the human only when the TASK is ambiguous, never because a tool
   failed
-
-## Git Remote Configuration (Fork Workflow)
-
-| Remote | URL | Purpose |
-|--------|-----|---------|
-| `origin` | `git@github.com:sbadakhc/aixcl.git` | Personal fork (push branches here) |
-| `upstream` | `git@github.com:xencon/aixcl.git` | Canonical repository (PRs target here) |
-
-Push branches to `origin`, open PRs against `upstream`. Use SSH, not HTTPS.
-If `upstream` remote is missing: `git remote add upstream git@github.com:xencon/aixcl.git`
-
-## Authority Hierarchy
-
-When conflicts arise, follow this order:
-
-1. **Direct human instruction** in active session
-2. **AGENTS.md** (Operating Contract) - Critical constraints and core principles
-3. **DEVELOPMENT.md** (Workflow Rules) - Development workflow and contribution rules
-4. **`.opencode/rules/`** - Behavioral constraints and workflow policy
-5. **`.github/`** - Issue and PR templates
-6. **`.opencode/skills/`** - Specialized task workflows
-7. `docs/architecture/governance/` - Platform invariants and service contracts
-8. `docs/developer/` - Developer guides and workflow documentation
-
-## Core Principles
-
-1. **Security over convenience**
-2. **Determinism over creativity**
-3. **Minimal scope changes**
-4. **Explicit reasoning over implicit assumptions**
-5. **No speculative modifications**
-6. **No unauthorized dependency introduction**
-7. **No hidden behavior**
-
-## Platform Invariants (Non-Negotiable)
-
-### Fixed Core Runtime
-- **Inference Engine** (Ollama) - Docker-managed service
-- **OpenCode** - AI-powered code assistance (client-side)
-- These components are always enabled and never optional
-- Never remove, replace, or conditionally disable runtime core components
-
-### Runtime vs Operational Services Boundary
-- Runtime core must be runnable **without** operational services
-- Operational services may depend on runtime core
-- Runtime core must **never** depend on operational services
-- Network mode: `host` networking for all services (by design -- not a vulnerability)
-
-## Issue-First Development Workflow (MANDATORY)
-
-**ALWAYS create an issue before starting work.**
-
-### Step-by-Step Workflow:
-
-1. **Create Issue**
-   - Title format: `[TYPE] Description` (e.g., `[TASK]`, `[BUG]`, `[FEATURE]`)
-   - NO colons in titles
-   - Use plain ASCII markdown (`- [x]` checkboxes, not Unicode)
-   - Add labels: component (required), priority (optional), profile (optional)
-   - Always assign the issue
-
-2. **Create Branch**
-   - Format: `issue-<number>/<short-description>`
-   - Example: `issue-217/fix-encoding-problem`
-   - Always branch from `dev`
-
-3. **Make Changes**
-   - Small, reversible steps
-   - Follow project conventions
-
-4. **Commit**
-   - Format: `<type>: <description>` (under 72 chars)
-   - Reference issue: `Fixes #<issue-number>`
-   - Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`
-
-5. **Push and Create PR**
-   - Title format: `<description> (#<number>)` (no colons)
-   - PR body must reference issue: `Fixes #<number>`
-   - Add matching labels to PR
-   - Always assign the PR
-   - Push to `fork`, PR targets `origin`
-
-6. **Verify CI**
-   - Check GitHub Actions status
-   - All status checks must be green before completing
-
-### Lazy-Loading Templates
-
-When creating issues or PRs, read the appropriate template first:
-
-- Bug report -- `.github/ISSUE_TEMPLATE/bug_report.md`
-- Feature request -- `.github/ISSUE_TEMPLATE/feature_request.md`
-- Task -- `.github/ISSUE_TEMPLATE/task.md`
-- Pull request -- `.github/PULL_REQUEST_TEMPLATE.md`
-
-## Safe Areas for AI Contribution
-
-**You MAY safely operate in:**
-- Operational services (monitoring, logging, automation)
-- Documentation improvements
-- CLI ergonomics (without changing semantics)
-- Compose organization (if invariants preserved)
-- Adding new operational profiles or tooling
-
-**You MUST NOT:**
-- Remove, replace, or conditionally disable runtime core components
-- Introduce dependencies from runtime core to operational services
-- Merge runtime logic with monitoring, logging, or admin tooling
-- Collapse service boundaries
-- Introduce architectural indirection without explicit instruction
-
-## Tool Usage
-
-### bash
-- Prefer actually running commands over printing them
-- Avoid destructive operations (`git push --force`, `git reset --hard`, `rm -rf`)
-
-### read/edit/write
-- Load files on a need-to-know basis (lazy loading)
-- Read full files when needed, not just snippets
-- Preserve existing code style and conventions; make minimal, focused changes
-
-### webfetch
-- Use only when explicitly needed for external documentation; ask for approval first
-
-## Self-Verification Checklist
-
-Before ANY operation, confirm:
-
-- [ ] I have read AGENTS.md and DEVELOPMENT.md
-- [ ] This change is explicitly requested and minimally scoped
-- [ ] Sufficient repository evidence exists (no hallucination risk)
-- [ ] Required issue exists or override is documented
-- [ ] No security principles are violated
-- [ ] No unauthorized dependencies are introduced
-- [ ] `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit
-
-## Escalation Procedures
-
-When halting due to insufficient evidence, missing requirements, or conflicts:
-
-1. **If working on an issue**: Post clarification question as issue comment
-2. **If no issue exists**: Ask human operator directly; do not create issue unilaterally
-3. **If security concern**: Flag with `[SECURITY]` prefix and await explicit approval
-4. **If authority conflict**: Document override request and obtain explicit confirmation
-
-## Response Style
-
-- Use plain ASCII text (no Unicode special characters)
-- Use markdown checkboxes: `- [x]` for completed items, `- [ ]` for incomplete
-- Be concise but thorough
-- Surface risks and assumptions explicitly
-- Suggest tests when making code changes
-
-## External References
-
-- `docs/developer/development-workflow.md` - Full workflow guide
-- `docs/architecture/governance/00_invariants.md` - Platform invariants
-- `docs/architecture/governance/01_ai_guidance.md` - AI behavioral guidance
-- `docs/architecture/governance/02_profiles.md` - Profile definitions
-- `docs/architecture/decisions/` - Architectural decision records
-- `docs/developer/agent-pitfalls.md` - Common agent mistakes and corrections
-- `.opencode/skills/add-service/SKILL.md` - Guided workflow for adding a service
-- `.opencode/skills/release/SKILL.md` - Guided workflow for cutting a release
-- `.opencode/rules/workflow.md` - Workflow constraints
+- `webfetch`: use only when explicitly needed for external
+  documentation; ask for approval first
 
 ---
 

--- a/.opencode/rules/CONTEXT.md
+++ b/.opencode/rules/CONTEXT.md
@@ -9,8 +9,8 @@ workflow, and Discussions.
 | File | What it constrains |
 |------|-------------------|
 | `ci-checks.md` | Pre-commit checklist, elision guard, CI workflow summary, ShellCheck flags |
-| `formatting.md` | Title formats (no colons), ASCII mandate, label taxonomy, commit types |
-| `security.md` | Runtime core invariants, safe vs prohibited areas for agents |
+| `formatting.md` | Title formats (no colons), ASCII mandate, commit types; labels point to AGENTS.md |
+| `security.md` | Invariants and escalation summary; canonical text is AGENTS.md Sections 3-4 and 7 |
 | `workflow.md` | Issue-first step-by-step, branch strategy, PR requirements |
 | `discussions.md` | GitHub Discussions policy -- secret handling, untrusted-input treatment, advisory-only status |
 

--- a/.opencode/rules/formatting.md
+++ b/.opencode/rules/formatting.md
@@ -19,12 +19,10 @@ provided every glyph has an ASCII fallback (the `${ICON_*:-[x]}` pattern
 in lib/) so non-UTF-8 terminals degrade gracefully.
 
 ## Labels
-**Issue Types** (select exactly one): `Bug`, `Feature`, `Task`
-**Component Labels** (required): `component:runtime-core`, `component:ollama`, `component:persistence`, `component:observability`, `component:ui`, `component:cli`, `component:infrastructure`, `component:testing`
-**Priority** (optional): `P1`, `P2`, `P3`
-**Profile** (optional): `profile:bld`, `profile:sys`
-**Category** (optional): `Fix`, `Enhancement`, `Refactor`, `Maintenance`
-**Agent queue** (optional): `agent:qwen` -- marks an issue as queued for a named agent
+The label taxonomy is defined once, in **AGENTS.md Section 3 (Label
+Taxonomy)** -- that list is canonical; do not restate or extend it here.
+In short: exactly one type label, at least one `component:*` label,
+optional priority/profile/category/agent-queue labels.
 
 ## Commits
 - Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`

--- a/.opencode/rules/security.md
+++ b/.opencode/rules/security.md
@@ -1,36 +1,24 @@
 # Security and Architecture Policy
 
-## Fixed Core Runtime (Non-Negotiable)
-- **Inference Engine** (Ollama) -- Docker-managed, always enabled
-- Never remove, replace, or conditionally disable the Inference Engine
+**Canonical text: AGENTS.md** -- Section 3 (Platform Invariants), Section 4
+(Safe Areas), Section 7 (Escalation Procedures). This file is a summary for
+the rules set; it adds no policy of its own. If this summary and AGENTS.md
+ever disagree, AGENTS.md wins.
 
-## Supported AI Coding Clients (Non-Exclusive)
-- AIXCL is client-agnostic above the OpenAI-compatible API layer
-- OpenCode and Claude Code are documented clients; others are equally valid
-- Do not treat any specific AI coding client as a platform invariant
+## Hard Invariants (summary)
 
-## Runtime vs Operational Services Boundary
-- Runtime core must be runnable **without** any operational services
-- Operational services may depend on runtime core
-- Runtime core must **never** depend on operational services
+- **Inference Engine** (Ollama) is fixed core runtime -- never remove,
+  replace, or conditionally disable it
+- Runtime core must never depend on operational services; operational
+  services may depend on runtime core
+- AIXCL is client-agnostic above the OpenAI-compatible API layer -- no
+  specific AI coding client is a platform invariant
+- No external libraries, cloud services, telemetry, or analytics without
+  explicit approval
 
-## Safe Areas for AI Contribution
-**You MAY:**
-- Modify operational services (monitoring, logging, automation)
-- Improve documentation
-- Adjust CLI ergonomics (without changing semantics)
-- Organize Compose files (if invariants are preserved)
-- Add new operational profiles or tooling
+## Escalation (summary)
 
-**You MUST NOT:**
-- Remove/replace/disable runtime core components
-- Introduce runtime core -> operational service dependencies
-- Merge runtime logic with monitoring/admin tooling
-- Collapse service boundaries
-- Add external libraries, cloud services, telemetry, or analytics without explicit approval
-
-## Escalation
-1. If working on an issue -> Post clarification as issue comment
-2. If no issue exists -> Ask human operator directly; do not create issue unilaterally
-3. If security concern -> Flag with `[SECURITY]` prefix and await explicit approval
-4. If authority conflict -> Document override request and obtain explicit confirmation
+- Security concern -> flag with `[SECURITY]` prefix and await explicit
+  approval
+- No issue exists -> ask the human operator directly; do not create issues
+  unilaterally

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 | field | value |
 |-------|-------|
 | file | AGENTS.md |
-| version | 2.1 |
+| version | 2.2 |
 | purpose | agent_contract |
 | priority | critical |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, MCP-compatible systems |
-| last_updated | 2026-06-14 |
+| last_updated | 2026-07-06 |
 
 # AGENTS.md
 
@@ -24,7 +24,9 @@ If you are starting a new session in this repository, read exactly these four do
 
 You do NOT need to read `.claude/rules/` or `.opencode/rules/` separately -- they are
 subsets of the above and loaded automatically by your tool. You do NOT need to read
-`.opencode/agents/agent-context.md` -- it is a thin pointer back to this file.
+`.opencode/agents/agent-context.md` -- it carries only OpenCode-agent-specific
+operational guidance (work queue, tool list, memory) and defers to this file for
+all policy.
 
 After reading those four files you are fully oriented. Begin work.
 
@@ -222,10 +224,7 @@ In exceptional situations, a human operator may explicitly authorize the agent t
 
 **Commit Format:** `[OVERRIDE] type: Brief description`
 
-### What DOES NOT Qualify
-
-- "Just do it" without context
-- Vague urgency
+**Does NOT qualify:** "just do it" without context, or vague urgency.
 
 ## 9. Human in the Loop Checklist Policy
 
@@ -256,28 +255,16 @@ Use plain ASCII only. Place the block at the end of the comment or PR body, afte
 ---
 ```
 
-### Required fields
+Field meanings: `Agent` = YOUR OWN tool name and model (never copy an
+example's identity); `Date` = posting date (YYYY-MM-DD); `Method` = what
+the agent did (e.g. read-only repository scan); `Scope` = files, issues,
+or context the agent had access to; `Confirmation` = `yes` if code or
+file changes were made, `no` if read-only.
 
-| Field | Value |
-|-------|-------|
-| `Agent` | Tool name and model, e.g. `Claude Code (claude-sonnet-4-6)` or `OpenCode (ollama-cloud/kimi-k2.7-code)` |
-| `Date` | Date the interaction was posted, in `YYYY-MM-DD` format |
-| `Method` | Brief description of what the agent did, e.g. `read-only issue review and repository scan` |
-| `Scope` | Files, directories, issues, or context the agent had access to when forming the comment |
-| `Confirmation` | `yes` if the agent made code or file changes; `no` if it was read-only |
-
-### When the block is required
-
-- Agent-authored issue comments
-- Agent-authored PR descriptions
-- Agent-authored PR review comments
-- Agent-authored issue bodies (when the agent creates issues under human direction)
-
-### When the block is not required
-
-- Commit messages (conventional commit format takes precedence)
-- Internal tool outputs not posted to GitHub
-- Human-authored content
+**Required on:** every agent-authored issue body, issue comment, PR
+description, and PR review comment.
+**Not required on:** commit messages (conventional format takes
+precedence), internal tool output, human-authored content.
 
 ## 10. Quick References
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1737

### Description of Changes

Phase 2 of the documentation optimization for agentic use: every policy now has exactly one canonical home, with pointers instead of restatement. This removes silent-drift risk and shrinks the auto-loaded instruction payload for both agents.

**Measured payload (auto-loaded instruction set for the local OpenCode agent): 5388 -> 4483 words (-905 words, -17%)** -- roughly 1200 tokens of headroom returned to the 32k context window every session.

- `.opencode/agents/agent-context.md`: 244 -> 76 lines. It duplicated the AGENTS.md cold-start table, remotes table, invariants, workflow steps, and escalation text wholesale -- all of which are already auto-loaded via the `instructions` array, so the local model was loading everything twice. Now contains only agent-specific content: queue discovery, guided commands, memory conventions, tool discipline. The rewrite also removes two outright defects: inverted remote guidance ("Push to `fork`, PR targets `origin`") and OpenCode listed as a fixed core runtime component, contradicting the client-agnostic invariant.
- `rules/security.md` (both mirrors): now an explicit summary-with-pointer; canonical text is AGENTS.md Sections 3-4 and 7. Previously a near-verbatim restatement that would drift silently.
- `rules/formatting.md` (both mirrors): the label taxonomy restatement is replaced with a pointer to the canonical AGENTS.md Section 3 list.
- `rules/CONTEXT.md` (both mirrors): table descriptions updated to match.
- `.claude/commands/finish-pr.md`: adopts the `.opencode` body verbatim (it had drifted textually while being semantically identical); only the tool-specific frontmatter now differs.
- `AGENTS.md` v2.2: Section 9.5 compressed (field table and required/not-required lists folded into prose, with a new warning against copying an example's identity -- a real incident), Section 8 tightened, and the stale "thin pointer" description of agent-context.md corrected.

The intentional mass rewrite of agent-context.md is declared via the `AIXCL_ALLOW_MASS_DELETE` token in the commit message, per the documented elision-guard convention.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- `./aixcl checks all` green (paths, agents mirror parity, elisions, generated, ascii, pins, yaml, compose, env)
- `bash scripts/checks/check-agents.sh` mirror parity clean after every mirror edit
- Payload measured with `wc -w` over AGENTS.md + `.opencode/rules/*.md` + `.opencode/memory/MEMORY.md` + `.opencode/agents/agent-context.md` before and after

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- No policy statement lost -- only relocated or pointed to

### Related Issues

- Closes #1737

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-06
- Method: policy deduplication with before/after payload measurement, local CI parity checks
- Scope: AGENTS.md, .claude and .opencode rules mirrors, agent-context.md, finish-pr commands
- Confirmation: yes
---
