### PR TITLE
Create data dirs before chown in openwebui entrypoint (#1901)

### DIFF
--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,13 +77,22 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
-    # Data directories are written to after privileges drop: a failed chown
-    # here guarantees a later crash, so fail fast instead of hiding it.
+    # Create missing directories BEFORE chowning their parents: on a fresh
+    # volume the parent is still root-owned so mkdir needs no extra
+    # capability, and the recursive chown below covers the new children.
+    # Root has no CAP_DAC_OVERRIDE here, so it cannot mkdir inside a
+    # directory already owned by $USER_ID -- that case is deferred to the
+    # non-root phase, which owns the parent by then.
     for dir in /app/backend/data /app/data /app/backend/data/static; do
         if [ ! -d "$dir" ]; then
             echo "Creating directory $dir"
-            mkdir -p "$dir"
+            mkdir -p "$dir" || echo "[WARN] mkdir $dir failed as root; deferring to non-root phase"
         fi
+    done
+
+    # Data directories are written to after privileges drop: a failed chown
+    # here guarantees a later crash, so fail fast instead of hiding it.
+    for dir in /app/backend/data /app/data; do
         echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
         if ! chown -R "$USER_ID:$GROUP_ID" "$dir"; then
             echo "[ERROR] chown of $dir failed -- container likely lacks CAP_CHOWN (check cap_add in docker-compose.yml)"
@@ -121,10 +130,18 @@ CURRENT_GID="$(id -g)"
 echo "Running as user: $CURRENT_UID:$CURRENT_GID"
 
 DATA_DIR="/app/backend/data"
-if [ ! -d "$DATA_DIR" ]; then
-    echo "Error: Data directory $DATA_DIR does not exist"
-    exit 1
-fi
+
+# Ensure data directories exist now that this user owns the parents; the
+# root phase cannot create children inside an already-chowned directory
+# (no CAP_DAC_OVERRIDE).
+for dir in "$DATA_DIR" /app/data "$DATA_DIR/static"; do
+    if [ ! -d "$dir" ]; then
+        if ! mkdir -p "$dir"; then
+            echo "[ERROR] cannot create $dir as UID $CURRENT_UID -- volume ownership is wrong (root-phase chown failed?)"
+            exit 1
+        fi
+    fi
+done
 
 echo "Data directory: $DATA_DIR"
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1901

### Description of Changes

Follow-up to #1892: the restored CAP_CHOWN exposed an ordering bug in the same entrypoint. The refactored loop chowned `/app/backend/data` to the target UID before creating the missing `static/` subdirectory, and root without CAP_DAC_OVERRIDE cannot mkdir inside a directory it no longer owns -- fatal under `set -e`, so Open WebUI crash-looped on any truly fresh volume (one with no pre-existing subdirectories). The #1892 verification missed it because that volume retained `static/` from earlier crash-looped runs; a full purge created a genuinely empty volume and surfaced the path immediately.

Two changes in `scripts/runtime/openwebui-entrypoint.sh`, no capability changes:

- Root phase creates all missing data directories BEFORE chowning parents (fresh volumes are root-owned at that point, so mkdir needs no extra capability; the recursive chown covers the new children); a mkdir failure on an already user-owned parent warns and defers instead of dying
- Non-root phase ensures the data directories exist after privileges drop (it owns the parents by then) and fails loudly if it cannot create them

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

Describe how this change was tested:

- Three throwaway-volume scenarios with the edited entrypoint bind-mounted into the v0.10.2 image and a stub secrets volume (independent of the running stack):
- Brand-new empty volume with production caps (SETUID/SETGID/CHOWN/FOWNER): `static/` created before the chown, secret key generated, Open WebUI starts
- Parent pre-chowned to 1000:1000 with `static/` missing: root-phase mkdir fails with a visible `[WARN] ... deferring to non-root phase`, non-root phase creates it, Open WebUI starts
- Regression check without CAP_CHOWN: still exits 1 with the #1892 `[ERROR] chown ... likely lacks CAP_CHOWN` message
- `shellcheck --severity=warning --exclude=SC1091` and `bash -n` clean; `check-ai-elisions.sh --staged` clean
- Final end-to-end confirmation (stack purge + clean init to 21/21 healthy) is tracked as the `(post-merge)` verification item on #1901 -- the operator is performing a full podman reset, which exercises exactly this path

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1901

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-18
- Method: Root-cause analysis of the live crash-loop, ordering fix, three-scenario throwaway-volume verification; commit GPG-signed by the operator
- Scope: scripts/runtime/openwebui-entrypoint.sh, issue #1901
- Confirmation: yes
---

