### PR TITLE
Release v1.1.54 (#1797)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the AIXCL project will be documented in this file.
 ## [Unreleased]
 
 
+## [v1.1.54] - 2026-07-09
+
+### Summary
+
+Release v1.1.54 -- First-run experience repaired end to end: a vanilla clone-to-running deployment no longer logs the Vault root token, no longer storms through container recreations during phased start, and stops Ollama gracefully instead of waiting out the kill timeout.
+
+### Changed
+
+- [x] **Recreation Storm Regression Test**: test-02-stack-start now fails if a stack start emits "name already in use" or "has dependent containers" errors, or unseals Vault more than once -- the observable symptoms of a compose recreation storm. Addresses #1788.
+
+### Fixed
+
+- [x] **Vault Root Token No Longer Logged**: vault-init logged the plaintext root token during artefact verification because lookup-self returns the token itself as `.data.id`; the check now extracts and logs the audit-safe token accessor instead. Operators of existing installs should rotate the root token. Closes #1787.
+- [x] **Compose Recreation Storm on Phased Start**: `VAULT_TOKEN` in the compose process environment changed podman-compose's interpolated config hash between start phases, forcing scoped down/up cycles that recreated healthy containers, double-unsealed Vault, and spewed "name already in use" errors; the token is now excluded from the compose environment and the two Vault agent sidecars are run directly. Closes #1788.
+- [x] **First-Run UX Polish**: the missing-.env warning now points at `./aixcl stack init` and stays quiet while init/start run; progress lines pad to end of line so shrinking counters leave no residue; the Vault sidecar image is derived from the compose pin instead of three hardcoded copies; and the Ollama entrypoint drops privileges with setpriv instead of `su -`, so PID 1 receives SIGTERM (graceful stop in under 1s instead of the 10s SIGKILL timeout) and compose-provided tuning variables reach the engine. Closes #1792.
+
+
+
+
 ## [v1.1.53] - 2026-07-07
 
 ### Summary

--- a/aixcl
+++ b/aixcl
@@ -25,9 +25,12 @@ source "${SCRIPT_DIR}/lib/core/service_utils.sh"
 
 # Load environment variables from .env file (before docker_utils validates COMPOSE_FILE)
 if ! load_env_file ".env"; then
-    if [ "${1:-}" != "stack" ] || [ "${2:-}" != "start" ]; then
+    # stack init is the documented first-run path and stack start creates
+    # .env itself -- warning during either would be noise (or, worse, point
+    # the user away from the command they are already running).
+    if [ "${1:-}" != "stack" ] || { [ "${2:-}" != "start" ] && [ "${2:-}" != "init" ]; }; then
         echo "   Warning: .env file not found. AIXCL will use default values."
-        echo "   Run './aixcl stack start' to initialize the environment."
+        echo "   Run './aixcl stack init' to initialize the environment."
         echo ""
     fi
 fi

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -761,11 +761,14 @@ function start() {
                 local _vtoken="${VAULT_TOKEN}"
                 local _bin="${DOCKER_BIN:-podman}"
                 # Single source for the Vault image used by direct container
-                # runs. Must match the pin in services/docker-compose.yml --
-                # agents and helpers must run the same Vault version as the
-                # server (the previous hardcoded 2.0.2 had drifted from the
-                # compose pin).
-                local _vault_image="docker.io/hashicorp/vault:2.0.3"
+                # runs: derive it from the compose pin at runtime so agents
+                # and helpers can never drift from the server version again
+                # (a previous hardcoded 2.0.2 had drifted from the compose
+                # pin). The fallback is only used if the grep fails.
+                local _vault_image
+                _vault_image=$(grep -m1 -oE 'docker\.io/hashicorp/vault:[0-9][0-9.]*' \
+                    "${SERVICES_DIR:-${SCRIPT_DIR}/services}/docker-compose.yml" 2>/dev/null || true)
+                _vault_image="${_vault_image:-docker.io/hashicorp/vault:2.0.3}"
 
                 # Ensure the shared secrets volume is writable by the image's
                 # non-root runtime user (uid 100, gid 1000) regardless of
@@ -1013,7 +1016,7 @@ function start() {
                 printf "  All services report healthy.%20s\n" ""
                 break
             fi
-            printf "  %d service(s) still starting... (%ds/%ds)  \r" "$still_starting" "$((hw_attempt * 5))" "$((hw_max * 5))"
+            printf "  %d service(s) still starting... (%ds/%ds)%10s\r" "$still_starting" "$((hw_attempt * 5))" "$((hw_max * 5))" ""
             sleep 5
             hw_attempt=$((hw_attempt + 1))
         done
@@ -1039,7 +1042,7 @@ function start() {
             if [ -f "$vault_unseal_script" ]; then
                 bash "$vault_unseal_script" 2>&1 | grep -E "\[INFO\]|\[WARN\]|\[ERROR\]" || true
             fi
-            printf "  Waiting for Vault to settle... (%ds/%ds)\r" "$((vault_settle * 5))" "$((vault_settle_max * 5))"
+            printf "  Waiting for Vault to settle... (%ds/%ds)%10s\r" "$((vault_settle * 5))" "$((vault_settle_max * 5))" ""
             sleep 5
             vault_settle=$((vault_settle + 1))
         done
@@ -1089,7 +1092,7 @@ function stop() {
             _print_stopped_status "$profile"
             return 0
         fi
-        printf "  Waiting for containers to stop... (%ds/%ds)\r" "$((st_attempt * 2))" "$((st_max * 2))"
+        printf "  Waiting for containers to stop... (%ds/%ds)%10s\r" "$((st_attempt * 2))" "$((st_max * 2))" ""
         sleep 2
         st_attempt=$((st_attempt + 1))
     done

--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -597,8 +597,11 @@ function start() {
     echo "Setting ENABLE_DB_STORAGE=${ENABLE_DB_STORAGE} for profile: $profile"
 
     # On warm start (token file already exists from a previous init), pre-load the
-    # Vault token so bootstrap agents start with it from the first compose up.
-    # On first boot the file won't exist yet; bootstrap agents are excluded from the
+    # Vault token so vault-init and the direct agent container runs below can use
+    # it without a second GPG prompt. Compose never sees the token: run_compose
+    # scrubs VAULT_TOKEN so the compose model hash stays stable across the phased
+    # bring-up (see lib/core/docker_utils.sh and issue #1788).
+    # On first boot the file won't exist yet; vault agents are excluded from the
     # initial bring-up and started explicitly after vault-init runs below.
     local _vault_token_file="${SCRIPT_DIR}/.security/vault-root-token.gpg"
     if [ -f "$_vault_token_file" ]; then
@@ -741,10 +744,11 @@ function start() {
                 echo "Vault initialization complete."
 
                 # Decrypt the token vault-init just wrote.
-                # This is the authoritative token delivery path for bootstrap agents.
+                # This is the authoritative token delivery path for vault agents.
                 # --force ensures a stale VAULT_TOKEN in the shell env is replaced
-                # by the newly generated token, which run_compose then passes into
-                # containers via VAULT_TOKEN: ${VAULT_TOKEN:-} in docker-compose.yml.
+                # by the newly generated token. The token reaches agent containers
+                # only via the direct container runs below -- run_compose scrubs
+                # VAULT_TOKEN so the compose model hash stays stable (see #1788).
                 if ! _load_vault_token_for_stack --force; then
                     echo "[ ] Error: Could not load Vault token after init — bootstrap agents cannot start."
                     echo "   Run: ./aixcl vault init"
@@ -756,6 +760,12 @@ function start() {
                 echo "Starting Vault bootstrap agents..."
                 local _vtoken="${VAULT_TOKEN}"
                 local _bin="${DOCKER_BIN:-podman}"
+                # Single source for the Vault image used by direct container
+                # runs. Must match the pin in services/docker-compose.yml --
+                # agents and helpers must run the same Vault version as the
+                # server (the previous hardcoded 2.0.2 had drifted from the
+                # compose pin).
+                local _vault_image="docker.io/hashicorp/vault:2.0.3"
 
                 # Ensure the shared secrets volume is writable by the image's
                 # non-root runtime user (uid 100, gid 1000) regardless of
@@ -771,12 +781,14 @@ function start() {
                 # --network none: this one-shot container only touches a
                 # volume, it never needs network access.
                 "$_bin" run --rm --network none --user 0:0 -v aixcl-vault-secrets:/run/secrets \
-                    docker.io/hashicorp/vault:2.0.2 chown -R 100:1000 /run/secrets \
+                    "$_vault_image" chown -R 100:1000 /run/secrets \
                     >/dev/null 2>&1 || true
 
                 # Force-recreate bootstrap agents with explicit VAULT_TOKEN.
-                # podman-compose 1.0.6 does not interpolate exported shell variables
-                # into compose environment blocks — pass the token directly via podman run.
+                # The token is passed via direct container runs, never through
+                # compose: interpolating it into the compose model changes the
+                # podman-compose project hash mid-start and triggers a forced
+                # recreate of running services (see #1788 and run_compose).
                 # The agent list is derived from compose service names so adding a new
                 # bootstrap agent only requires a change in services/docker-compose.yml.
                 # NOTE: --replace is Podman-only (unsupported by plain Docker), so any
@@ -800,13 +812,47 @@ function start() {
                         --env "VAULT_TOKEN=${_vtoken}" \
                         -v "${SCRIPT_DIR}/scripts/vault/${_script}:/usr/local/bin/${_script}:ro" \
                         -v aixcl-vault-secrets:/run/secrets \
-                        docker.io/hashicorp/vault:2.0.2 "/usr/local/bin/${_script}" > /dev/null
+                        "$_vault_image" "/usr/local/bin/${_script}" > /dev/null
                     echo "  Started ${_agent}"
                 done
-                # Start non-bootstrap vault agents via compose
-                run_compose up -d --no-deps \
-                    vault-agent-postgres \
-                    vault-agent-openwebui 2>/dev/null || true
+
+                # Start the long-running sidecar agents the same way. Their
+                # compose definitions remain in services/docker-compose.yml
+                # (used by `stack stop` and status), but starting them through
+                # compose would require VAULT_TOKEN in the compose model --
+                # exactly the hash instability that recreates running services
+                # (see #1788). Flags mirror the compose definitions.
+                echo "Starting Vault sidecar agents..."
+                local _sidecar
+                for _sidecar in vault-agent-postgres vault-agent-openwebui; do
+                    local _sc_script _sc_args
+                    case "$_sidecar" in
+                        vault-agent-postgres)
+                            _sc_script="vault-agent.sh"
+                            _sc_args="postgres"
+                            ;;
+                        vault-agent-openwebui)
+                            _sc_script="vault-agent-openwebui.sh"
+                            _sc_args=""
+                            ;;
+                    esac
+                    "$_bin" rm -f "$_sidecar" >/dev/null 2>&1 || true
+                    # shellcheck disable=SC2086  # _sc_args is deliberately word-split
+                    if "$_bin" run -d --name "$_sidecar" --restart unless-stopped \
+                        --network host \
+                        --cap-drop ALL --cap-add SETUID --cap-add SETGID \
+                        --tmpfs /vault/file:noexec,nosuid,size=1m \
+                        --tmpfs /vault/logs:noexec,nosuid,size=1m \
+                        --env VAULT_ADDR=http://127.0.0.1:8200 \
+                        --env "VAULT_TOKEN=${_vtoken}" \
+                        -v "${SCRIPT_DIR}/vault/agent-config:/etc/vault:ro" \
+                        -v "${SCRIPT_DIR}/scripts/vault/${_sc_script}:/usr/local/bin/${_sc_script}:ro" \
+                        "$_vault_image" "/usr/local/bin/${_sc_script}" ${_sc_args} > /dev/null; then
+                        echo "  Started ${_sidecar}"
+                    else
+                        echo "  Warning: failed to start ${_sidecar}"
+                    fi
+                done
 
                 # Wait for postgres-password to appear in the shared secrets volume
                 echo "Waiting for bootstrap secrets to be written..."
@@ -816,7 +862,7 @@ function start() {
                     local _pw
                     _pw=$("$_docker_bin" run --rm \
                         -v aixcl-vault-secrets:/s \
-                        docker.io/hashicorp/vault:2.0.2 \
+                        "$_vault_image" \
                         sh -c "cat /s/postgres-password 2>/dev/null" 2>/dev/null || true)
                     if [ -n "$_pw" ]; then
                         echo "Bootstrap secrets ready."

--- a/lib/aixcl/commands/vault-init.sh
+++ b/lib/aixcl/commands/vault-init.sh
@@ -124,11 +124,13 @@ check_artefact_token() {
     local check
     local retries=10
     while [ $retries -gt 0 ]; do
+        # Extract the token accessor, never .data.id -- for lookup-self,
+        # .data.id is the plaintext token itself and must not be logged.
         check=$(curl -sf "${VAULT_ADDR}/v1/auth/token/lookup-self" \
             -H "X-Vault-Token: ${VAULT_TOKEN}" 2>/dev/null \
-            | jq -r '.data.id // empty' 2>/dev/null || true)
+            | jq -r '.data.accessor // empty' 2>/dev/null || true)
         if [ -n "$check" ]; then
-            log_info "  [ok] Vault token authenticates (id: ${check})"
+            log_info "  [ok] Vault token authenticates (accessor: ${check})"
             return 0
         fi
         log_verbose "Vault token check failed — retrying... ($retries left)"

--- a/lib/core/docker_utils.sh
+++ b/lib/core/docker_utils.sh
@@ -140,7 +140,17 @@ run_compose() {
     # podman-compose create/start fallback pair (name collision on an
     # existing container followed by a successful "podman start"). Real
     # errors do not match these narrow patterns and always pass through.
-    (cd "${COMPOSE_WORKDIR}" && "${COMPOSE_CMD[@]}" "$@" 2>&1) | \
+    # VAULT_TOKEN is scrubbed from the compose environment on purpose.
+    # podman-compose hashes the fully-interpolated compose model and
+    # force-recreates every container in scope (dependencies included,
+    # regardless of --no-deps) whenever any existing container's hash label
+    # differs from the current model. stack start exports VAULT_TOKEN midway
+    # through its phased bring-up, so letting compose interpolate it changes
+    # the project hash between phases and tears down running services --
+    # including Vault itself, which then reseals (issue #1788). Containers
+    # that need the token (vault agents) receive it via direct container
+    # runs in stack.sh instead.
+    (cd "${COMPOSE_WORKDIR}" && env -u VAULT_TOKEN "${COMPOSE_CMD[@]}" "$@" 2>&1) | \
     awk '
         # -- Stateful: suppress merged-command dumps ------------------------
         # podman-compose echoes "** merged:" followed by the merged command

--- a/scripts/runtime/ollama-entrypoint.sh
+++ b/scripts/runtime/ollama-entrypoint.sh
@@ -24,5 +24,10 @@ usermod -aG video,render "$OLLAMA_USER" 2>/dev/null || true
 
 echo "Starting Ollama as $OLLAMA_USER user..."
 
-# Switch to ubuntu user and execute ollama
-exec su - "$OLLAMA_USER" -c "exec ollama serve"
+# Switch to the ollama user and exec ollama directly so PID 1 receives
+# SIGTERM (su as PID 1 swallows signals, forcing a SIGKILL at the stop
+# timeout). setpriv ships with util-linux in the base image;
+# --init-groups picks up the video/render groups added above, and unlike
+# 'su -' it preserves the container environment (OLLAMA_HOST, tuning vars).
+exec setpriv --reuid "$OLLAMA_UID" --regid "$OLLAMA_UID" --init-groups \
+    env HOME="$OLLAMA_HOME" USER="$OLLAMA_USER" LOGNAME="$OLLAMA_USER" ollama serve

--- a/services/docker-compose.gpu.yml
+++ b/services/docker-compose.gpu.yml
@@ -31,7 +31,8 @@ services:
         mkdir -p "$$OLLAMA_DATA"
         chown -R "$$OLLAMA_USER:$$OLLAMA_USER" "$$OLLAMA_HOME"
         usermod -aG video,render "$$OLLAMA_USER" 2>/dev/null || true
-        exec su - "$$OLLAMA_USER" -c "exec ollama serve"
+        exec setpriv --reuid "$$OLLAMA_UID" --regid "$$OLLAMA_UID" --init-groups \
+            env HOME="$$OLLAMA_HOME" USER="$$OLLAMA_USER" LOGNAME="$$OLLAMA_USER" ollama serve
 
   nvidia-gpu-exporter:
     deploy:

--- a/tests/command-tests/test-02-stack-start.sh
+++ b/tests/command-tests/test-02-stack-start.sh
@@ -34,6 +34,23 @@ log_info "Setting engine to ollama..."
 # Test: Stack starts successfully
 assert_command_success "${SCRIPT_DIR}/aixcl stack start --profile sys" "Stack starts with sys profile"
 
+# Regression #1788: the phased bring-up must not recreate running containers.
+# podman-compose force-recreates a service's whole dependency closure when the
+# compose model hash changes mid-start; these signatures indicate that storm.
+# /tmp/test_output.log still holds the stack start output captured above.
+START_OUTPUT=$(cat /tmp/test_output.log 2>/dev/null || true)
+assert_string_not_contains "$START_OUTPUT" "is already in use" \
+    "No container name collisions during phased start"
+assert_string_not_contains "$START_OUTPUT" "has dependent containers" \
+    "No dependent-container removal failures during phased start"
+UNSEAL_COUNT=$(grep -c "Vault unsealed successfully" /tmp/test_output.log 2>/dev/null || true)
+if [ "${UNSEAL_COUNT:-0}" -le 1 ]; then
+    log_success "Vault unsealed at most once during start (count: ${UNSEAL_COUNT:-0})"
+else
+    log_error "Vault resealed during start (unseal count: ${UNSEAL_COUNT})"
+    exit 1
+fi
+
 # Test: Core containers are running
 wait_for_container "ollama"
 wait_for_container "postgres"


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1797

### Description of Changes
Release v1.1.54. Promotes dev to main with the changelog entry for this cycle.

First-run experience repaired end to end: a vanilla clone-to-running deployment no longer logs the Vault root token, no longer storms through container recreations during phased start, and stops Ollama gracefully instead of waiting out the kill timeout.

Included work:

- Closes #1787 (Vault root token no longer logged; accessor logged instead)
- Closes #1788 (compose recreation storm on phased start, plus regression test)
- Closes #1792 (first-run UX polish: warning target, progress lines, Vault image pin dedup, setpriv entrypoint)

Pre-release retrospective: https://github.com/xencon/aixcl/discussions/1796

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- `./aixcl checks all` green on the release branch (paths, agents, elisions, generated, ascii, pins, yaml, compose, env)
- All constituent PRs merged to dev with full CI green and live-stack verification on rootless Podman 4.9.3 / WSL2:
  - PR #1793
  - PR #1794
  - PR #1795

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #1797

## Additional Notes

Changelog-only diff against main apart from the already-reviewed dev history; the version tag is created after merge via `./aixcl release tag`.

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-09
- Method: release preparation via ./aixcl release prep with human-authorized GPG commit
- Scope: CHANGELOG.md on branch issue-1797/release-v1-1-54; release cycle PRs and issues referenced above
- Confirmation: yes
---
