### PR TITLE
Convert silenced entrypoint failures to fail-fast or WARN (#1909)

### DIFF
--- a/docs/developer/adding-services.md
+++ b/docs/developer/adding-services.md
@@ -39,6 +39,13 @@ Define the service configuration:
       - /tmp:noexec,nosuid,size=50m
 ```
 
+**Capped entrypoint rules** (learned from #1891/#1901; audited in #1909). If your entrypoint does privileged filesystem work under a restricted capability set:
+
+1. **Create before chown.** Root without CAP_DAC_OVERRIDE cannot `mkdir` inside a directory it has already chowned to another UID. Create missing directories while the parent is still root-owned, then chown recursively; defer any creation that must happen later to the non-root phase, which owns the parent by then.
+2. **Fail fast on REQUIRED operations, naming the capability.** A silenced failure (`2>/dev/null || true`) on an operation the service needs (data-volume chown, privilege-drop user creation) guarantees a later crash with no cause in the logs. Fail with a message naming the likely missing capability (e.g. `container likely lacks CAP_CHOWN`).
+3. **WARN visibly on OPTIONAL operations.** Operations the service can survive without (GPU group membership, cosmetic chowns) get a visible `[WARN]` with the consequence, never a silent `|| true`.
+4. **Test against the three-scenario matrix** before merging: a truly-empty volume (clean init), a partially-initialised volume (prior failed run), and a capability-regression run (required cap withheld) that must fail loudly. Long-lived stacks mask init bugs -- a fresh volume is the only honest fixture.
+
 ### 2. `lib/cli/profile.sh`
 
 Add the service to **all applicable profile mappings** in `get_profile_services_for_profile()`:

--- a/scripts/runtime/CONTEXT.md
+++ b/scripts/runtime/CONTEXT.md
@@ -9,7 +9,7 @@ via volume mounts defined in `services/docker-compose.yml`.
 | File | Service | Notes |
 |------|---------|-------|
 | `ollama-entrypoint.sh` | `ollama` | Sets permissions, switches to ubuntu user, starts Ollama. |
-| `grafana-entrypoint.sh` | `grafana` | Waits for Prometheus, then starts Grafana. |
+| `grafana-entrypoint.sh` | `grafana` | First start: waits for the Vault admin password, then starts Grafana. Restart: starts directly. |
 | `openwebui-entrypoint.sh` | `openwebui` | Standard OpenWebUI startup. |
 | `openwebui-vault-entrypoint.sh` | `openwebui` (vault profile) | Fetches credentials from Vault before starting OpenWebUI. |
 | `pgadmin-entrypoint.sh` | `pgadmin` | Configures pgAdmin servers.json, starts pgAdmin. |
@@ -23,6 +23,24 @@ via volume mounts defined in `services/docker-compose.yml`.
 - Do not add host-path references. Only paths inside the container or
   mounted volumes are accessible.
 - `docker_utils.sh` is NOT available here -- these scripts are container-side.
+
+## Capped Entrypoint Rules (#1891/#1901/#1909)
+
+For entrypoints doing privileged filesystem work under `cap_drop`:
+
+- **Create before chown**: root without CAP_DAC_OVERRIDE cannot mkdir
+  inside a directory it already chowned away. Create missing dirs while
+  the parent is root-owned; defer later creation to the non-root phase.
+- **REQUIRED ops fail fast, naming the capability** (e.g. "container
+  likely lacks CAP_CHOWN"). Never `2>/dev/null || true` an operation the
+  service cannot run without -- that converts a clear startup error into
+  an unexplained crash-loop later.
+- **OPTIONAL ops get a visible `[WARN]`** stating the consequence, never
+  a silent `|| true`. (Probe no-matches like `pkill` on an absent
+  process are the one exception: no-match is the normal case.)
+- **Verify with the three-scenario matrix**: truly-empty volume,
+  partially-initialised volume, and a withheld-capability run that must
+  fail loudly. See docs/developer/adding-services.md.
 
 ## Agent Guidance
 

--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -46,7 +46,8 @@ fi
 echo "[Vault] Configuring Grafana with initial admin password..."
 GRAFANA_PASS_FILE="/tmp/grafana-admin-password"
 echo "$GRAFANA_ADMIN_PASSWORD" > "$GRAFANA_PASS_FILE"
-chown 472:472 "$GRAFANA_PASS_FILE" 2>/dev/null || true
+chown 472:472 "$GRAFANA_PASS_FILE" \
+    || echo "[WARN] chown of $GRAFANA_PASS_FILE failed (no CAP_CHOWN); continuing — chmod 600 below still applies"
 chmod 600 "$GRAFANA_PASS_FILE"
 export GF_SECURITY_ADMIN_PASSWORD__FILE="$GRAFANA_PASS_FILE"
 

--- a/scripts/runtime/ollama-entrypoint.sh
+++ b/scripts/runtime/ollama-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Ollama entrypoint wrapper - ensures correct permissions for Ollama data directory
 
-set -e
+set -euo pipefail
 
 # Configuration
 OLLAMA_USER="ubuntu"
@@ -15,12 +15,19 @@ if ! id "$OLLAMA_USER" &>/dev/null; then
     useradd -m -u "$OLLAMA_UID" "$OLLAMA_USER"
 fi
 
-# Ensure .ollama directory exists with correct ownership
+# Ensure .ollama directory exists with correct ownership. Model store
+# ownership is REQUIRED before the privilege drop: ollama cannot write
+# models as UID 1000 into a root-owned volume.
 mkdir -p "$OLLAMA_DATA"
-chown -R "$OLLAMA_USER:$OLLAMA_USER" "$OLLAMA_HOME"
+if ! chown -R "$OLLAMA_USER:$OLLAMA_USER" "$OLLAMA_HOME"; then
+    echo "[ERROR] chown of $OLLAMA_HOME failed — container likely lacks CAP_CHOWN"
+    exit 1
+fi
 
-# Add user to video and render groups for GPU access (if they exist)
-usermod -aG video,render "$OLLAMA_USER" 2>/dev/null || true
+# Add user to video and render groups for GPU access (optional: the
+# groups do not exist on hosts without GPU device nodes)
+usermod -aG video,render "$OLLAMA_USER" \
+    || echo "[WARN] could not add $OLLAMA_USER to video/render groups; GPU device access may be unavailable (normal on CPU-only hosts)"
 
 echo "Starting Ollama as $OLLAMA_USER user..."
 

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,6 +77,12 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
+    # setpriv below works with numeric IDs, so a missing user is not fatal,
+    # but surface it: HOME=/home/webui will not exist without useradd -m
+    if ! id webui >/dev/null 2>&1; then
+        echo "[WARN] webui user could not be created; continuing with numeric IDs ($USER_ID:$GROUP_ID), /home/webui may be missing"
+    fi
+
     # Create missing directories BEFORE chowning their parents: on a fresh
     # volume the parent is still root-owned so mkdir needs no extra
     # capability, and the recursive chown below covers the new children.
@@ -110,11 +116,14 @@ if [ "$(id -u)" = "0" ]; then
     done
 
     if [ -f "/app/backend/openwebui.sh" ]; then
-        chmod +x /app/backend/openwebui.sh 2>/dev/null || true
-        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh 2>/dev/null || true
+        chmod +x /app/backend/openwebui.sh \
+            || echo "[WARN] chmod +x /app/backend/openwebui.sh failed; launcher script may not be executable"
+        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh \
+            || echo "[WARN] chown of /app/backend/openwebui.sh failed (CAP_CHOWN?); launcher stays image-owned"
     fi
 
-    chown -R "$USER_ID:$GROUP_ID" /tmp 2>/dev/null || true
+    chown -R "$USER_ID:$GROUP_ID" /tmp \
+        || echo "[WARN] chown of /tmp failed; sticky-bit world-writable /tmp below is sufficient"
     chmod 1777 /tmp
 
     echo "Switching to webui user (UID: $USER_ID)..."

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -22,35 +22,50 @@ if [ "$IS_FIRST_START" = false ]; then
     # Still need to set up directories and permissions
     USER_ID="${PGADMIN_USER_ID:-5050}"
     GROUP_ID="${PGADMIN_GROUP_ID:-5050}"
-    
+
     if [ "$(id -u)" = "0" ]; then
         echo "Running as root — setting up permissions for restart..."
-        
+
         mkdir -p /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
-        
+
         if ! getent group pgadmin >/dev/null 2>&1; then
             groupadd -g "$GROUP_ID" pgadmin 2>/dev/null || groupadd pgadmin 2>/dev/null || true
         fi
-        
+
         if ! id pgadmin >/dev/null 2>&1; then
             useradd -u "$USER_ID" -g "$GROUP_ID" -s /bin/false -M pgadmin 2>/dev/null || true
         fi
-        
-        chown -R "$USER_ID:$GROUP_ID" /var/lib/pgadmin 2>/dev/null || true
-        chown -R "$USER_ID:$GROUP_ID" /var/log/pgadmin 2>/dev/null || true
-        chown "$USER_ID:$GROUP_ID" /pgadmin4/servers.json 2>/dev/null || true
-        chmod +x /entrypoint.sh 2>/dev/null || true
-        
-        # Stop postfix if running
+
+        # su below requires the pgadmin user; creation failure is fatal, so
+        # verify the outcome instead of silencing it
+        if ! id pgadmin >/dev/null 2>&1; then
+            echo "[ERROR] pgadmin user could not be created — cannot drop privileges (check SETUID/SETGID caps and a writable /etc/passwd)"
+            exit 1
+        fi
+
+        # Data volume ownership is REQUIRED: pgAdmin crashes after the
+        # privilege drop if it cannot write /var/lib/pgadmin
+        if ! chown -R "$USER_ID:$GROUP_ID" /var/lib/pgadmin; then
+            echo "[ERROR] chown of /var/lib/pgadmin failed — container likely lacks CAP_CHOWN"
+            exit 1
+        fi
+        chown -R "$USER_ID:$GROUP_ID" /var/log/pgadmin \
+            || echo "[WARN] chown of /var/log/pgadmin failed (host bind mount); log writes may fail"
+        chown "$USER_ID:$GROUP_ID" /pgadmin4/servers.json \
+            || echo "[WARN] chown of /pgadmin4/servers.json failed (single-file bind mount); server list may not load"
+        chmod +x /entrypoint.sh \
+            || echo "[WARN] chmod +x /entrypoint.sh failed; assuming image default permissions"
+
+        # Stop postfix if running (pkill no-match is the normal case, not a failure)
         if [ -f /usr/libexec/postfix/master ]; then
             pkill -f "postfix/master" 2>/dev/null || true
         fi
-        
+
         echo "Switching to pgadmin user (UID: $USER_ID)..."
         export PGADMIN_LISTEN_PORT PGADMIN_LISTEN_ADDRESS PGADMIN_SERVER_JSON_FILE PGADMIN_REPLACE_SERVERS_ON_STARTUP
         exec su -m -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'
     fi
-    
+
     # Non-root restart: just start
     echo "Running as user: $(id -u):$(id -g)"
     echo "Starting pgAdmin (restart) — admin credentials unchanged"
@@ -115,26 +130,42 @@ chmod 600 /var/lib/pgadmin/.pgadmin-passwd /var/lib/pgadmin/.pg-connect-passwd
 # --- Root setup block (only on first start) ---
 if [ "$(id -u)" = "0" ]; then
     echo "Running as root — setting up permissions for first start..."
-    
+
     mkdir -p /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
-    
+
     if ! getent group pgadmin >/dev/null 2>&1; then
         groupadd -g "${PGADMIN_GROUP_ID:-5050}" pgadmin 2>/dev/null || groupadd pgadmin 2>/dev/null || true
     fi
-    
+
     if ! id pgadmin >/dev/null 2>&1; then
         useradd -u "${PGADMIN_USER_ID:-5050}" -g "${PGADMIN_GROUP_ID:-5050}" -s /bin/false -M pgadmin 2>/dev/null || true
     fi
-    
-    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/lib/pgadmin 2>/dev/null || true
-    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/log/pgadmin 2>/dev/null || true
-    chown "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /pgadmin4/servers.json 2>/dev/null || true
-    chmod +x /entrypoint.sh 2>/dev/null || true
-    
+
+    # su below requires the pgadmin user; creation failure is fatal, so
+    # verify the outcome instead of silencing it
+    if ! id pgadmin >/dev/null 2>&1; then
+        echo "[ERROR] pgadmin user could not be created — cannot drop privileges (check SETUID/SETGID caps and a writable /etc/passwd)"
+        exit 1
+    fi
+
+    # Data volume ownership is REQUIRED: pgAdmin crashes after the
+    # privilege drop if it cannot write /var/lib/pgadmin
+    if ! chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/lib/pgadmin; then
+        echo "[ERROR] chown of /var/lib/pgadmin failed — container likely lacks CAP_CHOWN"
+        exit 1
+    fi
+    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/log/pgadmin \
+        || echo "[WARN] chown of /var/log/pgadmin failed (host bind mount); log writes may fail"
+    chown "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /pgadmin4/servers.json \
+        || echo "[WARN] chown of /pgadmin4/servers.json failed (single-file bind mount); server list may not load"
+    chmod +x /entrypoint.sh \
+        || echo "[WARN] chmod +x /entrypoint.sh failed; assuming image default permissions"
+
+    # Stop postfix if running (pkill no-match is the normal case, not a failure)
     if [ -f /usr/libexec/postfix/master ]; then
         pkill -f "postfix/master" 2>/dev/null || true
     fi
-    
+
     # Create servers.json with Vault password
     cat > /pgadmin4/servers.json << EOF
 {
@@ -154,7 +185,7 @@ if [ "$(id -u)" = "0" ]; then
 }
 EOF
     chmod 644 /pgadmin4/servers.json
-    
+
     echo "Switching to pgadmin user (UID: ${PGADMIN_USER_ID:-5050})..."
     export PGADMIN_DEFAULT_EMAIL PGADMIN_DEFAULT_PASSWORD PGADMIN_LISTEN_PORT PGADMIN_LISTEN_ADDRESS PGADMIN_SERVER_JSON_FILE PGADMIN_REPLACE_SERVERS_ON_STARTUP
     exec su -m -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'


### PR DESCRIPTION
# Pull Request

## Summary

Converts silenced capability failures (`2>/dev/null || true`) in four hardened entrypoints into either fail-fast errors naming the missing capability (for required operations) or visible `[WARN]` messages (for optional operations). This addresses all five deliverables of #1909's audit scope. The full purge/clean-init verification (#1909's Phase F) is intentionally left for after this PR merges -- it affects the live stable stack and is gated on a separate explicit go-ahead.

### Description of Changes

- `scripts/runtime/pgadmin-entrypoint.sh` -- both the restart-path and first-start-path root blocks: verify pgadmin user creation succeeded before the `su` that depends on it (fatal if absent); `/var/lib/pgadmin` chown is now fail-fast naming CAP_CHOWN (pgAdmin cannot start without write access here); `/var/log/pgadmin`, `servers.json`, and `chmod +x /entrypoint.sh` converted to visible WARNs; `pkill` on postfix left silent with a comment explaining no-match is the normal case
- `scripts/runtime/openwebui-entrypoint.sh` -- webui user creation, launcher chmod/chown, and `/tmp` chown converted to WARNs (all non-fatal; the load-bearing data-directory path was already fail-fast from #1892 and #1902)
- `scripts/runtime/ollama-entrypoint.sh` -- `set -e` to `set -euo pipefail`; data-directory chown is now fail-fast naming CAP_CHOWN; GPU group membership (`usermod -aG video,render`) converted to a WARN (normal on CPU-only hosts)
- `scripts/runtime/grafana-entrypoint.sh` -- tmp password-file chown converted to a WARN (the following `chmod 600` is unsilenced and still applies)
- `scripts/runtime/CONTEXT.md`, `docs/developer/adding-services.md` -- new "capped entrypoint rules" documentation: create-before-chown ordering, fail-fast vs WARN split, and the 3-scenario test matrix, for contributors adding future hardened entrypoints

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

Verified with an offline 3-scenario harness (bind-mounted entrypoint, stubbed Vault secrets, throwaway per-scenario podman volumes, `--network none`) covering a truly-empty volume, a partially-initialised volume, and a capability-withheld run that must fail loudly:

- ollama: 3/3 PASS, including a loud named-capability failure with CAP_CHOWN withheld
- pgadmin: 3/3 PASS, confirmed full gunicorn boot on a truly-empty volume
- openwebui: 3/3 PASS
- grafana: 3/3 PASS -- empty-volume (first-start reaches ready, admin verified), partial-volume (a volume seeded by a completed first-start correctly takes the restart path: `exec /run.sh` directly, no password re-prompt), and capability-withheld (root user, `--cap-drop ALL`: the WARN fires on the tmp password-file chown and Grafana still starts successfully, confirming the optional-operation WARN behaves as intended rather than crashing)

Also ran `shellcheck --severity=warning --exclude=SC1091` and `bash -n` against all four modified entrypoints (clean), and `./aixcl checks all` (11/11 passing).

### Verification

To verify this change is complete:

- [x] Behavior works as expected (human confirmation: operator instructed merge after reviewing harness results)
- [x] No regressions observed (human confirmation: operator instructed merge after reviewing harness results)
- [x] Tests cover change (all four entrypoints now 3/3 on the harness matrix, see Testing Notes)

### Related Issues

- Part of #1909
- Follow-up: #1920
- Follow-up: #1921
- Follow-up: #1922

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-22
- Method: Entrypoint code changes plus an offline podman-based 3-scenario test harness (not committed to the repo)
- Scope: scripts/runtime/{pgadmin,openwebui,ollama,grafana}-entrypoint.sh, scripts/runtime/CONTEXT.md, docs/developer/adding-services.md
- Confirmation: yes
---
