### PR TITLE
Sync main into dev before v1.1.52 release (#1770)

### DIFF
--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Create minimal .env for validation
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v7.0.0
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Validate Compose Files
         run: |


### PR DESCRIPTION
Reconcile branches before the v1.1.52 release. Fixes #1770

Brings the Dependabot buildx-action bump (merged to main via PR #1764) into dev so the upcoming release PR is clean.

- [x] Sync PR opened from main into dev
- [x] dev contains main after merge

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-07
- Method: main-to-dev sync PR per release reconciliation pattern
- Scope: issue #1770, upstream main and dev branches
- Confirmation: no (branch merge only; no file edits)
---

