### PR TITLE
Sync main into dev before v1.1.57 release (#1829)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -446,19 +446,6 @@ services:
       - ../pgadmin-servers.json:/pgadmin4/servers.json
       - ../scripts/runtime/pgadmin-entrypoint.sh:/usr/local/bin/pgadmin-entrypoint.sh:ro
       - aixcl-vault-secrets:/run/secrets:ro
-    cap_drop:
-      - ALL
-    cap_add:
-      - SETUID
-      - SETGID
-    deploy:
-      resources:
-        limits:
-          cpus: '1.0'
-          memory: 1G
-        reservations:
-          cpus: '0.25'
-          memory: 256M
     restart: unless-stopped
     entrypoint: ["/usr/local/bin/pgadmin-entrypoint.sh"]
 


### PR DESCRIPTION
Reconcile the pgadmin cap-restriction hotfix (99e6385, applied directly to main 2026-07-10) back into dev before cutting v1.1.57. Fixes #1829

Merge resolution note: dev has not modified the pgadmin block since the hotfix's merge-base, so the merge keeps main's removal of the cap restrictions cleanly.

---
- Agent: Claude Code (claude-fable-5)
- Date: 2026-07-11
- Method: sync PR creation per the release skill and the sync convention established by PR 1818
- Scope: upstream main and dev branches, issue #1829
- Confirmation: no
---
