### PR TITLE
Redact Vault root token from init log output (#1787)

### DIFF
--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -124,11 +124,13 @@ check_artefact_token() {
     local check
     local retries=10
     while [ $retries -gt 0 ]; do
+        # Extract the token accessor, never .data.id -- for lookup-self,
+        # .data.id is the plaintext token itself and must not be logged.
         check=$(curl -sf "${VAULT_ADDR}/v1/auth/token/lookup-self" \
             -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null \
-            | jq -r '.data.id // empty' 2>/dev/null || true)
+            | jq -r '.data.accessor // empty' 2>/dev/null || true)
         if [ -n "$check" ]; then
-            log_info "  [ok] Vault token authenticates (id: ${check})"
+            log_info "  [ok] Vault token authenticates (accessor: ${check})"
             return 0
         fi
         log_verbose "Vault token check failed — retrying... ($retries left)"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1787

### Description of Changes

`check_artefact_token()` in `lib/aixcl/commands/vault-init.sh` printed `.data.id` from the `auth/token/lookup-self` response in its success message. For a token lookup, `.data.id` is the plaintext token itself, so the Vault root token was written to stdout (terminal scrollback, session logs) on every `stack start` and `vault init`. The success message now prints `.data.accessor` instead, which is the audit-safe token identifier and cannot be used to authenticate. A comment marks the line so `.data.id` is not reintroduced.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

Describe how this change was tested:

- Verified against a live Vault instance (fresh vanilla deployment, rootless Podman 4.9.3 on WSL2): the old jq extraction returns the raw `hvs.`-prefixed token, the new extraction returns the accessor
- `bash -n` and `shellcheck --severity=warning --exclude=SC1091` pass on the modified file
- `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- Tests cover change

### Related Issues

- Closes #1787

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-08
- Method: code fix with live-stack verification against a running Vault instance
- Scope: lib/aixcl/commands/vault-init.sh on branch issue-1787/redact-vault-token-init-log
- Confirmation: yes
---
