### PR TITLE
Release v1.1.63 (#1904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the AIXCL project will be documented in this file.
 ## [Unreleased]
 
 
+## [v1.1.63] - 2026-07-18
+
+### Summary
+
+Release v1.1.63 -- Follow-up bugfix: completes the v1.1.62 Open WebUI clean-init repair by fixing a directory-creation ordering bug the previous fix introduced, verified end to end with a full podman reset and clean initialisation to 21/21 healthy.
+
+### Fixed
+
+- [x] **Open WebUI entrypoint mkdir ordering on brand-new volumes**: the v1.1.62 fix chowned the data directory to the target UID before creating the missing static subdirectory, and container root without CAP_DAC_OVERRIDE cannot mkdir inside a directory it no longer owns, so genuinely empty volumes still crash-looped; the root phase now creates missing directories before chowning parents (warning and deferring when it cannot), and the non-root phase guarantees them after privileges drop -- capability set unchanged (#1901).
+
+
+
+
 ## [v1.1.62] - 2026-07-17
 
 ### Summary

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,13 +77,22 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
-    # Data directories are written to after privileges drop: a failed chown
-    # here guarantees a later crash, so fail fast instead of hiding it.
+    # Create missing directories BEFORE chowning their parents: on a fresh
+    # volume the parent is still root-owned so mkdir needs no extra
+    # capability, and the recursive chown below covers the new children.
+    # Root has no CAP_DAC_OVERRIDE here, so it cannot mkdir inside a
+    # directory already owned by $USER_ID -- that case is deferred to the
+    # non-root phase, which owns the parent by then.
     for dir in /app/backend/data /app/data /app/backend/data/static; do
         if [ ! -d "$dir" ]; then
             echo "Creating directory $dir"
-            mkdir -p "$dir"
+            mkdir -p "$dir" || echo "[WARN] mkdir $dir failed as root; deferring to non-root phase"
         fi
+    done
+
+    # Data directories are written to after privileges drop: a failed chown
+    # here guarantees a later crash, so fail fast instead of hiding it.
+    for dir in /app/backend/data /app/data; do
         echo "Setting ownership of $dir to $USER_ID:$GROUP_ID"
         if ! chown -R "$USER_ID:$GROUP_ID" "$dir"; then
             echo "[ERROR] chown of $dir failed -- container likely lacks CAP_CHOWN (check cap_add in docker-compose.yml)"
@@ -121,10 +130,18 @@ CURRENT_GID="$(id -g)"
 echo "Running as user: $CURRENT_UID:$CURRENT_GID"
 
 DATA_DIR="/app/backend/data"
-if [ ! -d "$DATA_DIR" ]; then
-    echo "Error: Data directory $DATA_DIR does not exist"
-    exit 1
-fi
+
+# Ensure data directories exist now that this user owns the parents; the
+# root phase cannot create children inside an already-chowned directory
+# (no CAP_DAC_OVERRIDE).
+for dir in "$DATA_DIR" /app/data "$DATA_DIR/static"; do
+    if [ ! -d "$dir" ]; then
+        if ! mkdir -p "$dir"; then
+            echo "[ERROR] cannot create $dir as UID $CURRENT_UID -- volume ownership is wrong (root-phase chown failed?)"
+            exit 1
+        fi
+    fi
+done
 
 echo "Data directory: $DATA_DIR"
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1904

### Description of Changes

Release v1.1.63 -- follow-up bugfix release promoting one fix from dev to main:

- Open WebUI entrypoint mkdir-ordering fix: completes the v1.1.62 clean-init repair by creating missing data directories before chowning parents, with a non-root-phase guarantee after privileges drop; capability set unchanged (#1901)

Changelog entry added under v1.1.63. Pre-release retrospective: https://github.com/xencon/aixcl/discussions/1903

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes

Describe how this change was tested:

- The included fix was verified in PR #1902 across three throwaway-volume scenarios (empty volume, user-owned parent missing static, missing-CAP_CHOWN regression)
- Post-merge it was confirmed end to end: full podman reset, purge, and clean init reached 21/21 healthy with the fixed sequence visible in the entrypoint log
- Only CHANGELOG.md changes in this PR; entry is plain ASCII

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1904

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-18
- Method: Release prep via ./aixcl release prep; changelog authored from merged PR history; commit GPG-signed by the operator
- Scope: CHANGELOG.md, release issue #1904, retrospective discussion #1903
- Confirmation: yes
---

