### PR TITLE
Bake capability hardening into the app scaffold template (#1925)

### DIFF
--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -256,6 +256,39 @@ docker run --rm --entrypoint id redis:7
 on startup (e.g. the Vault image, which starts as a non-root user by
 default) can use `cap_drop: ALL` without the `user:` override.
 
+### Building a new app's entrypoint hardened from day one
+
+The section above is about *retrofitting* `cap_drop: ALL` onto an
+existing third-party image whose entrypoint wasn't designed around it --
+that risk (crash-loops discovered the hard way, restart counts climbing
+into the thousands) comes from not knowing what the image's entrypoint
+needs in advance. If you are writing your *own* entrypoint for a new
+app, design it around the hardened capability set from the start
+instead: there is no existing behavior to accidentally break.
+
+`etc/app-scaffold/docker-compose.yml`'s `example-service` demonstrates
+the default pattern: `cap_drop: ALL` plus either a `user:` override (for
+images with no root-phase setup) or a minimal `cap_add` (for a custom
+entrypoint that does its own chown/user-creation before dropping
+privileges) -- see the comments in that file for both paths.
+
+If your entrypoint needs the second path, follow the capped-entrypoint
+rules in `docs/developer/adding-services.md` (learned auditing the
+platform's own hardened entrypoints in #1909):
+
+1. Create directories while still root, then `chown` -- root without
+   `CAP_DAC_OVERRIDE` cannot `mkdir` inside a directory it no longer
+   owns, so create everything the root phase needs before chowning it
+   away.
+2. Fail fast, naming the capability, on REQUIRED operations (e.g. a
+   data-volume chown your service cannot start without).
+3. WARN visibly, never silently swallow (`2>/dev/null || true`), on
+   OPTIONAL operations.
+4. Test against the three-scenario matrix before shipping: a truly-empty
+   volume, a partially-initialised volume, and a capability-withheld run
+   (which should fail loudly for required operations, or WARN-and-continue
+   for optional ones).
+
 ## External App Repos
 
 Apps do not need to live inside the platform tree. If your app source is in its

--- a/etc/app-scaffold/CONTEXT.md
+++ b/etc/app-scaffold/CONTEXT.md
@@ -9,7 +9,7 @@ of an existing app.
 | File | Purpose |
 |------|---------|
 | `app.yaml` | Canonical app manifest template. Shows every supported field with comments. This is the schema that `lib/core/app_parser.sh` parses. |
-| `docker-compose.yml` | Compose scaffold for app services. Shows the minimum required structure and recommended patterns. |
+| `docker-compose.yml` | Compose scaffold for app services. Shows the minimum required structure and recommended patterns, including capability hardening (`cap_drop: ALL` + a `user:` override or minimal `cap_add`) baked in as the default -- see #1925. |
 
 ## How app.yaml Maps to Shell Variables
 
@@ -31,7 +31,8 @@ See `docs/architecture/decisions/004-topological-sort-depends-on.md`.
 2. Copy `etc/app-scaffold/docker-compose.yml` to `apps/<your-app-name>/docker-compose.yml`
 3. Fill in the required fields
 4. Read `docs/developer/adding-apps.md` for the full guide (includes `depends_on`
-   semantics and `cap_drop: ALL` compatibility guidance)
+   semantics and `cap_drop: ALL` guidance -- both retrofitting an existing
+   image and hardening a new entrypoint from day one)
 
 ## Agent Guidance
 

--- a/etc/app-scaffold/docker-compose.yml
+++ b/etc/app-scaffold/docker-compose.yml
@@ -21,3 +21,27 @@ services:
       - "9000:9000"
     environment:
       - "EXAMPLE_VAR=default"
+
+    # --- Capability hardening (default for new apps -- see
+    #     docs/developer/adding-apps.md, "Building a new app's entrypoint
+    #     hardened from day one") ---
+    #
+    # Path A -- most third-party images (no root-phase setup needed):
+    # find the image's default UID with `docker run --rm --entrypoint id
+    # <image>` and pin it below, then drop every capability.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    user: "1000:1000"   # replace with your image's actual default UID:GID
+    #
+    # Path B -- your own entrypoint that does root-phase setup (chown,
+    # user creation, privilege drop): delete the `user:` line above, keep
+    # cap_drop: ALL, and add only the specific capabilities your
+    # entrypoint needs, e.g.:
+    #   cap_add:
+    #     - CHOWN
+    #     - SETUID
+    #     - SETGID
+    # Follow the create-before-chown and fail-fast/WARN rules in
+    # docs/developer/adding-services.md before writing that entrypoint.


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1925

### Description of Changes

Bakes `cap_drop: ALL` into `etc/app-scaffold/docker-compose.yml`'s `example-service` as the default, demonstrating both safe patterns so new BYO apps start hardened instead of being retrofitted later:

- **Path A** (most third-party images, no root-phase setup): `cap_drop: ALL` + `user: "<uid>:<gid>"` override
- **Path B** (a custom entrypoint that does its own chown/user-creation): `cap_drop: ALL` + a minimal `cap_add`, built around the create-before-chown / fail-fast-vs-WARN pattern from #1909

This is deliberately scoped as greenfield template guidance, not a retrofit -- #1891/#1901/#1909 and `adding-apps.md`'s existing "Hardened images and cap_drop: ALL" section are all about fixing an *existing* image whose entrypoint behavior wasn't designed around hardening. A brand-new app can be designed around it from the start, so this doesn't carry that risk.

- `etc/app-scaffold/docker-compose.yml` -- hardening block added to `example-service`, both paths documented inline with comments
- `docs/developer/adding-apps.md` -- new "Building a new app's entrypoint hardened from day one" subsection immediately after the existing retrofit-focused section, cross-referencing `docs/developer/adding-services.md`'s capped-entrypoint rules and 3-scenario test matrix
- `etc/app-scaffold/CONTEXT.md` -- file-purpose table and creation-steps updated to mention the hardening default

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `docker compose -f etc/app-scaffold/docker-compose.yml config` -- valid (the scaffold's placeholder `example-app:latest` image can't be pulled, so this validates config parsing, not a live boot)
- `yamllint -c .yamllint.yml etc/app-scaffold/docker-compose.yml` -- clean
- `./aixcl checks all` -- 11/11 passing
- Verified the actual Path A pattern against a **real** image on a **fresh volume**, since the scaffold's placeholder image isn't pullable: `podman run --user 999:999 --cap-drop ALL --security-opt no-new-privileges:true -v <fresh-volume>:/data redis:7` started cleanly and responded `PONG` immediately, with no root-phase chown ever needed -- confirming the recipe works exactly as documented
- No existing app's `docker-compose.yml` touched (diff is scoped to `etc/app-scaffold/` and two doc files, per the issue's own verification requirement)

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (real-image fresh-volume verification directly exercises the documented Path A recipe, see Testing Notes)

### Related Issues

- Closes #1925

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-22
- Method: Scaffold and doc changes plus a live podman verification of the Path A pattern against a real image on a fresh volume
- Scope: etc/app-scaffold/docker-compose.yml, etc/app-scaffold/CONTEXT.md, docs/developer/adding-apps.md
- Confirmation: yes
---
