### PR TITLE
Validate custom issue bodies in create-issue.sh (#1883)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -48,6 +48,21 @@ gh pr create \
 - Body references: one issue/PR reference per list item -- no comma-packing (enforced by CI: `validate-pr-body-references` job in `pr-validation.yml`)
 - Check locally before pushing: `echo "$BODY" | bash scripts/checks/check-pr-references.sh`
 
+## Issue Authoring (same rules, checked later)
+
+Issue bodies are held to the same reference style as PR bodies -- the
+`pr-ready` merge gate validates them, so a violation written at issue
+creation surfaces as a merge blocker weeks later. Author to the rules
+up front:
+
+- One issue/PR reference per list item; slash-packed pairs (`#1/#2`)
+  count as comma-packing
+- Checkboxes that can only become true AFTER the PR merges (tag pushed,
+  branches synced, release published) must carry a `(post-merge)` suffix
+  -- the gate reports those as informational instead of blocking
+- Use `./scripts/utils/create-issue.sh "[TASK] Title" task <labels> <assignee> <body-file>`
+  for custom bodies -- it runs the reference check before creation
+
 ## CI Workflows Summary
 
 | Workflow | Trigger | Key Checks |

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -48,6 +48,21 @@ gh pr create \
 - Body references: one issue/PR reference per list item -- no comma-packing (enforced by CI: `validate-pr-body-references` job in `pr-validation.yml`)
 - Check locally before pushing: `echo "$BODY" | bash scripts/checks/check-pr-references.sh`
 
+## Issue Authoring (same rules, checked later)
+
+Issue bodies are held to the same reference style as PR bodies -- the
+`pr-ready` merge gate validates them, so a violation written at issue
+creation surfaces as a merge blocker weeks later. Author to the rules
+up front:
+
+- One issue/PR reference per list item; slash-packed pairs (`#1/#2`)
+  count as comma-packing
+- Checkboxes that can only become true AFTER the PR merges (tag pushed,
+  branches synced, release published) must carry a `(post-merge)` suffix
+  -- the gate reports those as informational instead of blocking
+- Use `./scripts/utils/create-issue.sh "[TASK] Title" task <labels> <assignee> <body-file>`
+  for custom bodies -- it runs the reference check before creation
+
 ## CI Workflows Summary
 
 | Workflow | Trigger | Key Checks |

--- a/scripts/utils/CONTEXT.md
+++ b/scripts/utils/CONTEXT.md
@@ -8,7 +8,7 @@ which runs inside containers).
 
 | File | Purpose |
 |------|---------|
-| `create-issue.sh` | Issue creation wrapper -- targets xencon/aixcl, template-based body, assignee at creation. Required by DEVELOPMENT.md. |
+| `create-issue.sh` | Issue creation wrapper -- targets xencon/aixcl, template-based or custom body (custom bodies validated for reference style), assignee at creation. Required by DEVELOPMENT.md. |
 | `create-pr.sh` | PR creation wrapper -- fork-aware `--head`, title/branch/body validation, assignee and labels at creation time. Required by DEVELOPMENT.md. |
 | `sync-mirrors.sh` | One-command `.claude/` <-> `.opencode/` skills and rules sync, then parity verification. Run after editing either side. |
 | `init-volumes.sh` | Creates the external Docker volumes shared across contexts. |

--- a/scripts/utils/create-issue.sh
+++ b/scripts/utils/create-issue.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # create-issue.sh — Safe issue creation wrapper
-# Usage: ./scripts/utils/create-issue.sh "[TASK] Title" "task" "component:cli" "<github-username>"
+# Usage: ./scripts/utils/create-issue.sh "[TASK] Title" "task" "component:cli" "<github-username>" [body-file]
 #
 # Benefits over manual gh issue create:
 # - Targets the canonical repo regardless of which clone you run from
@@ -8,6 +8,9 @@
 # - Always uses --body-file (no backtick injection risk)
 # - Always sets --assignee (no PR validation race condition)
 # - Validates issue type prefix before creation
