### PR TITLE
Sync agent queue label rename to docs and agent definitions (#1813)

### DIFF
--- a/.opencode/CONTEXT.md
+++ b/.opencode/CONTEXT.md
@@ -20,14 +20,14 @@ notes) inside those two directories, or they register as a bogus
 
 | File | Mode | Purpose |
 |------|------|---------|
-| `agents/agent-context.md` | primary | Worker for the `agent:qwen` issue queue -- operational guidance, tool discipline, memory conventions |
+| `agents/agent-context.md` | primary | Worker for the `agent` issue queue -- operational guidance, tool discipline, memory conventions |
 | `agents/reviewer.md` | subagent | Read-only reviewer: `edit` denied, inspection-only bash allowlist |
 
 ## Commands
 
 | File | Command | Purpose |
 |------|---------|---------|
-| `commands/next-task.md` | `/next-task` | Injects the single oldest open `agent:qwen` issue as the one and only work item |
+| `commands/next-task.md` | `/next-task` | Injects the single oldest open `agent` issue as the one and only work item |
 | `commands/pr-ready.md` | `/pr-ready` | Gates PR creation on verified signed commits ahead of `upstream/dev`; hands the commit to the human if none exist |
 | `commands/finish-pr.md` | `/finish-pr` | Verifies a PR is actually MERGED before branch cleanup and issue close |
 

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -17,11 +17,11 @@ is specific to this agent.
 
 ## Finding Your Work
 
-Issues queued for this agent carry the `agent:qwen` label. At session
+Issues queued for this agent carry the `agent` label. At session
 start, or whenever the human asks what to work on next, list the queue:
 
 ```bash
-gh issue list --repo xencon/aixcl --label agent:qwen --state open
+gh issue list --repo xencon/aixcl --label agent --state open
 ```
 
 Rules for working the queue:
@@ -30,7 +30,7 @@ Rules for working the queue:
   already exists -- start at the branch step)
 - The issue body is the task specification; if it is ambiguous, post a
   clarifying question as an issue comment and wait rather than guessing
-- Do not pick up issues without the `agent:qwen` label unless the human
+- Do not pick up issues without the `agent` label unless the human
   directs you to in the live session
 
 Prefer the guided commands for procedural work -- they embed the correct

--- a/.opencode/commands/next-task.md
+++ b/.opencode/commands/next-task.md
@@ -1,5 +1,5 @@
 ---
-description: Pick up the next issue from the agent:qwen work queue
+description: Pick up the next issue from the agent work queue
 agent: agent-context
 ---
 
@@ -7,7 +7,7 @@ Your next task -- this is the only issue you are assigned; there is no
 choice to make. If the line below is empty, report that the queue is empty
 and stop:
 
-!`gh issue list --repo xencon/aixcl --label agent:qwen --state open --json number,title,labels --jq 'sort_by(.number) | .[0] // empty | "#\(.number) [\(.labels | map(.name) | join(","))] \(.title)"'`
+!`gh issue list --repo xencon/aixcl --label agent --state open --json number,title,labels --jq 'sort_by(.number) | .[0] // empty | "#\(.number) [\(.labels | map(.name) | join(","))] \(.title)"'`
 
 Your current git state:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,8 @@ AIXCL is client-agnostic above the OpenAI-compatible API layer. OpenCode and Cla
 - Priority: `P1`, `P2`, `P3`
 - Profile: `profile:bld`, `profile:sys`
 - Category: `Fix`, `Enhancement`, `Refactor`, `Maintenance`
-- Agent queue: `agent:qwen` (issues queued for a named agent; the agent
-  discovers its work by listing open issues with its label)
+- Agent queue: `agent` (issues queued for agent execution; an agent
+  discovers its work by listing open issues with this label)
 
 ### Lean Repository Policy
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1813

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected -- the renamed label query returns the queue (#1812) exactly as /next-task will inject it
- [x] No regressions observed -- ./aixcl checks all and ./aixcl test lib pass; diff is docs and agent definitions only
- [x] Tests cover change -- covered by CI check-agents, check-ascii-markdown, and markdown link checks that gate these files

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #1813

## Additional Notes

The GitHub queue label was renamed from agent-qwen form to `agent` on 2026-07-10 so a single queue serves any onboarded agent. This PR syncs the tracked references that implement and document the queue: the agent definition discovery query, the /next-task injected query, the .opencode directory contract, and the AGENTS.md label taxonomy. The CHANGELOG.md historical entry is intentionally unchanged.

Testing: `./aixcl checks all` passes (paths, agents, elisions, generated, ascii, pins, yaml, compose, env); repo-wide grep confirms no remaining references outside the changelog history.

---
- Agent: Claude Code (Claude Fable 5, model id claude-fable-5)
- Date: 2026-07-10
- Method: label rename executed via gh label edit under human direction; sed sync of tracked references; full local checks
- Scope: AGENTS.md, .opencode/agents/agent-context.md, .opencode/commands/next-task.md, .opencode/CONTEXT.md
- Confirmation: yes (documentation and agent definition changes; commit GPG-signed by the human operator)
---


