### PR TITLE
Restore CAP_CHOWN for open-webui volume permission setup (#1891)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,24 +77,26 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
+    # Data directories are written to after privileges drop: a failed chown
+    # here guarantees a later crash, so fail fast instead of hiding it.
     for dir in /app/backend/data /app/data /app/backend/data/static; do
-        if [ -d "$dir" ]; then
-            echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
-        else
+        if [ ! -d "$dir" ]; then
             echo "Creating directory $dir"
-            mkdir -p "$dir" 2>/dev/null || true
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
+            mkdir -p "$dir"
         fi
+        echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
+        if ! chown -R "$USER_ID:$GROUP_ID" "$dir"; then
+            echo "[ERROR] chown of $dir failed -- container likely lacks CAP_CHOWN (check cap_add in docker-compose.yml)"
+            exit 1
+        fi
+        chmod 755 "$dir"
     done
 
     for dir in /app/backend/open_webui /app/backend/open_webui/static; do
         if [ -d "$dir" ]; then
             echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
+            chown -R "$USER_ID:$GROUP_ID" "$dir" || echo "[WARN] chown of $dir failed; static asset writes may not work"
+            chmod 755 "$dir" || true
         fi
     done
 

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -414,6 +414,10 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      # CHOWN/FOWNER: entrypoint root phase must chown/chmod freshly
+      # created volumes to UID 1000 before dropping privileges
+      - CHOWN
+      - FOWNER
     deploy:
       resources:
         limits:


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1891

### Description of Changes

Open WebUI crash-looped on a cleanly initialised stack because the container hardening capability set (`cap_drop: ALL` with only `SETUID`/`SETGID` added back) removed `CAP_CHOWN`. The entrypoint's root-phase `chown -R 1000:1000` of the data volumes failed silently (`2>/dev/null || true`), so after dropping to UID 1000 the process could not write `/app/backend/data/.webui_secret_key` into the still-root-owned directory and exited 1.

Two changes:

- `services/docker-compose.yml` -- add `CHOWN` and `FOWNER` to the open-webui `cap_add` list so the root phase can chown/chmod freshly created volumes before dropping privileges
- `scripts/runtime/openwebui-entrypoint.sh` -- fail fast with a clear `[ERROR]` (pointing at container capabilities) when chown of the data directories fails, instead of silencing it; image-directory chown failures now emit a visible `[WARN]`

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

Describe how this change was tested:

- Reproduced the failure directly: running the image with the old capability set against the `aixcl-open-webui-main` volume, `chown` fails with `Operation not permitted` and the volume stays owned 0:0
- Applied the fix and performed a full stack restart (`./aixcl stack stop` / `./aixcl stack start --profile sys`) on the previously failing stack: the entrypoint chown now succeeds and Open WebUI reaches healthy -- 21/21 services healthy
- `shellcheck --severity=warning --exclude=SC1091` and `bash -n` clean on the entrypoint; `compose config` validates; `check-ai-elisions.sh --staged` clean
- Environment: rootless Podman on WSL2

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1891

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-17
- Method: Root-cause analysis via container logs and capability reproduction, minimal two-file fix, end-to-end verification on the live stack
- Scope: services/docker-compose.yml, scripts/runtime/openwebui-entrypoint.sh, issue #1891
- Confirmation: yes
---