+# - With a body-file argument, validates reference style (one issue/PR
+#   reference per list item) before creation -- the same rule the
+#   pr-ready merge gate enforces on issue bodies later (#1883)
 
 set -euo pipefail
 
@@ -21,11 +24,18 @@ TITLE="${1:-}"
 TYPE="${2:-task}"        # bug, feature, task
 LABELS="${3:-}"
 ASSIGNEE="${4:-${GITHUB_USER:-}}"
+CUSTOM_BODY="${5:-}"     # optional: path to a ready-made body file
 
 # Validate
 if [[ -z "$TITLE" ]]; then
-    echo "Usage: $0 \"[TYPE] Title\" [type] [labels] [assignee]"
+    echo "Usage: $0 \"[TYPE] Title\" [type] [labels] [assignee] [body-file]"
     echo "  type: bug | feature | task"
+    echo "  body-file: optional ready-made body (validated, replaces the template)"
+    exit 1
+fi
+
+if [[ -n "$CUSTOM_BODY" ]] && [[ ! -f "$CUSTOM_BODY" ]]; then
+    echo "ERROR: Body file not found: $CUSTOM_BODY"
     exit 1
 fi
 
@@ -52,8 +62,20 @@ esac
 BODY_FILE="$(mktemp /tmp/aixcl-issue-XXXXXX.md)"
 trap 'rm -f "$BODY_FILE"' EXIT
 
-# Read template and strip frontmatter
-if [[ -f "$TEMPLATE_FILE" ]]; then
+if [[ -n "$CUSTOM_BODY" ]]; then
+    # Custom body: validate reference style before anything reaches GitHub.
+    # The pr-ready gate applies this same check to issue bodies at merge
+    # time; catching it here saves a round-trip (#1883).
+    if [[ -f "${SCRIPT_DIR}/scripts/checks/check-pr-references.sh" ]]; then
+        if ! bash "${SCRIPT_DIR}/scripts/checks/check-pr-references.sh" < "$CUSTOM_BODY"; then
+            echo "ERROR: Body failed reference style check (one reference per list item)"
+            echo "  Reminder: checkboxes only satisfiable after a merge need a '(post-merge)' suffix."
+            exit 1
+        fi
+    fi
+    cp "$CUSTOM_BODY" "$BODY_FILE"
+elif [[ -f "$TEMPLATE_FILE" ]]; then
+    # Read template and strip frontmatter
     sed '1,/^---$/d' "$TEMPLATE_FILE" > "$BODY_FILE"
 else
     cat > "$BODY_FILE" << 'EOF'


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1883

### Description of Changes

Closes the issue-authoring validation gap exposed by the two pr-ready gate trips on issue #1881 (slash-packed reference, missing post-merge markers):

- `scripts/utils/create-issue.sh` now takes an optional 5th argument -- a ready-made body file. When given, the body is piped through `check-pr-references.sh` before anything reaches GitHub (the same rail `create-pr.sh` already has), and replaces the template skeleton. The template path is unchanged when the argument is omitted. This also removes the incentive to bypass the wrapper with raw `gh issue create --body-file`, which validates nothing.
- New "Issue Authoring" section in `ci-checks.md` (mirror pair): issue bodies follow the same one-reference-per-line style as PR bodies (the pr-ready gate checks them at merge time), and checkboxes only satisfiable after a merge need the `(post-merge)` suffix.
- `scripts/utils/CONTEXT.md` wrapper description updated.

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements

The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:

- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

- Bad body (comma-packed reference): wrapper prints the violation and exits 1 before invoking gh
- Missing body file: refused with a clear error, exit 1
- Clean custom body: verified end-to-end with a stubbed gh that the exact body content passes through
- No 5th argument: template path byte-identical to previous behavior (stubbed gh)
- shellcheck and bash -n clean; mirror parity green; `./aixcl checks all` green (11 checks)

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1883

---
- Agent: Claude Code (Claude Fable 5)
- Date: 2026-07-14
- Method: wrapper extension with stubbed-gh path testing
- Scope: scripts/utils/create-issue.sh, scripts/utils/CONTEXT.md, rules mirror pair
- Confirmation: yes
---
