### PR TITLE
Release v1.1.58 (#1850)

### DIFF
--- a/.opencode/memory/MEMORY.md
+++ b/.opencode/memory/MEMORY.md
@@ -18,3 +18,4 @@ Read a memory file only when its hook is relevant to the current task
 ## Memories
 
 - [Working conventions](working-conventions.md) -- GPG is human-only, verify MERGED before cleanup, mirror parity, /tmp for scratch files
+- [Security hardening lessons](security-hardening-lessons.md) -- container hardening findings: entrypoint compatibility, pgadmin exception, status CLI bug, verification protocol

--- a/.opencode/memory/security-hardening-lessons.md
+++ b/.opencode/memory/security-hardening-lessons.md
@@ -1,0 +1,60 @@
+# Security Hardening Session -- Key Findings (2026-07-10)
+
+## Container Security Hardening -- What Worked
+
+**Successfully applied to 23 services:**
+- CPU/memory/pids resource limits via `deploy.resources` -- prevents DoS/fork bombs
+- `cap_drop: ALL` + minimal `cap_add` -- reduced privilege surface
+- `no-new-privileges:true` on runtime core (ollama, vault) and observability (prometheus, loki, grafana)
+- `read_only: true` + `tmpfs` on vault, loki -- immutable rootfs
+- cadvisor removed from `sys` profile (retained in `bld` for dev)
+- All hardening done WITHOUT changing `network_mode: host` invariant
+
+## Entrypoint Compatibility -- Critical Lesson
+
+**Services that CANNOT use `read_only` + `tmpfs /tmp:noexec`:**
+| Service | Root Cause |
+|---------|------------|
+| **ollama** | Entrypoint starts as root, `chown`s `/home/ubuntu` on rootfs, then drops to ubuntu user via `setpriv` |
+| **open-webui** | Entrypoint starts as root, sets up dirs, then `setpriv` drops to UID 1000 |
+| **pgadmin** | Entrypoint starts as root, `su -m` drops to pgadmin user; also starts postfix mail system |
+
+**Services that WORK with `read_only` + hardening:**
+- vault, loki, prometheus, alertmanager, exporters (all start as non-root)
+
+## pgAdmin -- Special Case
+
+pgAdmin requires **no capability restrictions** (`cap_drop: ALL` breaks it) because:
+1. Entrypoint uses `su -m` for user transition
+2. Starts postfix mail system (needs `SYS_RESOURCE`, `DAC_OVERRIDE`, etc.)
+3. Original compose had comment: "Security hardening removed -- cap_drop/no-new-privileges breaks su authentication"
+
+**Resolution:** Remove all hardening from pgadmin; let it run with default capabilities. Other services retain full hardening.
+
+## Stack Status CLI Bug
+
+**Bug:** `./aixcl stack status` exited early on curl failures due to `set -e` in main script.
+**Fix:** Added `|| health_result="000"` to all curl calls in status() function.
+
+## Verification Protocol
+
+**Live verification required** (CI only validates syntax):
+- `./aixcl stack start --profile sys` completes without timeout
+- `./aixcl stack status` shows all services healthy
+- **Inference round-trip**: `curl POST /v1/chat/completions` with model load + completion
+- `podman inspect <service> --format '{{.HostConfig.ReadonlyRootfs}}'` confirms hardening state
+
+## Release v1.1.56 Summary
+
+- Container security hardening across stack
+- Runtime core entrypoint compatibility fixes
+- Stack status curl failure handling
+- pgAdmin postfix compatibility
+- Agent queue label: `agent-qwen` -> `agent`
+
+## Files Modified
+
+- `services/docker-compose.yml` -- hardening + pgadmin fix
+- `config/profiles/sys.env` -- cadvisor removed from sys
+- `lib/aixcl/commands/stack.sh` -- status curl failure handling
+- `CHANGELOG.md` -- v1.1.56 entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the AIXCL project will be documented in this file.
 ## [Unreleased]
 
 
+## [v1.1.58] - 2026-07-11
+
+### Summary
+
+Release v1.1.58 -- Observability stack refresh and continued least-privilege work: seven monitoring services updated in one batch, Ollama bumped to 0.31.2, the Open WebUI rootless Podman permission failure fixed, and cAdvisor reduced to a single capability.
+
+### Changed
+
+- [x] **Observability stack batch update**: Seven services bumped in one pass -- cadvisor v0.60.5, prometheus v3.13.1, alertmanager v0.33.1, grafana 13.1.0, node-exporter v1.12.0, postgres-exporter v0.20.1, nvidia-gpu-exporter 1.10.0. All patch/minor bumps with no breaking changes in upstream release notes (#1840).
+- [x] **Ollama 0.31.1 to 0.31.2**: Inference engine patch bump; inference verified post-update (#1839).
+- [x] **cAdvisor capability tightening**: `cap_drop: ALL` keeping only `SYS_PTRACE`, default seccomp profile restored (previously `unconfined`), and `no-new-privileges` added, mirroring the blackbox-exporter pattern. cAdvisor stays root by necessity for host-wide metrics; verified live with no metric regression against a 24h Prometheus baseline (#1847).
+- [x] **gitleaks install instructions updated**: README.md install snippet moved from v8.21.2 to v8.30.1 (#1841).
+
+### Fixed
+
+- [x] **Open WebUI rootless Podman permissions**: Volume writes failed under rootless Podman because the upstream `USER_ID`/`GROUP_ID` defaults collide with subordinate UID mapping; entrypoint now uses prefixed `OPENWEBUI_USER_ID`/`OPENWEBUI_GROUP_ID` (default 1000) following the proven pgAdmin pattern. Also corrects the nvidia-gpu-exporter tag (`v1.10.0` to `1.10.0`) and adds cadvisor to the sys profile per the profiles contract (#1845).
+
+### Documentation
+
+- [x] **Security hardening lessons in agent memory**: Lessons from the v1.1.56/v1.1.57 hardening cycle (entrypoint compatibility limits, UID audit findings) landed as a durable agent memory file (#1837).
+
+
+
 ## [v1.1.57] - 2026-07-11
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ sudo apt-get install -y yamllint
 curl -sSL https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz | tar -xJ -C /tmp
 sudo cp /tmp/shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
 
-# gitleaks 8.21.2+ -- secret scanning (runs in pre-commit and CI)
-curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz | tar -xz -C /tmp
+# gitleaks 8.30.1+ -- secret scanning (runs in pre-commit and CI)
+curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar -xz -C /tmp
 sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
 
 # git-cliff 2.x -- changelog generation (required for the release skill)

--- a/config/profiles/sys.env
+++ b/config/profiles/sys.env
@@ -6,7 +6,7 @@ PROFILE_NAME=sys
 PROFILE_DESCRIPTION="System-oriented (complete stack with automation)"
 
 # Services included in this profile
-PROFILE_SERVICES="$INFERENCE_ENGINE vault open-webui postgres pgadmin prometheus alertmanager grafana loki node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-openwebui vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap vault-agent-grafana-bootstrap"
+PROFILE_SERVICES="$INFERENCE_ENGINE vault open-webui postgres pgadmin prometheus alertmanager grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-openwebui vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap vault-agent-grafana-bootstrap"
 
 # Database storage enabled
 ENABLE_DB_STORAGE=true

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Open WebUI Non-Root Entrypoint
 # Reads all credentials from Vault-mounted secrets; no hardcoded defaults.
+# UID/GID configurable via USER_ID/GROUP_ID (default 5051 to avoid pgAdmin UID 5050
+# and work correctly in rootless Podman subordinate UID mapping).
 
 set -euo pipefail
 
-# Default user/group IDs
-USER_ID="${USER_ID:-1000}"
-GROUP_ID="${GROUP_ID:-1000}"
+# Default user/group IDs (1000 maps correctly in rootless Podman user namespace)
+# Using OPENWEBUI_ prefix to avoid conflict with upstream image's default USER_ID/GROUP_ID=1000
+USER_ID="${OPENWEBUI_USER_ID:-${USER_ID:-1000}}"
+GROUP_ID="${OPENWEBUI_GROUP_ID:-${GROUP_ID:-1000}}"
 
 echo "=== Open WebUI Non-Root Entrypoint ==="
 echo "Target UID: $USER_ID"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -378,6 +378,8 @@ services:
       - ../scripts/runtime/openwebui-entrypoint.sh:/usr/local/bin/openwebui-entrypoint.sh:ro
       - aixcl-vault-secrets:/run/secrets:ro
     environment:
+      - OPENWEBUI_USER_ID=1000
+      - OPENWEBUI_GROUP_ID=1000
       - DATA_DIR=/app/data
       - STATIC_DIR=/app/backend/data/static
       # NOTE: No DATABASE_URL here — entrypoint constructs it from /run/secrets/postgres-password

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -450,7 +450,7 @@ services:
     entrypoint: ["/usr/local/bin/pgadmin-entrypoint.sh"]
 
   prometheus:
-    image: docker.io/prom/prometheus:v3.12.0
+    image: docker.io/prom/prometheus:v3.13.1
     container_name: prometheus
     pull_policy: missing
     cap_drop:
@@ -488,7 +488,7 @@ services:
       retries: 3
 
   alertmanager:
-    image: docker.io/prom/alertmanager:v0.33.0
+    image: docker.io/prom/alertmanager:v0.33.1
     container_name: alertmanager
     pull_policy: missing
     cap_drop:
@@ -522,7 +522,7 @@ services:
       retries: 3
 
   grafana:
-    image: docker.io/grafana/grafana:13.0.3
+    image: docker.io/grafana/grafana:13.1.0
     container_name: grafana
     pull_policy: missing
     cap_drop:
@@ -561,7 +561,7 @@ services:
       retries: 3
 
   cadvisor:
-    image: ghcr.io/google/cadvisor:v0.60.3
+    image: ghcr.io/google/cadvisor:v0.60.5
     container_name: cadvisor
     pull_policy: missing
     volumes:
@@ -589,7 +589,7 @@ services:
       - '--docker_only=true'
 
   node-exporter:
-    image: docker.io/prom/node-exporter:v1.11.1
+    image: docker.io/prom/node-exporter:v1.12.0
     container_name: node-exporter
     pull_policy: missing
     user: "65534:65534"  # node-exporter user (official image default) - avoids 'nobody' ambiguity
@@ -621,7 +621,7 @@ services:
           memory: 64M
 
   postgres-exporter:
-    image: docker.io/prometheuscommunity/postgres-exporter:v0.20.0
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.20.1
     container_name: postgres-exporter
     pull_policy: missing
     user: "65534:65534"  # postgres-exporter user (official image default) - avoids 'nobody' ambiguity
@@ -657,7 +657,7 @@ services:
           memory: 64M
 
   nvidia-gpu-exporter:
-    image: docker.io/utkuozdemir/nvidia_gpu_exporter:1.5.0
+    image: docker.io/utkuozdemir/nvidia_gpu_exporter:v1.10.0
     container_name: nvidia-gpu-exporter
     pull_policy: missing
     cap_drop:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -570,10 +570,15 @@ services:
       - /:/rootfs:ro
       - /sys:/sys:ro
       - /dev/disk/:/dev/disk:ro
+    # Runs as root by necessity (host-wide metrics; allowlisted in
+    # lib/core/env_check.sh) but with all capabilities dropped except
+    # SYS_PTRACE, mirroring the blackbox-exporter pattern (#1827)
+    cap_drop:
+      - ALL
     cap_add:
       - SYS_PTRACE
     security_opt:
-      - seccomp=unconfined
+      - no-new-privileges:true
     devices:
       - /dev/kmsg
     network_mode: host

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -15,7 +15,7 @@
 
 services:
   ollama:
-    image: docker.io/ollama/ollama:0.31.1
+    image: docker.io/ollama/ollama:0.31.2
     container_name: ollama
     pull_policy: missing
     user: "0:0"  # Start as root to set permissions, entrypoint switches to ubuntu user

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -657,7 +657,7 @@ services:
           memory: 64M
 
   nvidia-gpu-exporter:
-    image: docker.io/utkuozdemir/nvidia_gpu_exporter:v1.10.0
+    image: docker.io/utkuozdemir/nvidia_gpu_exporter:1.10.0
     container_name: nvidia-gpu-exporter
     pull_policy: missing
     cap_drop:


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1850

### Description of Changes

Promote dev to main for release v1.1.58.

Changelog summary: observability stack refresh and continued least-privilege work -- seven monitoring services updated in one batch, Ollama bumped to 0.31.2, the Open WebUI rootless Podman permission failure fixed, and cAdvisor reduced to a single capability.

Included PRs since v1.1.57:

- PR #1842 -- batch update of 7 observability stack services
- PR #1843 -- Ollama 0.31.1 to 0.31.2
- PR #1844 -- gitleaks README install instructions to v8.30.1
- PR #1846 -- Open WebUI rootless Podman permissions and sys profile sync
- PR #1848 -- cAdvisor capability tightening
- PR #1838 -- security hardening lessons agent memory file

Retrospective: https://github.com/xencon/aixcl/discussions/1849

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:

- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

- All CI green on dev at merge base (every included PR merged with green checks today)
- `./aixcl checks all` green locally on 2026-07-11 (all 9 checks)
- Live sys-profile stack at this commit range: 21/21 services healthy, Ollama 0.31.2 inference verified (#1845 verification), cAdvisor hardening verified against 24h Prometheus baseline (#1847 verification)
- CHANGELOG.md entry reviewed and edited; ASCII and elision checks pass

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1850

---
- Agent: Claude Code (Claude Fable 5)
- Date: 2026-07-11
- Method: release promotion PR assembled from git history and verified release-prep tooling output
- Scope: CHANGELOG.md, commits v1.1.57..dev, issues and PRs #1837-#1850
- Confirmation: yes
---
