### PR TITLE
First-run UX polish for stack init and start (#1792)

### DIFF
--- a/aixcl
+++ b/aixcl
@@ -25,9 +25,12 @@ source "${SCRIPT_DIR}/lib/core/service_utils.sh"
 
 # Load environment variables from .env file (before docker_utils validates COMPOSE_FILE)
 if ! load_env_file ".env"; then
-    if [ "${1:-}" != "stack" ] || [ "${2:-}" != "start" ]; then
+    # stack init is the documented first-run path and stack start creates
+    # .env itself -- warning during either would be noise (or, worse, point
+    # the user away from the command they are already running).
+    if [ "${1:-}" != "stack" ] || { [ "${2:-}" != "start" ] && [ "${2:-}" != "init" ]; }; then
         echo "   Warning: .env file not found. AIXCL will use default values."
-        echo "   Run './aixcl stack start' to initialize the environment."
+        echo "   Run './aixcl stack init' to initialize the environment."
         echo ""
     fi
 fi

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -761,11 +761,14 @@ function start() {
                 local _vtoken="${VAULT_TOKEN}"
                 local _bin="${DOCKER_BIN:-podman}"
                 # Single source for the Vault image used by direct container
-                # runs. Must match the pin in services/docker-compose.yml --
-                # agents and helpers must run the same Vault version as the
-                # server (the previous hardcoded 2.0.2 had drifted from the
-                # compose pin).
-                local _vault_image="docker.io/hashicorp/vault:2.0.3"
+                # runs: derive it from the compose pin at runtime so agents
+                # and helpers can never drift from the server version again
+                # (a previous hardcoded 2.0.2 had drifted from the compose
+                # pin). The fallback is only used if the grep fails.
+                local _vault_image
+                _vault_image=$(grep -m1 -oE 'docker\.io/hashicorp/vault:[0-9][0-9.]*' \
+                    "${SERVICES_DIR:-${SCRIPT_DIR}/services}/docker-compose.yml" 2>/dev/null || true)
+                _vault_image="${_vault_image:-docker.io/hashicorp/vault:2.0.3}"
 
                 # Ensure the shared secrets volume is writable by the image's
                 # non-root runtime user (uid 100, gid 1000) regardless of
@@ -1013,7 +1016,7 @@ function start() {
                 printf "  All services report healthy.%20s\n" ""
                 break
             fi
-            printf "  %d service(s) still starting... (%ds/%ds)  \r" "$still_starting" "$((hw_attempt * 5))" "$((hw_max * 5))"
+            printf "  %d service(s) still starting... (%ds/%ds)%10s\r" "$still_starting" "$((hw_attempt * 5))" "$((hw_max * 5))" ""
             sleep 5
             hw_attempt=$((hw_attempt + 1))
         done
@@ -1039,7 +1042,7 @@ function start() {
             if [ -f "$vault_unseal_script" ]; then
                 bash "$vault_unseal_script" 2>&1 | grep -E "\[INFO\]|\[WARN\]|\[ERROR\]" || true
             fi
-            printf "  Waiting for Vault to settle... (%ds/%ds)\r" "$((vault_settle * 5))" "$((vault_settle_max * 5))"
+            printf "  Waiting for Vault to settle... (%ds/%ds)%10s\r" "$((vault_settle * 5))" "$((vault_settle_max * 5))" ""
             sleep 5
             vault_settle=$((vault_settle + 1))
         done
@@ -1089,7 +1092,7 @@ function stop() {
             _print_stopped_status "$profile"
             return 0
         fi
-        printf "  Waiting for containers to stop... (%ds/%ds)\r" "$((st_attempt * 2))" "$((st_max * 2))"
+        printf "  Waiting for containers to stop... (%ds/%ds)%10s\r" "$((st_attempt * 2))" "$((st_max * 2))" ""
         sleep 2
         st_attempt=$((st_attempt + 1))
     done

--- a/scripts/runtime/ollama-entrypoint.sh
+++ b/scripts/runtime/ollama-entrypoint.sh
@@ -24,5 +24,10 @@ usermod -aG video,render "$OLLAMA_USER" 2>/dev/null || true
 
 echo "Starting Ollama as $OLLAMA_USER user..."
 
-# Switch to ubuntu user and execute ollama
-exec su - "$OLLAMA_USER" -c "exec ollama serve"
+# Switch to the ollama user and exec ollama directly so PID 1 receives
+# SIGTERM (su as PID 1 swallows signals, forcing a SIGKILL at the stop
+# timeout). setpriv ships with util-linux in the base image;
+# --init-groups picks up the video/render groups added above, and unlike
+# 'su -' it preserves the container environment (OLLAMA_HOST, tuning vars).
+exec setpriv --reuid "$OLLAMA_UID" --regid "$OLLAMA_UID" --init-groups \
+    env HOME="$OLLAMA_HOME" USER="$OLLAMA_USER" LOGNAME="$OLLAMA_USER" ollama serve

--- a/services/docker-compose.gpu.yml
+++ b/services/docker-compose.gpu.yml
@@ -31,7 +31,8 @@ services:
         mkdir -p "$$OLLAMA_DATA"
         chown -R "$$OLLAMA_USER:$$OLLAMA_USER" "$$OLLAMA_HOME"
         usermod -aG video,render "$$OLLAMA_USER" 2>/dev/null || true
-        exec su - "$$OLLAMA_USER" -c "exec ollama serve"
+        exec setpriv --reuid "$$OLLAMA_UID" --regid "$$OLLAMA_UID" --init-groups \
+            env HOME="$$OLLAMA_HOME" USER="$$OLLAMA_USER" LOGNAME="$$OLLAMA_USER" ollama serve
 
   nvidia-gpu-exporter:
     deploy:


### PR DESCRIPTION
## Summary

Fixes #1792

Polishes the first-run experience observed during a vanilla deployment (clone, check-env, init, start) on rootless Podman. Four small changes, no behavioral semantics altered.

## Changes

- `aixcl`: the missing-.env warning now points to `./aixcl stack init` (the documented initialization path) instead of `stack start`, and is suppressed while `stack init` or `stack start` is itself running -- warning the user to run the command they are already running was noise
- `lib/aixcl/commands/stack.sh`: the three `printf "...\r"` progress lines (health wait, vault settle, stop wait) now pad to end of line so shrinking counters no longer leave residue like `(15s/180s)0s/180s)`
- `lib/aixcl/commands/stack.sh`: the Vault sidecar image is now derived at runtime from the pin in `services/docker-compose.yml` (with the current pin as fallback) instead of being hardcoded three times, so version bumps cannot drift
- `scripts/runtime/ollama-entrypoint.sh` + `services/docker-compose.gpu.yml` (inline parity block): replace `su - ubuntu -c "exec ollama serve"` with `setpriv --reuid --regid --init-groups env HOME=... ollama serve`; `su` as PID 1 swallowed SIGTERM (forcing the 10s SIGKILL timeout on every stop) and, being a login shell, silently dropped all compose-provided tuning env vars (OLLAMA_HOST, OLLAMA_NUM_PARALLEL, etc.) before they reached the engine

The completion-fallback deliverable from the issue was found already fixed on dev (`completion/aixcl.bash` explicitly clears COMPREPLY instead of falling back to filename completion); no change needed.

## Verification

- [x] Bare `./aixcl` with no .env prints the corrected warning; `./aixcl stack init` and `./aixcl stack start` print no warning (tested by moving .env aside and restoring)
- [x] `git grep 'hashicorp/vault' -- lib services` shows the compose file as the single pinned source; stack.sh only derives from it
- [x] Ollama container PID 1 is `ollama serve` running as ubuntu; server config log shows OLLAMA_HOST and OLLAMA_NUM_PARALLEL propagated; GPU (CUDA) still detected
- [x] `./aixcl stack stop` stops ollama gracefully in under 1s (was 10s SIGKILL timeout)
- [x] Full cold-boot `./aixcl stack start --profile sys` cycle: no container conflicts, single Vault unseal, all services healthy, progress lines render clean
- [x] shellcheck and bash -n clean on all touched shell files

## Human Verification

- [x] Fresh-clone walkthrough produces no misleading warnings or garbled progress lines
- [x] No regressions observed in stack start/stop behavior

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-09
- Method: implementation with live-stack verification on rootless Podman 4.9.3 / WSL2
- Scope: aixcl, lib/aixcl/commands/stack.sh, scripts/runtime/ollama-entrypoint.sh, services/docker-compose.gpu.yml, completion/aixcl.bash (read-only), running podman containers
- Confirmation: yes
---

