### PR TITLE
Exclude changelog and fork slug from username scan (#1756)

### DIFF
--- a/scripts/checks/check-paths.sh
+++ b/scripts/checks/check-paths.sh
@@ -104,7 +104,16 @@ check_hardcoded_usernames() {
 
     local username_pattern="sbadakhc"
     local occurrences
-    occurrences=$(grep -rn "$username_pattern" --include="*.md" . 2>/dev/null | grep -v ".git/" | grep -v "CODEOWNERS" || true)
+    # Exclusions (see issue #1756): CHANGELOG.md is a historical record,
+    # and the fork repo slug (sbadakhc/aixcl) documents real infrastructure
+    # (remote URLs, fork layout) rather than an assignee that should be a
+    # placeholder. Everything else stays strict.
+    occurrences=$(grep -rn "$username_pattern" --include="*.md" . 2>/dev/null \
+        | grep -v ".git/" \
+        | grep -v "CODEOWNERS" \
+        | grep -v "^\./CHANGELOG\.md:" \
+        | grep -v "sbadakhc/aixcl" \
+        || true)
 
     if [[ -n "$occurrences" ]]; then
         warn "Found hardcoded username (should use <assignee> placeholder):"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes 1756

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes 1756

## Additional Notes

Adds exclusions to the hardcoded-username scan in `scripts/checks/check-paths.sh` so legitimate occurrences stop producing a standing warning on every `./aixcl checks all` run.

Excluded:

- `CHANGELOG.md` wholesale -- changelogs are historical records by definition
- lines containing the fork repo slug `sbadakhc/aixcl` -- these document real infrastructure (the AGENTS.md remote table, the fork layout prose in agent-pitfalls.md), not assignees that should be placeholders

Everything else stays strict. Verification performed: `./aixcl checks paths` now reports zero warnings on a clean tree; a planted `--assignee sbadakhc` violation in a scratch doc was still detected before cleanup; `bash -n` and `shellcheck --severity=warning --exclude=SC1091` pass on the changed script; elision check clean; all pre-commit hooks passed at commit time.

---
- Agent: Claude Code (Claude Fable 5)
- Date: 2026-07-06
- Method: added two grep exclusions to the username scan, verified with clean run and planted-violation negative test
- Scope: scripts/checks/check-paths.sh
- Confirmation: yes
---

