### PR TITLE
Forward stop signals to grafana on first-start (#1920)

### DIFF
--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -55,6 +55,12 @@ export GF_SECURITY_ADMIN_PASSWORD__FILE="$GRAFANA_PASS_FILE"
 /run.sh &
 GRAFANA_PID=$!
 
+# Forward stop signals to Grafana. PID 1 does not get the default signal
+# disposition, so without this trap `wait` below ignores SIGTERM entirely
+# and the container only stops after the orchestrator's SIGKILL grace
+# period elapses on every first-start container (#1920).
+trap 'kill -TERM "$GRAFANA_PID" 2>/dev/null' TERM INT
+
 # Wait for Grafana to be ready
 echo "[Vault] Waiting for Grafana to be ready..."
 for _ in {1..60}; do
@@ -77,6 +83,7 @@ fi
 unset GF_SECURITY_ADMIN_PASSWORD__FILE
 rm -f "$GRAFANA_PASS_FILE"
 
-# Keep Grafana running as PID 1 for clean signal handling
+# Wait for Grafana to exit; the trap above forwards a stop signal so this
+# returns promptly instead of stalling until SIGKILL.
 echo "[Vault] Grafana is running (PID: $GRAFANA_PID)"
 wait $GRAFANA_PID


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1920

### Description of Changes

`scripts/runtime/grafana-entrypoint.sh`'s first-start path backgrounds `/run.sh` and `wait`s on it while its own bash process stays PID 1. PID 1 does not get the default signal disposition unless it installs a trap, so `wait` ignored SIGTERM entirely -- every first-start container stalled out the full SIGKILL grace period on stop, contradicting the script's own (now-corrected) comment claiming clean signal handling. The restart path (`exec /run.sh`, which replaces PID 1 with Grafana directly) was already unaffected.

- Added `trap 'kill -TERM "$GRAFANA_PID" 2>/dev/null' TERM INT` right after backgrounding `/run.sh`, forwarding stop signals to the actual Grafana process for the container's whole lifetime
- Corrected the misleading `# Keep Grafana running as PID 1 for clean signal handling` comment to describe what the trap actually does

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `shellcheck --severity=warning --exclude=SC1091` and `bash -n` -- clean
- `./aixcl checks all` -- 11/11 passing
- Timed verification against a live first-start container (offline harness: bind-mounted entrypoint, stubbed Vault secret, `--network none`): started the container, waited for "Grafana is ready (first start)" in the logs, then timed `podman stop -t 10`, run against **both** versions for a direct before/after:
  - Pre-fix (dev's current entrypoint): `podman stop` took **9.0s**, hitting the 10s grace period as expected
  - Post-fix (this branch): `podman stop` took **0.25s**, confirming the trap forwards the signal correctly
- Restart-path unaffected: confirmed by diff -- both changed hunks are inside the first-start block only; every restart-path line is byte-for-byte unchanged

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (timed stop test directly exercises the fixed behavior, see Testing Notes)

### Related Issues

- Closes #1920

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-22
- Method: Entrypoint code change plus a timed podman-stop verification against a live first-start container
- Scope: scripts/runtime/grafana-entrypoint.sh
- Confirmation: yes
---

