### PR TITLE
Neutralize agent-identity names in tracked files (#1856)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -68,7 +68,7 @@ mutation {
 ```
 
 - [ ] This agent has posted its retrospective (what landed, what was deferred, open concerns)
-- [ ] Kimi has posted its retrospective, or confirmed nothing material to add
+- [ ] The other agent has posted its retrospective, or confirmed nothing material to add
 - [ ] Human has reviewed and confirmed readiness to proceed
 
 Each agent post must include the standard agent identification block

--- a/.opencode/memory/security-hardening-lessons.md
+++ b/.opencode/memory/security-hardening-lessons.md
@@ -50,7 +50,7 @@ pgAdmin requires **no capability restrictions** (`cap_drop: ALL` breaks it) beca
 - Runtime core entrypoint compatibility fixes
 - Stack status curl failure handling
 - pgAdmin postfix compatibility
-- Agent queue label: `agent-qwen` -> `agent`
+- Agent queue label renamed to `agent` (previously model-specific)
 
 ## Files Modified
 

--- a/.opencode/memory/working-conventions.md
+++ b/.opencode/memory/working-conventions.md
@@ -1,6 +1,6 @@
 # Working Conventions
 
-Seed memory for the Qwen agent, written at onboarding (2026-07-02).
+Seed memory for the OpenCode agent, written at onboarding (2026-07-02).
 
 - **GPG commits are human-only.** You have no TTY for the pinentry prompt.
   Stage changes, verify hooks pass, then give the human the exact

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -68,7 +68,7 @@ mutation {
 ```
 
 - [ ] This agent has posted its retrospective (what landed, what was deferred, open concerns)
-- [ ] Kimi has posted its retrospective, or confirmed nothing material to add
+- [ ] The other agent has posted its retrospective, or confirmed nothing material to add
 - [ ] Human has reviewed and confirmed readiness to proceed
 
 Each agent post must include the standard agent identification block


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1856

### Description of Changes

Replace agent-identity names (Kimi, Qwen) in tracked files with role-based wording, so skills and memory stay accurate as the agent roster changes:

- `.claude/skills/release/SKILL.md` and `.opencode/skills/release/SKILL.md` (mirror pair): retrospective checklist says "the other agent" instead of Kimi
- `.opencode/memory/working-conventions.md`: seed memory attributed to the OpenCode agent role
- `.opencode/memory/security-hardening-lessons.md`: label-rename note rephrased without the old model-specific label name

Intentionally unchanged: Ollama/HF model tags (qwen2.5-coder etc.) are real model names; CHANGELOG.md entries are historical release records.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:

- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

- `./aixcl checks agents` green (mirror parity preserved)
- Post-change survey: `git grep -iE "kimi|qwen"` returns only model tags and CHANGELOG history
- All CI checks green

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1856

---
- Agent: Claude Code (Claude Fable 5)
- Date: 2026-07-11
- Method: git grep survey and scoped rename with mirror parity check
- Scope: .claude/skills/, .opencode/skills/, .opencode/memory/
- Confirmation: yes
---
