### PR TITLE
Add profile-vs-contract reconciliation check (#1865)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -56,20 +56,21 @@ gh pr create \
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |
-| documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, yamllint, compose validate |
+| documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, check-profiles.sh, yamllint, compose validate |
 | codeql.yml | PR + push | GitHub Actions workflow security (actions language only) |
 
 ## Running Checks Locally
 ```bash
 # Full pre-PR check (paths, mirror parity, elisions, generated files,
-# ASCII, yamllint, compose validation, environment)
+# ASCII, pins, profile reconciliation, yamllint, compose validation,
+# environment)
 ./aixcl checks all
 
 # Shellcheck sweep (not part of checks all -- run before shell changes)
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 
 # Individual checks
-./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, yaml, compose, env
+./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, profiles, yaml, compose, env
 ./aixcl checks pr-refs <body-file>
 ./aixcl checks pr-ready <pr-number>
 ```

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -37,8 +37,9 @@ one does not block the others.
 ```
 
 Covers: documentation paths, mirror parity, elision guard, generated and
-dated files (lean policy), ASCII markdown, yamllint, compose validation,
-and environment prerequisites. Fix anything red before continuing.
+dated files (lean policy), ASCII markdown, image pins, profile-vs-contract
+reconciliation, yamllint, compose validation, and environment
+prerequisites. Fix anything red before continuing.
 
 ### Step 2 -- Branch Hygiene (Merged Branches and Fork Sync)
 

--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -44,6 +44,19 @@ jobs:
           chmod +x ./scripts/checks/check-generated-files.sh
           ./scripts/checks/check-generated-files.sh
 
+  check-profiles:
+    name: Check Profile Contract Reconciliation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Run profile reconciliation check
+        run: |
+          chmod +x ./scripts/checks/check-profiles.sh
+          ./scripts/checks/check-profiles.sh
+
   check-markdown-links:
     name: Check Markdown Links
     runs-on: ubuntu-latest

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -56,20 +56,21 @@ gh pr create \
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review |
-| documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, yamllint, compose validate |
+| documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, check-profiles.sh, yamllint, compose validate |
 | codeql.yml | PR + push | GitHub Actions workflow security (actions language only) |
 
 ## Running Checks Locally
 ```bash
 # Full pre-PR check (paths, mirror parity, elisions, generated files,
-# ASCII, yamllint, compose validation, environment)
+# ASCII, pins, profile reconciliation, yamllint, compose validation,
+# environment)
 ./aixcl checks all
 
 # Shellcheck sweep (not part of checks all -- run before shell changes)
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 
 # Individual checks
-./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, yaml, compose, env
+./aixcl checks paths        # or: agents, elisions, generated, ascii, pins, profiles, yaml, compose, env
 ./aixcl checks pr-refs <body-file>
 ./aixcl checks pr-ready <pr-number>
 ```

--- a/.opencode/skills/housekeeping/SKILL.md
+++ b/.opencode/skills/housekeeping/SKILL.md
@@ -37,8 +37,9 @@ one does not block the others.
 ```
 
 Covers: documentation paths, mirror parity, elision guard, generated and
-dated files (lean policy), ASCII markdown, yamllint, compose validation,
-and environment prerequisites. Fix anything red before continuing.
+dated files (lean policy), ASCII markdown, image pins, profile-vs-contract
+reconciliation, yamllint, compose validation, and environment
+prerequisites. Fix anything red before continuing.
 
 ### Step 2 -- Branch Hygiene (Merged Branches and Fork Sync)
 

--- a/config/profiles/bld.env
+++ b/config/profiles/bld.env
@@ -6,7 +6,7 @@ PROFILE_NAME=bld
 PROFILE_DESCRIPTION="Builder-focused (monitoring/logging)"
 
 # Services included in this profile
-PROFILE_SERVICES="$INFERENCE_ENGINE vault postgres prometheus grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
+PROFILE_SERVICES="$INFERENCE_ENGINE vault postgres prometheus alertmanager grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
 
 # Database storage enabled
 ENABLE_DB_STORAGE=true

--- a/lib/aixcl/commands/checks.sh
+++ b/lib/aixcl/commands/checks.sh
@@ -9,13 +9,14 @@ CHECKS_FAILED=()
 CHECKS_SKIPPED=()
 
 _checks_usage() {
-    echo "Usage: $0 checks {all|paths|agents|elisions|generated|ascii|pins|yaml|compose|env|pr-refs <file>|pr-ready <pr>}"
+    echo "Usage: $0 checks {all|paths|agents|elisions|generated|ascii|pins|profiles|yaml|compose|env|pr-refs <file>|pr-ready <pr>}"
     echo "  all              Run every check below (continues on failure, prints summary)"
     echo "  paths            Documentation relative links and stale path patterns"
     echo "  agents           .claude/ vs .opencode/ rules and skills mirror parity"
     echo "  elisions         AI-elision placeholders and suspicious mass deletions"
     echo "  generated        Tracked generated files and stale artifacts"
     echo "  pins             Container image references pinned (compose + shell code)"
+    echo "  profiles         Profile configs match the 02_profiles.md contract"
     echo "  ascii            Non-ASCII punctuation in markdown files"
     echo "  yaml             yamllint over the repository"
     echo "  compose          docker compose config validation (main + overrides)"
@@ -145,6 +146,9 @@ function checks_cmd() {
         pins)
             bash "${checks_dir}/check-image-pins.sh"
             ;;
+        profiles)
+            bash "${checks_dir}/check-profiles.sh"
+            ;;
         generated)
             bash "${checks_dir}/check-generated-files.sh"
             ;;
