### PR TITLE
Stabilize compose model hash across phased stack start (#1788)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -597,8 +597,11 @@ function start() {
     echo "Setting ENABLE_DB_STORAGE=${ENABLE_DB_STORAGE} for profile: $profile"
 
     # On warm start (token file already exists from a previous init), pre-load the
-    # Vault token so bootstrap agents start with it from the first compose up.
-    # On first boot the file won't exist yet; bootstrap agents are excluded from the
+    # Vault token so vault-init and the direct agent container runs below can use
+    # it without a second GPG prompt. Compose never sees the token: run_compose
+    # scrubs VAULT_TOKEN so the compose model hash stays stable across the phased
+    # bring-up (see lib/core/docker_utils.sh and issue #1788).
+    # On first boot the file won't exist yet; vault agents are excluded from the
     # initial bring-up and started explicitly after vault-init runs below.
     local _vault_token_file="${SCRIPT_DIR}/.security/vault-root-token.gpg"
     if [ -f "$_vault_token_file" ]; then
@@ -741,10 +744,11 @@ function start() {
                 echo "Vault initialization complete."
 
                 # Decrypt the token vault-init just wrote.
-                # This is the authoritative token delivery path for bootstrap agents.
+                # This is the authoritative token delivery path for vault agents.
                 # --force ensures a stale VAULT_TOKEN in the shell env is replaced
-                # by the newly generated token, which run_compose then passes into
-                # containers via VAULT_TOKEN: ${VAULT_TOKEN:-} in docker-compose.yml.
+                # by the newly generated token. The token reaches agent containers
+                # only via the direct container runs below -- run_compose scrubs
+                # VAULT_TOKEN so the compose model hash stays stable (see #1788).
                 if ! _load_vault_token_for_stack --force; then
                     echo "[ ] Error: Could not load Vault token after init — bootstrap agents cannot start."
                     echo "   Run: ./aixcl vault init"
@@ -756,6 +760,12 @@ function start() {
                 echo "Starting Vault bootstrap agents..."
                 local _vtoken="${VAULT_TOKEN}"
                 local _bin="${DOCKER_BIN:-podman}"
+                # Single source for the Vault image used by direct container
+                # runs. Must match the pin in services/docker-compose.yml --
+                # agents and helpers must run the same Vault version as the
+                # server (the previous hardcoded 2.0.2 had drifted from the
+                # compose pin).
+                local _vault_image="docker.io/hashicorp/vault:2.0.3"
 
                 # Ensure the shared secrets volume is writable by the image's
                 # non-root runtime user (uid 100, gid 1000) regardless of
@@ -771,12 +781,14 @@ function start() {
                 # --network none: this one-shot container only touches a
                 # volume, it never needs network access.
                 "$_bin" run --rm --network none --user 0:0 -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 chown -R 100:1000 /run/secrets \
+                    "$_vault_image" chown -R 100:1000 /run/secrets \
                     >/dev/null 2>&1 || true
 
                 # Force-recreate bootstrap agents with explicit VAULT_TOKEN.
-                # podman-compose 1.0.6 does not interpolate exported shell variables
-                # into compose environment blocks — pass the token directly via podman run.
+                # The token is passed via direct container runs, never through
+                # compose: interpolating it into the compose model changes the
+                # podman-compose project hash mid-start and triggers a forced
+                # recreate of running services (see #1788 and run_compose).
                 # The agent list is derived from compose service names so adding a new
                 # bootstrap agent only requires a change in services/docker-compose.yml.
                 # NOTE: --replace is Podman-only (unsupported by plain Docker), so any
@@ -800,13 +812,47 @@ function start() {
                         --env "VAULT_TOKEN=${_vtoken}" \
                         -v "${SCRIPT_DIR}/scripts/vault/${_script}:/usr/local/bin/${_script}:ro" \
                         -v aixcl-vault-secrets:/run/secrets \
-                        docker.io/hashicorp/vault:2.0.2 "/usr/local/bin/${_script}" > /dev/null
+                        "$_vault_image" "/usr/local/bin/${_script}" > /dev/null
                     echo "  Started ${_agent}"
                 done
-                # Start non-bootstrap vault agents via compose
-                run_compose up -d --no-deps \
-                    vault-agent-postgres \
-                    vault-agent-openwebui 2>/dev/null || true
+
+                # Start the long-running sidecar agents the same way. Their
+                # compose definitions remain in services/docker-compose.yml
+                # (used by `stack stop` and status), but starting them through
+                # compose would require VAULT_TOKEN in the compose model --
+                # exactly the hash instability that recreates running services
+                # (see #1788). Flags mirror the compose definitions.
+                echo "Starting Vault sidecar agents..."
+                local _sidecar
+                for _sidecar in vault-agent-postgres vault-agent-openwebui; do
+                    local _sc_script _sc_args
+                    case "$_sidecar" in
+                        vault-agent-postgres)
+                            _sc_script="vault-agent.sh"
+                            _sc_args="postgres"
+                            ;;
+                        vault-agent-openwebui)
+                            _sc_script="vault-agent-openwebui.sh"
+                            _sc_args=""
+                            ;;
+                    esac
+                    "$_bin" rm -f "$_sidecar" >/dev/null 2>&1 || true
+                    # shellcheck disable=SC2086  # _sc_args is deliberately word-split
+                    if "$_bin" run -d --name "$_sidecar" --restart unless-stopped \
+                        --network host \
+                        --cap-drop ALL --cap-add SETUID --cap-add SETGID \
+                        --tmpfs /vault/file:noexec,nosuid,size=1m \
+                        --tmpfs /vault/logs:noexec,nosuid,size=1m \
+                        --env VAULT_ADDR=http://127.0.0.1:8200 \
+                        --env "VAULT_TOKEN=${_vtoken}" \
+                        -v "${SCRIPT_DIR}/vault/agent-config:/etc/vault:ro" \
+                        -v "${SCRIPT_DIR}/scripts/vault/${_sc_script}:/usr/local/bin/${_sc_script}:ro" \
+                        "$_vault_image" "/usr/local/bin/${_sc_script}" ${_sc_args} > /dev/null; then
+                        echo "  Started ${_sidecar}"
+                    else
+                        echo "  Warning: failed to start ${_sidecar}"
+                    fi
+                done
 
                 # Wait for postgres-password to appear in the shared secrets volume
                 echo "Waiting for bootstrap secrets to be written..."
@@ -816,7 +862,7 @@ function start() {
                     local _pw
                     _pw=$("$_docker_bin" run --rm \
                         -v aixcl-vault-secrets:/s \
-                        docker.io/hashicorp/vault:2.0.2 \
+                        "$_vault_image" \
                         sh -c "cat /s/postgres-password 2>/dev/null" 2>/dev/null || true)
                     if [ -n "$_pw" ]; then
                         echo "Bootstrap secrets ready."

--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -140,7 +140,17 @@ run_compose() {
     # podman-compose create/start fallback pair (name collision on an
     # existing container followed by a successful "podman start"). Real
     # errors do not match these narrow patterns and always pass through.
-    (cd "${COMPOSE_WORKDIR}" && "${COMPOSE_CMD[@]}" "$@" 2>&1) | \
+    # VAULT_TOKEN is scrubbed from the compose environment on purpose.
+    # podman-compose hashes the fully-interpolated compose model and
+    # force-recreates every container in scope (dependencies included,
+    # regardless of --no-deps) whenever any existing container's hash label
+    # differs from the current model. stack start exports VAULT_TOKEN midway
+    # through its phased bring-up, so letting compose interpolate it changes
+    # the project hash between phases and tears down running services --
+    # including Vault itself, which then reseals (issue #1788). Containers
+    # that need the token (vault agents) receive it via direct container
+    # runs in stack.sh instead.
+    (cd "${COMPOSE_WORKDIR}" && env -u VAULT_TOKEN "${COMPOSE_CMD[@]}" "$@" 2>&1) | \
     awk '
         # -- Stateful: suppress merged-command dumps ------------------------
         # podman-compose echoes "** merged:" followed by the merged command

--- a/tests/command-tests/test-02-stack-start.sh
+++ b/tests/command-tests/test-02-stack-start.sh
@@ -34,6 +34,23 @@ log_info "Setting engine to ollama..."
 # Test: Stack starts successfully
 assert_command_success "${SCRIPT_DIR}/aixcl stack start --profile sys" "Stack starts with sys profile"
 
+# Regression #1788: the phased bring-up must not recreate running containers.
+# podman-compose force-recreates a service's whole dependency closure when the
+# compose model hash changes mid-start; these signatures indicate that storm.
+# /tmp/test_output.log still holds the stack start output captured above.
+START_OUTPUT=$(cat /tmp/test_output.log 2>/dev/null || true)
+assert_string_not_contains "$START_OUTPUT" "is already in use" \
+    "No container name collisions during phased start"
+assert_string_not_contains "$START_OUTPUT" "has dependent containers" \
+    "No dependent-container removal failures during phased start"
+UNSEAL_COUNT=$(grep -c "Vault unsealed successfully" /tmp/test_output.log 2>/dev/null || true)
+if [ "${UNSEAL_COUNT:-0}" -le 1 ]; then
+    log_success "Vault unsealed at most once during start (count: ${UNSEAL_COUNT:-0})"
+else
+    log_error "Vault resealed during start (unseal count: ${UNSEAL_COUNT})"
+    exit 1
+fi
+
 # Test: Core containers are running
 wait_for_container "ollama"
 wait_for_container "postgres"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1788

### Description of Changes

Root cause (verified in podman-compose 1.0.6 source): `compose_up` hashes the fully interpolated compose model and runs a scoped `compose_down` whenever any existing project container's `config-hash` label differs from the current model. `get_excluded` keeps dependencies in scope regardless of `--no-deps`, and `--no-recreate` is never consulted. `stack start` exports `VAULT_TOKEN` after vault-init, which changed the interpolated model (`${VAULT_TOKEN:-}` in the vault-agent environment blocks), so every later phased `up` tore down and recreated its whole dependency closure -- including Vault, which resealed on every recreation.

Changes:

- `run_compose` now scrubs `VAULT_TOKEN` from the compose environment (`env -u VAULT_TOKEN`), so the compose model interpolates identically at every lifecycle point and the project hash stays stable across the phased bring-up
- The long-running sidecar agents (`vault-agent-postgres`, `vault-agent-openwebui`) now start via direct container runs with the token passed explicitly, mirroring the established bootstrap-agent pattern; their compose definitions remain for `stack stop` and status
- The Vault image used by direct container runs is hoisted to a single `_vault_image` variable pinned to 2.0.3, matching the compose pin -- the previous hardcoded 2.0.2 had drifted and ran agents on a different Vault version than the server
- Stale comments describing compose as the token delivery path are corrected

Known limitation (pre-existing): starting a sidecar agent individually via `./aixcl service start vault-agent-postgres` goes through compose and therefore gets no token; this was already broken in any shell without VAULT_TOKEN exported and is unchanged by this PR. `stack start`/`stack restart` are the supported paths.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

Describe how this change was tested:

- Live verification on the reporting host (WSL2, rootless Podman 4.9.3, podman-compose 1.0.6): full `./aixcl stack stop` + `./aixcl stack start --profile sys` cycle with the fix applied
- Before: multiple "container name already in use" and "has dependent containers" errors per start; Vault stopped/recreated at least 3 times per start, resealing each time; postgres, prometheus, and loki removed and recreated mid-start
- After: zero name-collision errors, zero dependent-container errors, Vault unsealed exactly once ("already unsealed -- nothing to do" at the post-init check), no mid-start teardown of running services, final status 21/21 services healthy
- `bash -n` and `shellcheck --severity=warning --exclude=SC1091` pass on both modified files
- `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- Tests cover change

### Related Issues

- Closes #1788

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-09
- Method: root-cause analysis in podman-compose source, code fix, and live stack stop/start verification
- Scope: lib/aixcl/commands/stack.sh and lib/core/docker_utils.sh on branch issue-1788/stabilize-compose-hash-phased-start
- Confirmation: yes
---
