### PR TITLE
Exempt post-merge lifecycle boxes from pr-ready gate (#1778)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -86,3 +86,9 @@ It validates the PR and its linked issue in one pass: title formats, assignee,
 label taxonomy (exact case), zero unticked checkboxes on both bodies, body
 reference style, and all CI checks green. Merge only on exit 0. If a checkbox
 is legitimately unmet, resolve or surface it -- never merge past the gate.
+
+Exception: an unticked box whose text contains `(post-merge)` is reported
+as informational, not blocking. `./aixcl release prep` stamps this marker
+on release-lifecycle deliverables (tag pushed, release published, dev
+synced) that can only become true after the release PR merges. Tick each
+one as its step completes.

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -86,3 +86,9 @@ It validates the PR and its linked issue in one pass: title formats, assignee,
 label taxonomy (exact case), zero unticked checkboxes on both bodies, body
 reference style, and all CI checks green. Merge only on exit 0. If a checkbox
 is legitimately unmet, resolve or surface it -- never merge past the gate.
+
+Exception: an unticked box whose text contains `(post-merge)` is reported
+as informational, not blocking. `./aixcl release prep` stamps this marker
+on release-lifecycle deliverables (tag pushed, release published, dev
+synced) that can only become true after the release PR merges. Tick each
+one as its step completes.

--- a/lib/aixcl/commands/release.sh
+++ b/lib/aixcl/commands/release.sh
@@ -117,7 +117,7 @@ EOF
     assignee=$(_release_assignee)
     issue_url=$(gh issue create --repo "$RELEASE_UPSTREAM_REPO" \
         --title "[TASK] Release ${RELEASE_NEXT}" \
-        --body "$(printf '## Task Summary\n\nCut release %s.\n\n### Deliverables\n\n- [ ] CHANGELOG.md updated\n- [ ] PR merged to main\n- [ ] Tag %s pushed to upstream\n- [ ] GitHub release published\n- [ ] dev synced with main\n\n## Human in the Loop\n\nThe agent is responsible for completing all deliverables. The human is responsible for completing the verification checklist.' "$RELEASE_NEXT" "$RELEASE_NEXT")" \
+        --body "$(printf '## Task Summary\n\nCut release %s.\n\n### Deliverables\n\n- [ ] CHANGELOG.md updated\n- [ ] PR merged to main (post-merge)\n- [ ] Tag %s pushed to upstream (post-merge)\n- [ ] GitHub release published (post-merge)\n- [ ] dev synced with main (post-merge)\n\n## Human in the Loop\n\nThe agent is responsible for completing all deliverables. The human is responsible for completing the verification checklist.' "$RELEASE_NEXT" "$RELEASE_NEXT")" \
         --assignee "$assignee" \
         --label "Task,component:infrastructure,Maintenance")
     issue_num="${issue_url##*/}"

--- a/scripts/checks/check-pr-ready.sh
+++ b/scripts/checks/check-pr-ready.sh
@@ -70,7 +70,14 @@ _taxonomy_label() {
 _report_unchecked() {
     local body="$1" context="$2" line
     while IFS= read -r line; do
-        error "$context has an unticked checkbox: $line"
+        # Boxes marked "(post-merge)" track release-lifecycle steps (tag,
+        # publish, sync) that can only become true after the PR merges --
+        # release prep stamps them; they inform but never block (issue #1778).
+        if [[ "$line" == *"(post-merge)"* ]]; then
+            info "$context post-merge item (not blocking): $line"
+        else
+            error "$context has an unticked checkbox: $line"
+        fi
     done < <(echo "$body" | grep -E '^\s*- \[ \]' || true)
 }
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1778

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #1778

## Additional Notes

Fixes the gate-vs-release-issue conflict observed during the v1.1.52 cut (documented on PR #1774): the pr-ready gate blocked on release-issue checkboxes that by design can only become true after the release PR merges.

Mechanism (marker-based, per issue deliverable 1): an unticked checkbox whose text contains `(post-merge)` is reported as informational instead of blocking. `./aixcl release prep` now stamps that marker on the four lifecycle deliverables; "CHANGELOG.md updated" keeps gating since it is a pre-merge item. The exception is documented in the Merge Gate section of both rules mirrors.

Live functional test: the checkbox below is deliberately left unticked. The gate run before merging this PR must report it as "post-merge item (not blocking)" and still exit 0. It will be ticked after the merge, proving the marker lifecycle end to end.

- [x] Demonstration lifecycle step for the gate exception (post-merge)

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-07
- Method: implementation with self-demonstrating gate test
- Scope: issue #1778, scripts/checks/check-pr-ready.sh, lib/aixcl/commands/release.sh, rules mirrors
- Confirmation: yes (code changes in this PR)
---