@@ -191,6 +195,7 @@ function checks_cmd() {
             _check_run "generated" bash "${checks_dir}/check-generated-files.sh" || true
             _check_run "ascii" _check_ascii || true
             _check_run "pins" bash "${checks_dir}/check-image-pins.sh" || true
+            _check_run "profiles" bash "${checks_dir}/check-profiles.sh" || true
 
             if command -v yamllint > /dev/null 2>&1; then
                 _check_run "yaml" yamllint -c "${SCRIPT_DIR}/.yamllint.yml" "${SCRIPT_DIR}" || true

--- a/lib/cli/profile.sh
+++ b/lib/cli/profile.sh
@@ -112,7 +112,7 @@ get_profile_services_for_profile() {
     local engine="${INFERENCE_ENGINE:-ollama}"
     case "$profile" in
         bld)
-            echo "$engine vault postgres prometheus grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
+            echo "$engine vault postgres prometheus alertmanager grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-postgres-bootstrap"
             ;;
         sys)
             echo "$engine vault open-webui postgres pgadmin prometheus alertmanager grafana loki cadvisor node-exporter postgres-exporter nvidia-gpu-exporter blackbox-exporter json-exporter vault-agent-postgres vault-agent-openwebui vault-agent-postgres-bootstrap vault-agent-openwebui-bootstrap vault-agent-pgadmin-bootstrap vault-agent-grafana-bootstrap"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,9 +7,16 @@ This directory contains scripts used by AIXCL, Docker Compose, and GitHub Action
 ```
 scripts/
 +-- checks/           # CI validation scripts
+|   +-- check-agent-id-block.sh
 |   +-- check-agents.sh
+|   +-- check-ai-elisions.sh
+|   +-- check-environment.sh
 |   +-- check-generated-files.sh
-|   `-- check-paths.sh
+|   +-- check-image-pins.sh
+|   +-- check-paths.sh
+|   +-- check-pr-ready.sh
+|   +-- check-pr-references.sh
+|   `-- check-profiles.sh
 +-- db/               # Database management
 +-- exporters/        # Metrics exporters
 +-- hooks/            # Git hooks

--- a/scripts/checks/CONTEXT.md
+++ b/scripts/checks/CONTEXT.md
@@ -12,6 +12,7 @@ committing. This directory is the pre-commit safety net.
 | `check-environment.sh` | Full host prerequisite check (container runtime, Python3-yaml, jq, curl, GPG). | Before first stack start; on new dev machine setup. |
 | `check-generated-files.sh` | Verifies gitignored generated files are not tracked in git. | Part of CI; run locally if you added a new generated file. |
 | `check-paths.sh` | Validates all relative links in markdown files resolve to real paths. | After adding or moving markdown files. |
+| `check-profiles.sh` | Reconciles PROFILE_SERVICES in `config/profiles/*.env` against the enumerations in `docs/architecture/governance/02_profiles.md`. Caught the bld/alertmanager drift on its first run. | After editing a profile env file or 02_profiles.md. |
 
 ## The Elision Guard -- Do Not Skip
 
@@ -38,6 +39,6 @@ State the intent explicitly in the commit message when using the override.
 ## Cross-References
 
 - `.github/workflows/bash-ci.yml` -- runs check-ai-elisions and check-paths
-- `.github/workflows/documentation-checks.yml` -- runs check-paths and check-generated-files
+- `.github/workflows/documentation-checks.yml` -- runs check-paths, check-generated-files, and check-profiles
 - `.github/workflows/security.yml` -- runs ShellCheck
 - `.claude/rules/ci-checks.md` -- full CI workflow summary

--- a/scripts/checks/check-profiles.sh
+++ b/scripts/checks/check-profiles.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# check-profiles.sh -- reconcile profile configs against the profiles contract
+#
+# Compares PROFILE_SERVICES in config/profiles/<profile>.env against the
+# "Includes" enumeration for that profile in
+# docs/architecture/governance/02_profiles.md, in both directions.
+#
+# Motivation (issue #1865): cAdvisor was dropped from the sys profile in
+# v1.1.56 and nobody noticed for a day (#1845 restored it). `stack status`
+# grades against PROFILE_SERVICES itself, so a service removed from the
+# profile also vanishes from the health checklist. This check is the
+# missing reconciliation between config and contract.
+#
+# Rules:
+#   1. Every service enumerated in a profile's Includes section must appear
+#      in that profile's PROFILE_SERVICES, and vice versa
+#   2. $INFERENCE_ENGINE in PROFILE_SERVICES resolves to ollama
+#   3. vault-agent-* sidecars and bootstraps are implementation detail and
+#      exempt from the doc side
+#   4. A display name in the doc with no slug mapping fails the check --
+#      extend DISPLAY_TO_SLUG below when a new service is documented
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CONTRACT="docs/architecture/governance/02_profiles.md"
+PROFILE_DIR="config/profiles"
+fail=0
+
+# Display names used in 02_profiles.md -> service slugs used in
+# PROFILE_SERVICES and services/docker-compose.yml
+declare -A DISPLAY_TO_SLUG=(
+    ["Inference Engine"]="ollama"
+    ["Vault"]="vault"
+    ["PostgreSQL"]="postgres"
+    ["Prometheus"]="prometheus"
+    ["Grafana"]="grafana"
+    ["Loki"]="loki"
+    ["cAdvisor"]="cadvisor"
+    ["node-exporter"]="node-exporter"
+    ["postgres-exporter"]="postgres-exporter"
+    ["nvidia-gpu-exporter"]="nvidia-gpu-exporter"
+    ["blackbox-exporter"]="blackbox-exporter"
+    ["json-exporter"]="json-exporter"
+    ["Alertmanager"]="alertmanager"
+    ["Open WebUI"]="open-webui"
+    ["pgAdmin"]="pgadmin"
+)
+
+# Print the resolved slugs enumerated under "### <profile>" ... "**Includes**:"
+# in the contract, one per line. Recurses one level for "All <other> services:".
+doc_services() {
+    local profile="$1"
+    local in_section=0 in_includes=0
+    local line name rest sub
+
+    while IFS= read -r line; do
+        if [[ "$line" == "### ${profile}" ]]; then
+            in_section=1
+            continue
+        fi
+        [ "$in_section" -eq 1 ] || continue
+        # Section ends at the next heading or horizontal rule
+        if [[ "$line" == "---" || "$line" == "### "* || "$line" == "## "* ]]; then
+            break
+        fi
+        if [[ "$line" == "**Includes**:"* ]]; then
+            in_includes=1
+            continue
+        fi
+        [ "$in_includes" -eq 1 ] || continue
+        # Includes list ends at the next bold header (Excludes, Use Cases)
+        if [[ "$line" == "**"* ]]; then
+            break
+        fi
+        [[ "$line" == "- "* ]] || continue
+
+        name="${line#- }"
+        name="${name%% (*}"          # strip parenthetical description
+        if [[ "$name" == "Runtime core:"* ]]; then
+            name="${name#Runtime core: }"
+        fi
+        if [[ "$name" =~ ^All\ ([a-z]+)\ services:\ (.*)$ ]]; then
+            # Expand "All bld services: A, B, C" from its own enumeration
+            rest="${BASH_REMATCH[2]}"
+            IFS=',' read -ra sub <<< "$rest"
+            for name in "${sub[@]}"; do
+                name="$(echo "$name" | sed 's/^ *//; s/ *$//')"
+                resolve_slug "$profile" "$name"
+            done
+            continue
+        fi
+        resolve_slug "$profile" "$name"
+    done < "$CONTRACT"
+}
+
+resolve_slug() {
+    local profile="$1" name="$2"
+    if [[ -n "${DISPLAY_TO_SLUG[$name]:-}" ]]; then
+        echo "${DISPLAY_TO_SLUG[$name]}"
+    else
+        echo "UNMAPPED display name in ${CONTRACT} (${profile}): '${name}'" >&2
+        echo "  Add it to DISPLAY_TO_SLUG in scripts/checks/check-profiles.sh" >&2
+        return 1
+    fi
+}
+
+# Print the slugs from PROFILE_SERVICES in the profile env file, one per
+# line, with $INFERENCE_ENGINE resolved and vault-agent-* filtered out.
+env_services() {
+    local env_file="$1"
+    local raw svc
+    raw="$(grep -E '^PROFILE_SERVICES=' "$env_file" | head -1)"
+    raw="${raw#PROFILE_SERVICES=}"
+    raw="${raw%\"}"
+    raw="${raw#\"}"
+    for svc in $raw; do
+        [[ "$svc" == "\$INFERENCE_ENGINE" ]] && svc="ollama"
+        [[ "$svc" == vault-agent-* ]] && continue
+        echo "$svc"
+    done
+}
+
+for env_file in "$PROFILE_DIR"/*.env; do
+    profile="$(basename "$env_file" .env)"
+
+    if ! grep -q "^### ${profile}$" "$CONTRACT"; then
+        echo "MISSING CONTRACT: no '### ${profile}' section in ${CONTRACT} for ${env_file}"
+        fail=1
+        continue
+    fi
+
+    if ! doc_list="$(doc_services "$profile" | sort -u)"; then
+        fail=1
+        continue
+    fi
+    env_list="$(env_services "$env_file" | sort -u)"
+
+    missing_from_env="$(comm -23 <(echo "$doc_list") <(echo "$env_list"))"
+    missing_from_doc="$(comm -13 <(echo "$doc_list") <(echo "$env_list"))"
+
+    if [ -n "$missing_from_env" ]; then
+        echo "DRIFT (${profile}): documented in ${CONTRACT} but absent from PROFILE_SERVICES in ${env_file}:"
+        echo "$missing_from_env" | sed 's/^/  - /'
+        fail=1
+    fi
+    if [ -n "$missing_from_doc" ]; then
+        echo "DRIFT (${profile}): in PROFILE_SERVICES in ${env_file} but not documented in ${CONTRACT}:"
+        echo "$missing_from_doc" | sed 's/^/  - /'
+        fail=1
+    fi
+    if [ -z "$missing_from_env" ] && [ -z "$missing_from_doc" ]; then
+        echo "ok: ${profile} -- $(echo "$doc_list" | wc -l | tr -d ' ') services match the contract"
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    echo ""
+    echo "Profile reconciliation FAILED -- config/profiles/*.env and ${CONTRACT} disagree."
+    echo "Fix whichever side is wrong; they must move together in the same PR."
+    exit 1
+fi
+echo "All profiles match the contract"


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1865

### Description of Changes

Adds the reconciliation control that was missing when cAdvisor silently dropped out of the sys profile (v1.1.56, restored by #1846): a check that diffs each profile's `PROFILE_SERVICES` (`config/profiles/*.env`) against the Includes enumeration in `docs/architecture/governance/02_profiles.md`, in both directions.

- `scripts/checks/check-profiles.sh` -- new check. `$INFERENCE_ENGINE` resolves to ollama; `vault-agent-*` sidecars/bootstraps are exempt as implementation detail; a display name in the doc with no slug mapping fails the check so the map stays current.
- Registered as `./aixcl checks profiles` and included in `./aixcl checks all`.
- New `check-profiles` job in `documentation-checks.yml` runs it on every PR and push.
- Rules mirror pair (`.claude/rules/ci-checks.md`, `.opencode/rules/ci-checks.md`) and `scripts/checks/CONTEXT.md` updated.

**The check found real drift on its first run**: the bld profile documents Alertmanager but `bld.env` (and the fallback list in `lib/cli/profile.sh`) did not carry it -- the same defect class as the cadvisor drop, sitting undetected in the other profile. Both are fixed in this PR, so an observability-profile deployment actually gets alert routing.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:

- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

- Happy path: `./aixcl checks profiles` passes on this branch (bld 13, sys 15 services match)
- Failure mode 1: removing loki from `sys.env` produces a clear DRIFT message and exit 1
- Failure mode 2: an unrecognized display name in the doc produces an UNMAPPED error pointing at the map, and exit 1
- `shellcheck --severity=warning` clean on all three touched shell files; `bash -n` clean; yamllint clean on the workflow
- `./aixcl checks all` green including the new check (10 checks)
- Note: the bld alertmanager fix is config-only and verified via the reconciliation check and compose validation; a live bld-profile stack start was not performed (running stack is sys)

### Verification

To verify this change is complete:

- [ ] Behavior works as expected
- [ ] No regressions observed
- [ ] Tests cover change

### Related Issues

- Closes #1865

---
- Agent: Claude Code (Claude Fable 5)
- Date: 2026-07-11
- Method: check implementation with happy-path and failure-mode testing
- Scope: scripts/checks/, lib/aixcl/commands/checks.sh, lib/cli/profile.sh, config/profiles/, .github/workflows/, rules mirror pair
- Confirmation: yes
---
