### PR TITLE
Reorient OpenCode agent docs from junior to peer delegation (#1930)

### DIFF
--- a/.opencode/CONTEXT.md
+++ b/.opencode/CONTEXT.md
@@ -20,7 +20,7 @@ notes) inside those two directories, or they register as a bogus
 
 | File | Mode | Purpose |
 |------|------|---------|
-| `agents/agent-context.md` | primary | Worker for the `agent` issue queue -- operational guidance, tool discipline, memory conventions |
+| `agents/agent-context.md` | primary | Executes tasks delegated via the `agent` label -- a peer to Claude Code, not a supervised junior; operational guidance, tool discipline, memory conventions |
 | `agents/reviewer.md` | subagent | Read-only reviewer: `edit` denied, inspection-only bash allowlist |
 
 ## Commands

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -17,21 +17,27 @@ is specific to this agent.
 
 ## Finding Your Work
 
-Issues queued for this agent carry the `agent` label. At session
-start, or whenever the human asks what to work on next, list the queue:
+You are a peer to Claude Code, not a junior worker whose output gets
+graded -- the only real difference is that you run a cloud/local model
+rather than Claude's. Tasks reach you by delegation, not by
+self-service backlog-pulling: a human, or Claude working with the
+human, marks a task for you with the `agent` label. At session start,
+or whenever the human asks what to work on next, list what has been
+delegated to you:
 
 ```bash
 gh issue list --repo xencon/aixcl --label agent --state open
 ```
 
-Rules for working the queue:
+Rules for working delegated tasks:
 
 - Work one issue at a time, following the Issue-First workflow (the issue
   already exists -- start at the branch step)
 - The issue body is the task specification; if it is ambiguous, post a
   clarifying question as an issue comment and wait rather than guessing
 - Do not pick up issues without the `agent` label unless the human
-  directs you to in the live session
+  directs you to in the live session -- that label is how a task is
+  delegated to you specifically
 
 Prefer the guided commands for procedural work -- they embed the correct
 sequence and its guardrails:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 | field | value |
 |-------|-------|
 | file | AGENTS.md |
-| version | 2.2 |
+| version | 2.3 |
 | purpose | agent_contract |
 | priority | critical |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, MCP-compatible systems |
-| last_updated | 2026-07-18 |
+| last_updated | 2026-07-22 |
 
 # AGENTS.md
 
@@ -126,8 +126,9 @@ AIXCL is client-agnostic above the OpenAI-compatible API layer. OpenCode and Cla
 - Priority: `P1`, `P2`, `P3`
 - Profile: `profile:bld`, `profile:sys`
 - Category: `Fix`, `Enhancement`, `Refactor`, `Maintenance`
-- Agent queue: `agent` (issues queued for agent execution; an agent
-  discovers its work by listing open issues with this label)
+- Agent delegation: `agent` (issues delegated to a peer agent -- e.g.
+  the OpenCode agent -- for execution; the agent discovers delegated
+  work by listing open issues with this label)
 
 ### Lean Repository Policy
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 | field         | value                                                                      |
 |---------------|----------------------------------------------------------------------------|
 | file          | DEVELOPMENT.md                                                             |
-| version       | 2.1 (tracks workflow evolution; subordinate to AGENTS.md v2.2)             |
+| version       | 2.1 (tracks workflow evolution; subordinate to AGENTS.md v2.3)             |
 | scope         | all agents                                                                 |
 | priority      | high                                                                       |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, any MCP-compatible agent           |


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1930

### Description of Changes

Reframes how the OpenCode agent's relationship to Claude Code is described, per operator directive (2026-07-19, deferred until the #1909 audit and scaffold-hardening work completed): no longer a junior worker whose PRs get graded, but a peer running a cloud/local model to whom tasks are delegated via the `agent` label rather than self-service backlog-pulling.

This is purely a framing change. `next-task.md`, the `reviewer` subagent, and every hard gate / deny stay exactly as they are -- those exist because prose guidance does not reliably transfer to smaller models, a capability constraint independent of hierarchy framing. Peer status does not loosen the mechanized rails.

- `.opencode/agents/agent-context.md` -- "Finding Your Work" reworded to delegation language
- `.opencode/CONTEXT.md` -- agent table description updated to match
- `AGENTS.md` -- Label Taxonomy entry renamed "Agent queue" -> "Agent delegation"; version bumped 2.2 -> 2.3, `last_updated` 2026-07-22
- `DEVELOPMENT.md` -- cross-reference to AGENTS.md's version updated to v2.3

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `./aixcl checks agents` and `./aixcl checks all` -- both clean (mirror parity unaffected, no `name:` frontmatter regression)
- Confirmed by diff that no mechanical file changed: `next-task.md`, `reviewer.md`, and `config/opencode.json.example` are untouched -- only the four framing-language files listed above
- Not independently re-tested against a live OpenCode session in this pass (no code behavior changed, only documentation text)

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (mirror-parity and full check sweep directly cover the touched files; diff review confirms no mechanical file was touched)

### Related Issues

- Closes #1930

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-22
- Method: Documentation-only edits across four files, verified via `./aixcl checks agents`/`checks all` and a diff-scope review
- Scope: .opencode/agents/agent-context.md, .opencode/CONTEXT.md, AGENTS.md, DEVELOPMENT.md
- Confirmation: yes
---
