### PR TITLE
Release v1.1.62 (#1896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the AIXCL project will be documented in this file.
 ## [Unreleased]
 
 
+## [v1.1.62] - 2026-07-17
+
+### Summary
+
+Release v1.1.62 -- Bugfix release: Open WebUI starts healthy again on a cleanly initialised stack (the hardening capability set had silently broken its volume permission setup), and create-issue.sh now applies the taxonomy type label it always claimed to.
+
+### Fixed
+
+- [x] **Open WebUI crash-loop on clean init**: the cap_drop ALL hardening set had removed CAP_CHOWN, so the entrypoint's root-phase chown of fresh volumes failed silently and the non-root process could not write .webui_secret_key; CHOWN and FOWNER are restored in services/docker-compose.yml, and the entrypoint now fails fast with a clear error on data-directory chown failures instead of hiding them (#1891).
+- [x] **create-issue.sh missing type label**: the wrapper used its type argument only to select a template, leaving issues without the required Bug/Feature/Task label until the pr-ready gate blocked the linked PR; the label is now derived from the type and passed at creation, deduplicated against caller-supplied labels (#1893).
+
+
+
+
 ## [v1.1.61] - 2026-07-14
 
 ### Summary

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,24 +77,26 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
+    # Data directories are written to after privileges drop: a failed chown
+    # here guarantees a later crash, so fail fast instead of hiding it.
     for dir in /app/backend/data /app/data /app/backend/data/static; do
-        if [ -d "$dir" ]; then
-            echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
-        else
+        if [ ! -d "$dir" ]; then
             echo "Creating directory $dir"
-            mkdir -p "$dir" 2>/dev/null || true
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
+            mkdir -p "$dir"
         fi
+        echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
+        if ! chown -R "$USER_ID:$GROUP_ID" "$dir"; then
+            echo "[ERROR] chown of $dir failed -- container likely lacks CAP_CHOWN (check cap_add in docker-compose.yml)"
+            exit 1
+        fi
+        chmod 755 "$dir"
     done
 
     for dir in /app/backend/open_webui /app/backend/open_webui/static; do
         if [ -d "$dir" ]; then
             echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
-            chown -R "$USER_ID:$GROUP_ID" "$dir" 2>/dev/null || true
-            chmod 755 "$dir" 2>/dev/null || true
+            chown -R "$USER_ID:$GROUP_ID" "$dir" || echo "[WARN] chown of $dir failed; static asset writes may not work"
+            chmod 755 "$dir" || true
         fi
     done
 

--- a/scripts/utils/create-issue.sh
+++ b/scripts/utils/create-issue.sh
@@ -7,6 +7,8 @@
 # - Uses /tmp for body files (never touches repo)
 # - Always uses --body-file (no backtick injection risk)
 # - Always sets --assignee (no PR validation race condition)
+# - Applies the taxonomy type label (Bug/Feature/Task) from the type
+#   argument, deduplicated against caller-supplied labels (#1893)
 # - Validates issue type prefix before creation
 # - With a body-file argument, validates reference style (one issue/PR
 #   reference per list item) before creation -- the same rule the
@@ -49,14 +51,21 @@ if [[ -z "$ASSIGNEE" ]]; then
     exit 1
 fi
 
-# Select template
+# Select template and taxonomy type label
 TEMPLATE_FILE=""
+TYPE_LABEL=""
 case "$TYPE" in
-    bug)      TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/bug_report.md" ;;
-    feature)  TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/feature_request.md" ;;
-    task)     TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/task.md" ;;
+    bug)      TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/bug_report.md";      TYPE_LABEL="Bug" ;;
+    feature)  TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/feature_request.md"; TYPE_LABEL="Feature" ;;
+    task)     TEMPLATE_FILE="${SCRIPT_DIR}/.github/ISSUE_TEMPLATE/task.md";            TYPE_LABEL="Task" ;;
     *)        echo "ERROR: Unknown type '$TYPE'. Use: bug, feature, task"; exit 1 ;;
 esac
+
+# The taxonomy requires exactly one type label (Bug/Feature/Task); the
+# pr-ready merge gate blocks on its absence. Add it unless already given.
+if [[ ",${LABELS}," != *",${TYPE_LABEL},"* ]]; then
+    LABELS="${LABELS:+${LABELS},}${TYPE_LABEL}"
+fi
 
 # Create body file in /tmp
 BODY_FILE="$(mktemp /tmp/aixcl-issue-XXXXXX.md)"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -414,6 +414,10 @@ services:
     cap_add:
       - SETUID
       - SETGID
+      # CHOWN/FOWNER: entrypoint root phase must chown/chmod freshly
+      # created volumes to UID 1000 before dropping privileges
+      - CHOWN
+      - FOWNER
     deploy:
       resources:
         limits:


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1896

### Description of Changes

Release v1.1.62 -- bugfix release promoting two fixes from dev to main:

- Open WebUI crash-loop on clean init resolved by restoring CHOWN/FOWNER to its capability set and making the entrypoint fail loudly on chown errors (#1891)
- create-issue.sh now applies the taxonomy type label derived from its type argument (#1893)

Changelog entry added under v1.1.62 with summary and both fixes. Pre-release retrospective: https://github.com/xencon/aixcl/discussions/1895

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

Describe how this change was tested:

- Both included fixes were verified in their own PRs (#1892 live-stack verification to 21/21 healthy plus forced-failure reproduction; #1894 stubbed-gh argument capture across four cases)
- `./aixcl checks all` green on dev before prep (11/11)
- Housekeeping sweep clean on 2026-07-18 (branches, secrets, pins, shellcheck, line endings)
- Changelog edited to plain ASCII; only CHANGELOG.md changes in this PR

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1896

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-18
- Method: Release prep via ./aixcl release prep; changelog authored from merged PR history; commit GPG-signed by the operator
- Scope: CHANGELOG.md, release issue #1896, retrospective discussion #1895
- Confirmation: yes
---
