### PR TITLE
Pre-release agentic file consistency sweep (#1910)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -65,6 +65,8 @@ up front:
 
 ## CI Workflows Summary
 
+All 12 workflows:
+
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
 | pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
@@ -73,6 +75,12 @@ up front:
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review, gitleaks, shell obfuscation patterns |
 | documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, check-profiles.sh, yamllint, compose validate |
 | codeql.yml | PR + push | GitHub Actions workflow security (actions language only) |
+| check-opencode.yml | PR touching .opencode paths | check-agents.sh (agent/skill/rules/commands parity) |
+| integration-tests.yml | PR + push (main/dev) | Compose validation, engine and stack configuration tests |
+| dependency-review.yml | PR to main/dev | GitHub dependency review action |
+| commit-signature-check.yml | Push to main/dev | GPG signature presence (reporting only, non-blocking) |
+| close-linked-issues.yml | PR to dev closed | Closes issues linked from the merged PR body |
+| release.yml | Tag push (v*) + manual dispatch | Builds and publishes the GitHub release |
 
 ## Running Checks Locally
 ```bash

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: add-service
 description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
-version: 1.1
 compatibility: OpenCode, Claude Code
 metadata:
   category: platform

--- a/.claude/skills/check-updates/SKILL.md
+++ b/.claude/skills/check-updates/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: check-updates
 description: Audit all versioned platform components and manage the update process following issue-first workflow
-version: 1.0
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: housekeeping
 description: Comprehensive repository health check covering hygiene, security, and code quality
-version: 2.0
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: release
 description: Guided workflow for cutting an AIXCL release, fronting the aixcl release command
-version: 2.0
 compatibility: OpenCode, Claude Code
+disable-model-invocation: true
 metadata:
   category: workflow
   version: "2.0"

--- a/.claude/skills/workflow-guard/SKILL.md
+++ b/.claude/skills/workflow-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: workflow-guard
 description: Validates Issue-First workflow compliance before execution
-license: MIT
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow

--- a/.opencode/CONTEXT.md
+++ b/.opencode/CONTEXT.md
@@ -57,4 +57,4 @@ goes to BOTH files (edit the template, apply locally).
 - `AGENTS.md` -- operating contract (loaded via the `instructions` array)
 - `config/opencode.json.example` -- provider, model, permissions, instructions
 - `docs/developer/opencode-setup.md` -- human setup guide
-- `.claude/` -- Claude Code counterpart (rules/skills mirrored; commands tool-specific)
+- `.claude/` -- Claude Code counterpart (rules/skills mirrored; command sets tool-specific, but commands present on both sides must share the same body -- enforced by `check-agents.sh`)

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -65,6 +65,8 @@ up front:
 
 ## CI Workflows Summary
 
+All 12 workflows:
+
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
 | pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
@@ -73,6 +75,12 @@ up front:
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review, gitleaks, shell obfuscation patterns |
 | documentation-checks.yml | PR + push | check-paths.sh, check-generated-files.sh, check-profiles.sh, yamllint, compose validate |
 | codeql.yml | PR + push | GitHub Actions workflow security (actions language only) |
+| check-opencode.yml | PR touching .opencode paths | check-agents.sh (agent/skill/rules/commands parity) |
+| integration-tests.yml | PR + push (main/dev) | Compose validation, engine and stack configuration tests |
+| dependency-review.yml | PR to main/dev | GitHub dependency review action |
+| commit-signature-check.yml | Push to main/dev | GPG signature presence (reporting only, non-blocking) |
+| close-linked-issues.yml | PR to dev closed | Closes issues linked from the merged PR body |
+| release.yml | Tag push (v*) + manual dispatch | Builds and publishes the GitHub release |
 
 ## Running Checks Locally
 ```bash

--- a/.opencode/skills/add-service/SKILL.md
+++ b/.opencode/skills/add-service/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: add-service
 description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
-version: 1.1
 compatibility: OpenCode, Claude Code
 metadata:
   category: platform

--- a/.opencode/skills/check-updates/SKILL.md
+++ b/.opencode/skills/check-updates/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: check-updates
 description: Audit all versioned platform components and manage the update process following issue-first workflow
-version: 1.0
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance

--- a/.opencode/skills/housekeeping/SKILL.md
+++ b/.opencode/skills/housekeeping/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: housekeeping
 description: Comprehensive repository health check covering hygiene, security, and code quality
-version: 2.0
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: release
 description: Guided workflow for cutting an AIXCL release, fronting the aixcl release command
-version: 2.0
 compatibility: OpenCode, Claude Code
+disable-model-invocation: true
 metadata:
   category: workflow
   version: "2.0"

--- a/.opencode/skills/workflow-guard/SKILL.md
+++ b/.opencode/skills/workflow-guard/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: workflow-guard
 description: Validates Issue-First workflow compliance before execution
-license: MIT
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 | purpose | agent_contract |
 | priority | critical |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, MCP-compatible systems |
-| last_updated | 2026-07-06 |
+| last_updated | 2026-07-18 |
 
 # AGENTS.md
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 | field         | value                                                                      |
 |---------------|----------------------------------------------------------------------------|
 | file          | DEVELOPMENT.md                                                             |
-| version       | 2.0 (tracks workflow evolution; subordinate to AGENTS.md v2.0)             |
+| version       | 2.1 (tracks workflow evolution; subordinate to AGENTS.md v2.2)             |
 | scope         | all agents                                                                 |
 | priority      | high                                                                       |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, any MCP-compatible agent           |

--- a/docs/developer/development-workflow.md
+++ b/docs/developer/development-workflow.md
@@ -21,12 +21,17 @@ We follow an **Issue-First Development** workflow:
 - Discussion happens before implementation
 - Work is traceable and organized
 
-**Using GitHub CLI:**
+**Use the wrapper script** (validates the title prefix, applies the
+taxonomy type label, always sets the assignee, and checks reference
+style in custom bodies):
+
 ```bash
-# Note: GitHub CLI doesn't support setting issue type directly
-# Set the type in GitHub UI, then add labels:
-gh issue create --title "Brief description" --body "Detailed description of the problem or feature" --label "component:cli" --assignee <your-github-username>
+./scripts/utils/create-issue.sh "[TASK] Brief description" task "component:cli" <your-github-username> [body-file]
 ```
+
+If you must use raw `gh issue create`, always pass `--label` (including
+the type label from the AGENTS.md Label Taxonomy) and `--assignee` at
+creation time, and use `--body-file` rather than inline `--body`.
 
 **Best Practices:**
 - Use clear, descriptive titles
@@ -91,15 +96,19 @@ See [GPG-Signed Commits Guide](./gpg-signed-commits.md) for complete documentati
 
 ### 4. Push and Create Pull Request
 
-Push your branch and create a PR:
+Push your branch and create a PR with the wrapper script, which sets
+the assignee and labels at creation time:
 
 ```bash
 git push -u origin <branch-name>
-gh pr create --title "Title referencing issue" --body "Description linking to issue #<number>"
-
-# Always assign yourself and add matching labels to the PR
-gh pr edit <number> --add-assignee <your-github-username> --add-label "component:cli"
+./scripts/utils/create-pr.sh
 ```
+
+**Never** set the assignee or labels in a second step (`gh pr edit`
+after `gh pr create`). The PR validation workflow fires on the
+`opened` event; a PR created without assignee and labels fails
+validation permanently. See DEVELOPMENT.md Section 5 for the raw
+`gh pr create` fallback with `--assignee` and `--label` flags.
 
 **PR Best Practices:**
 - Title should reference the issue without colon: `"Fix Issue title (#<number>)"`
@@ -195,86 +204,11 @@ The human sees `[ ]` on verification items and ticks them during code review. Th
 
 ## Label Guidelines
 
-**GitHub Issue Types and Labels are required for all issues.** GitHub has native issue types that are separate from labels. Both help organize issues, track work, and make it easier to find related issues.
+**The label taxonomy is defined once, in AGENTS.md Section 3 (Label Taxonomy) -- that section is canonical; do not invent labels outside it.**
 
-### GitHub Issue Types (Required - Select One)
+In summary: exactly one type label (`Bug`, `Feature`, `Task`), at least one `component:*` label (required), optional priority (`P1`-`P3`), optional profile (`profile:bld`, `profile:sys`), and optional category (`Fix`, `Enhancement`, `Refactor`, `Maintenance`).
 
-GitHub provides native issue types that must be set for each issue. These are separate from labels:
-
-- **Bug** - An unexpected problem or behavior
-- **Feature** - A request, idea, or new functionality
-- **Task** - A specific piece of work
-
-**Note:** You cannot create custom issue types in GitHub. Use labels for additional categorization (see below).
-
-### Label Categories
-
-Labels are organized into categories using prefixes:
-
-#### Component Labels (Select All That Apply)
-- `component:runtime-core` - Runtime core services (Ollama)
-- `component:ollama` - Ollama LLM inference engine
-- `component:persistence` - Database and persistence services
-- `component:observability` - Monitoring and observability (Prometheus, Grafana, Loki)
-- `component:ui` - User interface components (Open WebUI)
-- `component:cli` - Command-line interface and tooling
-- `component:infrastructure` - Infrastructure and deployment (Docker, profiles, configuration)
-- `component:testing` - Tests and test infrastructure
-
-#### Priority Labels (Optional - Select One)
-- `P1` - High priority issue requiring immediate attention
-- `P2` - Medium priority issue
-- `P3` - Low priority issue
-
-#### Profile Labels (Select All That Apply)
-- `profile:bld` - Affects bld profile (observability-focused)
-- `profile:sys` - Affects sys profile (full deployment)
-
-#### Category Labels (Select All That Apply)
-- `Fix` - A fix for a bug or issue (use with Bug issue type)
-- `Enhancement` - Improvement to existing functionality (use with Feature issue type)
-- `Refactor` - Code refactoring without changing functionality (use with Task issue type)
-- `Maintenance` - Maintenance tasks and housekeeping (use with Task issue type)
-- `documentation` - Improvements or additions to documentation (GitHub default)
-
-**Note:** "Task" is an issue type, not a label. Use the Task issue type for tasks, refactoring, and maintenance work. Do not create a "Task" label as it's redundant with the issue type.
-
-#### Other Labels
-- `dependencies` - Dependency updates and management
-- `good first issue` - Good for newcomers
-- `help wanted` - Extra attention is needed
-- `question` - Further information is requested
-
-### How to Add Labels
-
-**When creating an issue:**
-```bash
-# Add labels during creation (set issue type in GitHub UI)
-gh issue create --title "Title" --body "Description" --label "component:cli,P1"
-
-# Or add labels after creation
-gh issue edit <number> --add-label "component:cli"
-```
-
-**Note:** GitHub CLI doesn't support setting the issue type (Bug/Feature/Task) directly. Set the type in the GitHub web interface, then use CLI for labels.
-
-**Issue Type and Label Selection Guidelines:**
-1. **Always select one GitHub issue type** - Bug, Feature, or Task (set via GitHub's Type field)
-   - **Note:** "Task" is an issue type only, not a label. Do not create or use a "Task" label.
-2. **Select relevant component labels** - Helps identify which part of the system is affected
-3. **Select category labels if applicable** - Fix, Enhancement, Refactor, Maintenance for additional context
-4. **Select priority if applicable** - Helps prioritize work
-5. **Select profile labels if issue is profile-specific** - Helps identify deployment impact
-6. **Use other labels as appropriate** - `good first issue`, `help wanted`, etc.
-
-**Examples:**
-- Bug in CLI: Type: **Bug**, Labels: `component:cli`
-- New feature for observability: Type: **Feature**, Labels: `component:observability`
-- Fix for database issue: Type: **Bug**, Labels: `Fix,component:persistence`
-- Task for infrastructure: Type: **Task**, Labels: `component:infrastructure`
-- Enhancement affecting all profiles: Type: **Feature**, Labels: `Enhancement,profile:bld,profile:sys`
-- High priority bug: Type: **Bug**, Labels: `component:runtime-core,P1`
-- Dependency update: Type: **Task**, Labels: `dependencies,Maintenance`
+`./scripts/utils/create-issue.sh` applies the type label automatically from its type argument. Labels applied by GitHub automation (e.g. `dependencies` on Dependabot PRs) are tolerated but never added by hand.
 
 ### Checking Available Labels
 
@@ -349,13 +283,12 @@ See [opencode-setup.md](./opencode-setup.md) for installation and configuration 
 
 ```
 Follow the development workflow documented in this document:
-1. Always create an issue first using 'gh issue create' with appropriate labels and assignee
+1. Always create an issue first using './scripts/utils/create-issue.sh' with appropriate labels and assignee
 2. Read the template file first before composing any issue or PR body
 3. Use /tmp for all generated body files and drafts (never commit generated artifacts)
 4. Create a branch with format 'issue-<number>/<description>' from dev
 5. Make changes and commit with conventional commit format
-6. Push branch and create PR that references the issue
-7. Assign the PR and add matching labels to it
+6. Push branch and create PR with './scripts/utils/create-pr.sh' (assignee and labels are set at creation time, never via a later 'gh pr edit')
 8. Use plain text formatting (markdown checkboxes - [x], not Unicode)
 9. Reference the issue number in commits and PRs
 10. Add labels to issues (type, component, priority, profile as applicable)
@@ -367,32 +300,22 @@ Follow the development workflow documented in this document:
 ## Quick Reference Commands
 
 ```bash
-# Create issue with labels and assignee (set issue type in GitHub UI)
-# Note: Both issue and PR titles should NOT include colon (e.g., "Fix CLI error handling" not "Fix: CLI error handling")
-gh issue create --title "Fix CLI error handling" --body "Description" --label "component:cli,P1" --assignee <your-github-username>
-
-# Or add labels/assignee after creation
-gh issue edit <number> --add-label "component:cli" --add-assignee <your-github-username>
+# Create issue (validates title, applies type label, sets assignee)
+# Note: No colons in issue or PR titles (e.g., "Fix CLI error handling" not "Fix: CLI error handling")
+./scripts/utils/create-issue.sh "[BUG] Fix CLI error handling" bug "component:cli,P1" <your-github-username>
 
 # Create branch
 git checkout -b issue-<number>/<description>
 
 # Commit
-git add .
+git add <files>
 git commit -m "type: Description
 
 Fixes #<number>"
 
-# Push and create PR
+# Push and create PR (assignee and labels set at creation time)
 git push -u origin issue-<number>/<description>
-gh pr create --title "Fix Title (#<number>)" --body "Fixes #<number>
-
-## Changes
-- [x] Change 1
-- [x] Change 2"
-
-# Assign and label the PR (matching the issue labels)
-gh pr edit <number> --add-assignee <your-github-username> --add-label "component:cli,P1"
+./scripts/utils/create-pr.sh
 ```
 
 ## Why This Workflow?
@@ -405,22 +328,20 @@ gh pr edit <number> --add-assignee <your-github-username> --add-label "component
 
 ## Checking Agent and Skill Files
 
-When creating or modifying Agent files (`.opencode/agents/agent-*.md`), or Agent reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
+When creating or modifying agent files (`.opencode/agents/agent-*.md`), skills, rules, commands, or agent reports (`docs/reference/ai-report-*.md`), run the lint check script before committing:
 
 ```bash
 ./scripts/checks/check-agents.sh
 ```
 
 This script validates:
-- Naming conventions (`agent-*.md`, `ai-report-*.md`)
-- Skill files (`skill-*.md`) if `.opencode/skills/` directory exists
-- Required YAML frontmatter fields (`name`, `description`, `role: system`)
-- Required sections (Purpose, Canonical references, Global rules, Tool usage, Workflow steps, Safety/governance)
-- References to core documentation (`development-workflow.md`, `01_ai_guidance.md`)
+- Agent naming convention (`agent-*.md`) and frontmatter (`description` required, `name` forbidden -- it overrides the filename-derived agent id)
+- `SKILL.md` frontmatter (`name` and `description` required)
+- Byte-identical mirror parity between `.claude/rules/` and `.opencode/rules/`, and between `.claude/skills/` and `.opencode/skills/`
+- Body parity for commands present in both `.claude/commands/` and `.opencode/commands/` (frontmatter may differ per tool)
+- AI report naming convention (`ai-report-*.md`)
 
-The same checks run automatically in CI on pull requests that touch agent, skill, or report files.
-
-**Note**: Custom skills in `.opencode/skills/` are optional. The directory only exists if skills are actually defined.
+The same checks run automatically in CI on pull requests that touch these paths (`check-opencode.yml`).
 
 ## Questions?
 

--- a/docs/reference/ai-report-structured-knowledge-architectures.md
+++ b/docs/reference/ai-report-structured-knowledge-architectures.md
@@ -18,6 +18,8 @@ references:
 
 # AI-Generated Research Report: Structured Knowledge Architectures for LLM-Assisted Software Engineering
 
+> Durable reference document. This is background research, not a dated operations report, and is exempt from the 30-day currency expectation in the AGENTS.md Lean Repository Policy (Section 3). Delete it only when its recommendations are fully superseded.
+
 ## Executive Summary
 
 This comprehensive research evaluates whether structured knowledge architectures -- harnesses, knowledge maps, structured repositories, knowledge graphs, ontologies, and context management systems -- improve software engineering outcomes when using Large Language Models (LLMs).

--- a/scripts/checks/check-agents.sh
+++ b/scripts/checks/check-agents.sh
@@ -172,6 +172,38 @@ check_rules_parity() {
     fi
 }
 
+# Print a markdown file's body with any leading YAML frontmatter removed.
+strip_frontmatter() {
+    awk 'NR==1 && /^---$/ {fm=1; next} fm && /^---$/ {fm=0; next} !fm' "$1"
+}
+
+# Check that commands present in BOTH tool directories carry the same body.
+# Command sets are intentionally tool-specific (a file on only one side is
+# fine), but a shared command must not drift: only frontmatter may differ
+# per tool (e.g. the OpenCode 'agent:' field). See issue #1910.
+check_commands_parity() {
+    local claude_cmds=".claude/commands"
+    local opencode_cmds=".opencode/commands"
+
+    if [[ ! -d "$claude_cmds" ]] || [[ ! -d "$opencode_cmds" ]]; then
+        return 0
+    fi
+
+    info "Checking shared-command parity: $claude_cmds <-> $opencode_cmds"
+
+    local cmd_file basename
+    for cmd_file in "$claude_cmds"/*.md; do
+        [[ -e "$cmd_file" ]] || continue
+        basename=$(basename "$cmd_file")
+        [[ -f "$opencode_cmds/$basename" ]] || continue
+        if ! diff -q \
+            <(strip_frontmatter "$cmd_file") \
+            <(strip_frontmatter "$opencode_cmds/$basename") >/dev/null; then
+            error "commands parity: $basename body differs between $claude_cmds and $opencode_cmds (frontmatter may differ; bodies must match)"
+        fi
+    done
+}
+
 # Check AI report files
 check_reports() {
     local reports_dir="docs/reference"
@@ -203,6 +235,7 @@ main() {
     check_agents
     check_skills
     check_rules_parity
+    check_commands_parity
     check_reports
 
     echo ""

--- a/scripts/checks/check-paths.sh
+++ b/scripts/checks/check-paths.sh
@@ -125,7 +125,6 @@ check_hardcoded_usernames() {
 check_directory_references() {
     info "Checking directory references..."
 
-    # Only check directories that SHOULD exist (not optional ones like ai/skills)
     local dirs_to_check=(
         ".opencode/agents"   # Should exist
     )
@@ -138,12 +137,6 @@ check_directory_references() {
             fi
         fi
     done
-
-    # ai/skills is optional - check it's documented as such
-    if [[ ! -d "ai/skills" ]]; then
-        # This is expected - it's documented as optional
-        info "Directory ai/skills does not exist (documented as optional)"
-    fi
 }
 
 # Main execution

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
-# Pre-commit hook: run shellcheck on staged shell scripts
-# Mirrors CI settings: --severity=warning --exclude=SC1091
+# Pre-commit hook: elision guard + shellcheck on staged shell scripts
+# Mirrors CI settings: check-ai-elisions (bash-ci.yml) and the
+# security.yml lint flags --severity=warning --exclude=SC1091
 
 set -euo pipefail
+
+# Elision guard: block AI-truncated files and unexplained mass deletions.
+# Intentional large rewrites: AIXCL_ALLOW_MASS_DELETE=1 git commit ...
+if [ -x scripts/checks/check-ai-elisions.sh ]; then
+    if ! scripts/checks/check-ai-elisions.sh --staged; then
+        echo ""
+        echo "check-ai-elisions failed. Fix the findings above before committing."
+        echo "To skip (not recommended): git commit --no-verify"
+        exit 1
+    fi
+fi
 
 SHELLCHECK=$(command -v shellcheck 2>/dev/null \
     || command -v /home/linuxbrew/.linuxbrew/bin/shellcheck 2>/dev/null \


### PR DESCRIPTION
# Pull Request

## Summary

Fixes #1910

### Description of Changes

Pre-release consistency sweep of the agentic file estate (docs, skills, rules, commands, governance, check scripts). Documentation and tooling only -- no runtime or service files are touched, so the stable deployment is unaffected. One commit implements the nine findings (F1-F9) enumerated on the issue:

- AGENTS.md and DEVELOPMENT.md: fixed the stale version cross-reference (DEVELOPMENT.md claimed subordination to AGENTS.md v2.0; it is v2.2) and refreshed the stale last_updated header field (F1)
- .claude/skills/ and .opencode/skills/: normalized SKILL.md frontmatter on all five skills to the canonical schema (name, description, compatibility, metadata), removing the duplicated top-level version field and the lone license field; both mirror sides updated together (F2)
- .claude/skills/release/ and .opencode/skills/release/: added disable-model-invocation true so the release workflow runs only when the operator invokes it deliberately; OpenCode documents unknown frontmatter fields as ignored, so mirror parity is safe (F7)
- scripts/checks/check-agents.sh: new check_commands_parity closes the parity blind spot -- commands present in both .claude/commands/ and .opencode/commands/ must share the same body (frontmatter may differ per tool); verified to fail loudly on injected drift (F3)
- .claude/rules/ci-checks.md and .opencode/rules/ci-checks.md: completed the CI Workflows Summary table from 6 to all 12 workflows (F4)
- docs/developer/development-workflow.md: removed the forbidden two-step gh pr edit label pattern the doc still taught, replaced the drifted 90-line Label Guidelines section with a pointer to the canonical AGENTS.md taxonomy (it contradicted the taxonomy on the Task label), documented the required wrapper scripts, and corrected the stale description of what check-agents.sh validates; the large deletion in this file is this intentional pointerization (F5)
- docs/reference/ai-report-structured-knowledge-architectures.md: marked as a durable reference document exempt from the 30-day dated-reports lean policy (F6)
- scripts/hooks/pre-commit: the standalone hook now runs check-ai-elisions.sh --staged before shellcheck, matching what the pre-commit framework config already enforces, so both hook paths have CI parity (F8)
- scripts/checks/check-paths.sh: removed the dead ai/skills special case; nothing documents that directory any longer (F9)

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### Testing Notes

- `./aixcl checks all` passes (11/11 including paths, agents, elisions, ascii, yaml, compose)
- `shellcheck --severity=warning --exclude=SC1091` and `bash -n` clean on all three modified scripts
- Negative test: injected drift into `.opencode/commands/finish-pr.md` and confirmed the new commands-parity check exits 1 with a named error, then restored
- Live confirmation of F7: after adding disable-model-invocation, the release skill left the model-invocable skill list while remaining operator-invocable
- Staged elision check passed; the development-workflow.md deletion is the intentional label-section pointerization described above
- Commit is GPG-signed (verified Good signature)

### Verification

To verify this change is complete:

- Behavior works as expected
- No regressions observed
- Tests cover change

### Related Issues

- Closes #1910

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-18
- Method: Audit-driven documentation and check-script sweep; local CI parity suite plus negative testing of the new parity check
- Scope: .claude/, .opencode/, docs/, AGENTS.md, DEVELOPMENT.md, scripts/checks/, scripts/hooks/
- Confirmation: yes
---
