### PR TITLE
Codify doc naming conventions and fix stale claims (#1738)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -185,9 +185,18 @@ canonical repo; forks follow these adaptations:
 - **Capturing upstream defects:** platform problems discovered during
   fork work are recorded in `UPSTREAM-ISSUES.md` at the repository root
   -- one entry per candidate ticket with severity and suggested labels.
-  This file is working inventory, exempt from the dated-reports lean
-  policy. When an entry is filed as a real issue upstream, delete it
-  from the file (the issue tracker takes over).
+  The file is created on demand (it does not exist when the inventory is
+  empty) and is exempt from the dated-reports lean policy. When an entry
+  is filed as a real issue upstream, delete it from the file (the issue
+  tracker takes over). Entry format:
+
+  ```markdown
+  ## <short title>
+  - Severity: P1 | P2 | P3
+  - Suggested labels: <type>, component:<name>
+  - Observed: <what happened, where, how to reproduce>
+  - Proposed fix: <one line, optional>
+  ```
 - **Before proposing fork work upstream:** scrub anything fork-specific
   (local tokens, machine paths, app experiments), squash exploratory
   history, and reference or create the upstream issue per the standard
@@ -220,9 +229,9 @@ Allowed types: `fix`, `feat`, `refactor`, `docs`, `test`, `chore`, `ci`
 Commits pushed to `main` and `dev` **must be GPG-signed by the human
 operator**. Honest scoping of this rule:
 
-- CI does **not** currently verify signatures; enforcement is by
-  maintainer discipline and branch protection. (Adding signature
-  verification to CI is a tracked enhancement.)
+- CI reports unsigned commits on pushes to `main`/`dev`
+  (`commit-signature-check.yml`) but the check is **non-blocking**;
+  enforcement is by maintainer discipline.
 - Agents running without a TTY cannot complete GPG pinentry. An agent
   asked to push signed commits must surface that limitation and hand the
   push to the operator -- never disable signing or bypass the requirement

--- a/docs/architecture/governance/service_contracts/README.md
+++ b/docs/architecture/governance/service_contracts/README.md
@@ -13,7 +13,7 @@ Purpose:
 ## Contract Scope
 
 - Name
-- Category (runtime | bld)
+- Category (Runtime Core | Operational Services | Supported AI Coding Client)
 - Purpose
 - Depends On
 - Exposes
@@ -24,6 +24,7 @@ Purpose:
 
 ## Enforcement
 
-- Runtime: strict
-- Ops: guiding
+- Runtime Core: Strict
+- Operational Services: Guided
+- Supported AI Coding Clients: Advisory
 - Violations require explicit maintainer approval

--- a/docs/architecture/governance/service_contracts/bld/persistence.md
+++ b/docs/architecture/governance/service_contracts/bld/persistence.md
@@ -1,21 +1,22 @@
 # Service Contract -- Persistence Stack
 
-**Category:** Operational Services  
+**Category:** Operational Services
 **Enforcement Level:** Guided
 
 ## Purpose
-Provides PostgreSQL database storage for runtime data (Open WebUI conversations, OpenCode plugin conversations) and operational data. Includes pgAdmin for database administration.
+Provides PostgreSQL database storage for runtime data (Open WebUI conversations) and operational data. Includes pgAdmin for database administration.
 
 ## Depends On
-- Open WebUI (uses PostgreSQL for conversation storage)
-- OpenCode plugin (uses PostgreSQL for conversation storage when configured)
+- Vault (database credentials are rendered by `vault-agent-postgres` into the shared secrets volume)
+
+## Consumed By
+- Open WebUI (conversation storage)
+- pgAdmin (administration)
+- Postgres Exporter (metrics)
 
 ## Exposes
 - PostgreSQL database server (port 5432)
 - pgAdmin web interface (port 5050)
-- Database endpoints for:
-  - Open WebUI conversations
-  - OpenCode plugin conversations
 
 ## Must Not Depend On
 - UI logic (pgAdmin is admin tool, not runtime UI)
@@ -24,6 +25,5 @@ Provides PostgreSQL database storage for runtime data (Open WebUI conversations,
 ## Notes
 - **Runtime/Operational Boundary**: PostgreSQL serves both runtime (conversation storage) and operational (admin) purposes. This creates a design tension with the invariant that "runtime core must be runnable without operational services."
 - **Resolution**: AIXCL services may use PostgreSQL if available, but must function gracefully if it is unavailable.
-- **Current Implementation**: Only active profiles (`bld`, `sys`) include PostgreSQL for persistence. The `bld` profile includes PostgreSQL as part of the observability stack, while `sys` includes it along with the full UI and monitoring suite.
+- **Current Implementation**: Both active profiles (`bld`, `sys`) include PostgreSQL. Database initialization is `scripts/db/init/01-create-webui.sql` (Open WebUI database only).
 - **pgAdmin**: Purely operational/admin tooling, never required for runtime.
-- **Database Separation**: OpenCode conversations use a separate database (`opencode`) from Open WebUI conversations, maintaining logical separation.

--- a/docs/architecture/governance/service_contracts/runtime/opencode.md
+++ b/docs/architecture/governance/service_contracts/runtime/opencode.md
@@ -5,7 +5,7 @@
 
 ## Purpose
 
-Developer-facing AI interaction layer. OpenCode is a VS Code extension/plugin that connects to the Inference Engine via the OpenAI-compatible API for AI-powered code assistance.
+Developer-facing AI interaction layer. OpenCode is a terminal-based (TUI) AI coding agent that connects to the Inference Engine via the OpenAI-compatible API for AI-powered code assistance.
 
 AIXCL is client-agnostic above the API layer. OpenCode is one documented client; other MCP-compatible or OpenAI-API-compatible clients (e.g. Claude Code, Cursor) are equally valid. This contract documents how OpenCode integrates, not that it is required.
 
@@ -15,8 +15,8 @@ AIXCL is client-agnostic above the API layer. OpenCode is one documented client;
 
 ## Exposes
 
-- VS Code extension interface for AI-powered code assistance
-- Developer interaction layer (via OpenCode plugin in IDE)
+- Terminal (TUI) interface for AI-powered code assistance
+- Developer interaction layer (agents, commands, and skills under `.opencode/`)
 
 ## Must Not Depend On
 

--- a/docs/developer/ai-file-naming.md
+++ b/docs/developer/ai-file-naming.md
@@ -1,66 +1,61 @@
-## AI-Related File Naming Conventions
+# File Naming and Metadata Conventions
 
-This document defines naming and directory conventions for AI-related markdown files in this repository. The goal is to make agents, skills, MCP-related docs, and AI-generated reports easy to discover and safe to use across different AI tools.
+This document defines naming, directory, and metadata conventions for markdown files in this repository, with emphasis on the AI-related surfaces (agents, skills, rules, reports). The goal is to make files easy to discover and safe to use for both humans and AI tools.
 
 These conventions complement the development workflow in `docs/developer/development-workflow.md` and the architectural guidance in `docs/architecture/governance/01_ai_guidance.md`.
 
-### Agents
+## General Naming Rules
+
+- **New documentation files use kebab-case**: `adding-services.md`, `threat-model.md`
+- **Existing numbered series keep their established style** -- do not rename files to change convention; renames break inbound links for no benefit:
+  - Governance docs keep `NN_snake_case`: `00_invariants.md`, `01_ai_guidance.md`
+  - Architecture decision records keep `NNN-kebab-case`: `001-network-mode-host.md`
+- **Any NEW numbered series must use kebab-case** with zero-padded prefixes: `001-topic-name.md`
+- Per-directory documentation: `CONTEXT.md` (agent-facing contract) or `README.md` (human-facing, top-level directories only) -- see AGENTS.md Section 10
+
+## Frontmatter Policy
+
+YAML frontmatter is used ONLY where a tool or specification consumes it. Do not add frontmatter to plain documentation -- it costs context tokens and has no consumer.
+
+| File type | Frontmatter | Consumed by |
+|-----------|-------------|-------------|
+| Skills (`SKILL.md`) | Required: `name`, `description` | Agent Skills standard (agentskills.io) |
+| OpenCode commands | Required: `description`; optional `agent` | OpenCode |
+| OpenCode agents | Required: `description`, `mode`; **`name` MUST NOT be present** | OpenCode |
+| Issue templates | Required: GitHub template fields | GitHub |
+| `AGENTS.md` / `DEVELOPMENT.md` | Markdown-table header (repo-local convention) | Humans |
+| All other docs | None | -- |
+
+## Agents
 
 - **Location**: `.opencode/agents/`
-- **Filename pattern**: `agent-<domain>.md`
-  - Examples:
-    - `agent-context.md`
-    - `agent-security-gate.md`
-    - `agent-audit-logger.md`
+- **Filename pattern**: the filename (minus `.md`) IS the agent ID -- e.g. `agent-context.md`, `reviewer.md`
 
 Agent files:
-- Contain YAML frontmatter with `name` and `description`.
-- Encode AIXCL-specific constraints (Issue-First workflow, governance rules, plain ASCII markdown).
-- Are intended to be used by multiple AI tools (e.g., OpenCode CLI, Cursor, Copilot-style agents).
+- Contain YAML frontmatter with `description` and `mode`.
+- **MUST NOT contain a `name:` field** -- OpenCode derives the agent ID from the filename, and a `name:` field overrides it and breaks command dispatch (issue #1703; enforced by `scripts/checks/check-agents.sh`).
+- Defer to `AGENTS.md` for all policy; contain only agent-specific operational guidance.
+- Never place non-agent markdown (CONTEXT.md, notes) in this directory -- OpenCode registers every markdown file here as an agent. Same rule for `.opencode/commands/`.
 
-### Skills (Optional)
+## Skills
 
-Skills are optional narrowly scoped capabilities. If used:
+- **Location**: `.claude/skills/<name>/SKILL.md` and `.opencode/skills/<name>/SKILL.md` (byte-identical mirrors -- edit both sides)
+- **Filename pattern**: directory-based (`<name>/SKILL.md`), directory name in kebab-case
+  - Examples: `housekeeping/SKILL.md`, `cut-release/SKILL.md`
 
-- **Location**: `.opencode/skills/<name>/SKILL.md`
-- **Filename pattern**: directory-based (`<name>/SKILL.md`)
-  - Examples:
-    - `workflow-guard/SKILL.md`
-    - `security-scan/SKILL.md`
+Skill files follow the [Agent Skills open standard](https://agentskills.io): keep SKILL.md lean and move bulky reference material to separate files loaded on demand (progressive disclosure).
 
-Skill files define narrowly scoped capabilities that agents can rely on, such as a specific refactoring or check.
+## Rules
 
-### Rules
+- **Location**: `.claude/rules/` and `.opencode/rules/` (byte-identical mirrors -- edit both sides)
+- **Filename pattern**: `<topic>.md` -- e.g. `workflow.md`, `formatting.md`, `security.md`
 
-- **Location**: `.opencode/rules/`
-- **Filename pattern**: `<topic>.md`
-  - Examples:
-    - `workflow.md`
-    - `formatting.md`
-    - `security.md`
+Rules are loaded automatically every session (Claude Code natively; OpenCode via the `instructions` array in `opencode.json`). Because they cost context every session, rules must not restate policy that lives in `AGENTS.md` -- summarize and point instead.
 
-Rules are automatically loaded by OpenCode via the `instructions` array in `opencode.json`.
-
-### MCP Documentation
-
-If MCP servers or tools are documented in markdown prompts or specs:
-
-- **Location**: `.opencode/mcp/`
-- **Filename patterns**:
-  - MCP servers: `mcp-server-<name>.md`
-  - MCP tools: `mcp-tool-<name>.md`
-  - Examples:
-    - `mcp-server-github.md`
-    - `mcp-server-local-shell.md`
-    - `mcp-tool-aixcl-cli.md`
-
-These files describe how MCP components should behave but do not replace the actual MCP server or tool configuration files.
-
-### AI-Generated Reports
+## AI-Generated Reports
 
 - **Location**: `docs/reference/`
 - **Filename pattern**: `ai-report-<topic>.md`
-  - Example:
-    - `ai-report-issues-compliance-analysis.md`
+  - Example: `ai-report-structured-knowledge-architectures.md`
 
-AI reports are outputs produced by agents or analysis tools. They are not agent or skill definitions and should not be treated as such by tooling.
+AI reports are analysis outputs, not agent or skill definitions, and are subject to the lean repository policy -- prefer the wiki for material that will not stay current.

--- a/docs/developer/gpg-signed-commits.md
+++ b/docs/developer/gpg-signed-commits.md
@@ -8,8 +8,10 @@ All commits to the `main` and `dev` branches must be cryptographically signed us
 
 - **Proof of Authorship**: Cryptographic verification of who made changes
 - **Code Integrity**: Tamper-evident commit history
-- **Compliance**: Meets SOC 2 / ISO 27001 requirements
+- **Compliance**: Supports SOC 2 / ISO 27001 compliance objectives
 - **Security**: Protection against compromised GitHub credentials
+
+**Honest scoping of enforcement**: CI reports unsigned commits on pushes to `main` and `dev` via `.github/workflows/commit-signature-check.yml`, but the check is **non-blocking** -- enforcement is by maintainer discipline. Agents cannot complete GPG pinentry (no TTY) and must hand commits to the human operator rather than bypass signing; see `docs/developer/agent-pitfalls.md`.
 
 ### Scope: Human Developers Only
 
@@ -124,16 +126,15 @@ Signed commits display a "Verified" badge on GitHub:
 
 - **Green "Verified"**: Signature valid and trusted
 - **Unverified**: Signature present but key not added to GitHub
-- **No badge**: Commit not signed (will be rejected)
+- **No badge**: Commit not signed (reported as a non-blocking CI warning on `main`/`dev`)
 
-### Branch Protection
+### Enforcement Status
 
-Repository settings enforce signed commits:
-
-```
-Settings > Branches > Branch protection rules
-[x] Require signed commits
-```
+There is currently NO hard rejection of unsigned commits. The
+`commit-signature-check.yml` workflow reports unsigned commits in a push
+to `main` or `dev` as warnings and always exits 0. Adding blocking
+enforcement (branch protection "require signed commits") is a maintainer
+decision, not a documented current state.
 
 ## Emergency Procedures
 
@@ -171,28 +172,18 @@ In emergencies, repository admins can:
 
 **Note**: This requires explicit admin approval and should be logged.
 
-## CI/CD Integration
+## Agents and Automation
 
-### GitHub Actions
+There is **no bot GPG key** in this repository, and CI does not create
+signed commits. AI agents running without a TTY cannot complete GPG
+pinentry: the correct behavior is to stage the changes, provide the exact
+`git commit` command, and hand signing to the human operator -- never
+disable signing, never use `--no-gpg-sign`, never use `--no-verify`.
 
-Automated commits (version bumps, changelog) should use a bot key:
-
-```yaml
-- name: Import GPG key
-  uses: crazy-max/ghaction-import-gpg@v5
-  with:
-    gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-    passphrase: ${{ secrets.GPG_PASSPHRASE }}
-    git_user_signingkey: true
-    git_commit_gpgsign: true
-```
-
-### Bot Signing
-
-Repository has a bot GPG key for automated commits:
-- Key ID: Available in repository secrets
-- Used by: GitHub Actions only
-- Scope: Changelog updates, version bumps
+If automated signing is ever introduced (bot key in CI), it requires a
+separate key with a distinct bot identity, storage in a secret vault, and
+an audit trail -- treat it as a `[SECURITY]`-flagged change requiring
+explicit maintainer approval.
 
 ## Troubleshooting
 


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1738

### Description of Changes

Phase 3 of the documentation optimization for agentic use: naming and metadata conventions are now codified, and the currency pass over the oldest docs removed claims that were factually wrong -- several of which would actively mislead an agent.

- `docs/developer/ai-file-naming.md` rewritten as the naming and frontmatter policy doc. The critical fix: the old text instructed that agent files "contain YAML frontmatter with `name` and `description`" -- the exact `name:` field that broke OpenCode agent discovery (#1703) and that `check-agents.sh` now forbids. An agent following the old doc would reintroduce the bug. New content: kebab-case for new docs, existing numbered series keep their style (no renames -- they break inbound links), new numbered series must use kebab-case, and a frontmatter-only-where-a-tool-consumes-it table.
- `DEVELOPMENT.md`: the `UPSTREAM-ISSUES.md` entry template is now embedded inline in Section 3, fixing the dangling reference (the file is create-on-demand and previously had no documented format). Also updates the stale "CI does not verify signatures" note: `commit-signature-check.yml` now reports unsigned commits on `main`/`dev` pushes, non-blocking.
- `service_contracts/bld/persistence.md`: the "Depends On" list actually named the stack's consumers (Open WebUI, OpenCode plugin) -- inverted. Now: Depends On Vault (credential rendering), with a separate Consumed By section. Also removes the claim of a separate `opencode` database; only `01-create-webui.sql` exists.
- `service_contracts/runtime/opencode.md`: OpenCode was described as "a VS Code extension/plugin"; it is a terminal (TUI) coding agent.
- `service_contracts/README.md`: category/enforcement vocabulary now matches what the contracts actually use (Runtime Core Strict, Operational Services Guided, AI Coding Client Advisory).
- `docs/developer/gpg-signed-commits.md`: honest scoping. Removed the false claims that unsigned commits "will be rejected", that branch protection requires signed commits, and that "Repository has a bot GPG key" (it does not). Added the real enforcement state (non-blocking CI reporter, maintainer discipline) and the agent rule: no TTY means hand the commit to the human -- never bypass signing.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- `./aixcl checks all` green (paths, agents, elisions, generated, ascii, pins, yaml, compose, env)
- Claims verified against current state: `scripts/db/init/` contents, `commit-signature-check.yml` behavior (non-blocking, exit 0), branch protection API (404, not protected), absence of any bot GPG key in workflows

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- ai-file-naming.md no longer instructs adding name: frontmatter to agent files

### Related Issues

- Closes #1738

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-06
- Method: currency pass verifying doc claims against code, workflows, and GitHub API state
- Scope: DEVELOPMENT.md, docs/developer/, docs/architecture/governance/service_contracts/
- Confirmation: yes
---
