### PR TITLE
Update ollama from 0.31.1 to 0.31.2 (#1839)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   ollama:
-    image: docker.io/ollama/ollama:0.31.1
+    image: docker.io/ollama/ollama:0.31.2
     container_name: ollama
     pull_policy: missing
     user: "0:0"  # Start as root to set permissions, entrypoint switches to ubuntu user


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1839

### Description of Changes
Provide a concise summary of changes.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Describe how this change was tested:

- Steps to reproduce (if relevant)
- What environments were used

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #1839

## Additional Notes

## Summary

Patch update for Ollama inference engine from 0.31.1 to 0.31.2.

## Changes

- `services/docker-compose.yml`: Updated `ollama/ollama` image tag from `0.31.1` to `0.31.2`

## Verification

- [x] `docker compose -f services/docker-compose.yml config > /dev/null` passes
- [x] Stack starts cleanly (`./aixcl stack start --profile sys`)
- [x] `./aixcl stack status` shows all services healthy
- [x] **Inference round-trip**: `curl POST /v1/chat/completions` with model load + completion works

> [!WARNING]
> Ollama is a runtime core invariant. Test inference with at least one
> model before merging. Confirm the OpenAI-compatible API endpoint
> (/v1/chat/completions) responds correctly after the upgrade.

## Related

Fixes #1839
