### PR TITLE
Use podman unshare to keep pgadmin-servers.json at mode 600 (#1922)

### DIFF
--- a/lib/core/pgadmin_utils.sh
+++ b/lib/core/pgadmin_utils.sh
@@ -7,20 +7,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Generate pgAdmin configuration
 generate_pgadmin_config() {
     echo "Generating pgAdmin server configuration..."
-    
+
     # Note: With Vault integration, credentials are dynamic
     # pgAdmin will need to use static bootstrap credentials or Vault-generated credentials
     local pg_user="${POSTGRES_USER:-admin}"
     local pg_pass="${POSTGRES_PASSWORD:-}"
-    
+    local pgadmin_uid="${PGADMIN_USER_ID:-5050}"
+    local pgadmin_gid="${PGADMIN_GROUP_ID:-5050}"
+
     # Remove old file if it exists (may have wrong permissions from container)
     # NOTE: If Podman previously created this as a directory mount point,
     # rmdir the empty directory first, then rm the file.
     if [ -d "${SCRIPT_DIR}/pgadmin-servers.json" ]; then
         rmdir "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
     fi
-    rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
-    
+    # A prior run of this function may have chowned the file into the
+    # pgadmin container's rootless-mapped UID (see below) -- the invoking
+    # host user cannot rm a file it no longer owns, so remove it from
+    # within the same user namespace that owns it (#1922).
+    podman unshare rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null \
+        || rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
+
     # Create pgadmin-servers.json with populated environment values
     cat > "${SCRIPT_DIR}/pgadmin-servers.json" << EOF
 {
@@ -39,10 +46,28 @@ generate_pgadmin_config() {
   }
 }
 EOF
-    
-    # Set file permissions (read/write for owner, read for others - needed for container)
-    chmod 644 "${SCRIPT_DIR}/pgadmin-servers.json"
-    
-    echo "✅ Generated pgadmin-servers.json with populated values and secure permissions"
+
+    # Restrict to owner-only before handing ownership to the container's
+    # identity, minimizing the window where the file is host-user-owned
+    # and could be group/other readable.
+    chmod 600 "${SCRIPT_DIR}/pgadmin-servers.json"
+
+    # This file is bind-mounted into the pgadmin container, which runs as
+    # a non-root UID (5050 by default) under rootless podman's user
+    # namespace -- that UID maps to a HOST uid outside the invoking
+    # user's own identity (verified: container uid 5050 -> host uid
+    # 105049 in one deployment), so a plain 644 was previously used to
+    # let the container read a file it doesn't match by owner. That made
+    # a file containing a live Postgres password world-readable on the
+    # host. `podman unshare chown` performs the chown from within the
+    # rootless user namespace, translating the container-relative
+    # UID:GID into the correct host-mapped identity, so the file can stay
+    # 600 and still be readable by the one process that needs it (#1922).
+    if podman unshare chown "${pgadmin_uid}:${pgadmin_gid}" "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null; then
+        echo "✅ Generated pgadmin-servers.json, restricted to the pgadmin container's UID (600)"
+    else
+        chmod 644 "${SCRIPT_DIR}/pgadmin-servers.json"
+        echo "⚠️  Could not map servers.json to the pgadmin container's UID (podman unshare failed) -- left world-readable (644) as a fallback so the container can still read it"
+    fi
     echo "   Note: With Vault enabled, use dynamic credentials from './aixcl vault credentials'"
 }


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1922

### Description of Changes

`lib/core/pgadmin_utils.sh`'s `generate_pgadmin_config()` writes the Postgres connection password into `pgadmin-servers.json` (bind-mounted at `/pgadmin4/servers.json` in the pgadmin container) and previously `chmod 644`'d it -- making a file with a live plaintext password world-readable on the host. This was investigated in #1922 and initially assumed unfixable without either dropping the password or accepting the risk: pgadmin's container runs as non-root UID 5050 under rootless podman, which maps to a host UID (105049, confirmed live) that the host-side generator script doesn't own, so a plain `chown`/`chmod 600` isn't available to an unprivileged process.

The actual fix: `podman unshare chown 5050:5050 <file>` runs the chown from within the rootless user's own namespace, which can target any UID in that namespace's subuid range -- it translates the container-relative UID:GID into the correct host-mapped identity automatically, computed fresh on whatever host runs it (no hardcoded UID, no per-host fragility). `podman unshare rm -f` is also needed for the cleanup-before-regenerate step, since a plain `rm -f` as the host user silently no-ops once a prior run has already chowned the file out of that user's ownership.

- `lib/core/pgadmin_utils.sh` -- `generate_pgadmin_config()`: chmod 600 immediately after writing content (minimizing the exposure window), then `podman unshare chown` to the pgadmin container's UID:GID (falls back to 644 with a visible warning if `podman unshare` fails, e.g. non-podman environments); cleanup step now tries `podman unshare rm -f` first

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `shellcheck --severity=warning --exclude=SC1091` and `bash -n` -- clean
- `./aixcl checks all` -- 11/11 passing
- **Verified against the live running pgadmin container** (the stack was up from an earlier clean-init), not just a scratch test:
  1. Sourced `.env` and `lib/core/pgadmin_utils.sh`, called `generate_pgadmin_config()` directly with the real repo environment
  2. Resulting file: `600`, owned by host UID `105049:105049` -- confirmed this exactly matches the pgadmin container's actual rootless-mapped identity (cross-checked against `.pgadmin-passwd`, a file the container creates itself, which the live volume already showed owned by the same `105049:1000`)
  3. Confirmed the invoking host user (`1000`) gets `Permission denied` trying to `cat` the file directly -- the intended security property
  4. Confirmed the **actual runtime process** can still read it: `podman exec --user 5050:5050 pgadmin cat /pgadmin4/servers.json` succeeded and returned the correct content. (Note: `podman exec` *without* `--user` defaults to container-root, which has unrestricted read access within its own namespace regardless of a file's real owner -- that would be a false-positive test; pinning `--user 5050:5050` to the actual service UID is what makes this a valid check)
  5. Restarted the live pgadmin container and confirmed it stayed healthy: `curl -o /dev/null -w '%{http_code}' http://127.0.0.1:5050/` -> `302` (normal login redirect)

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (live end-to-end verification against the real running container directly exercises the fixed code path, see Testing Notes)

### Related Issues

- Closes #1922

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Code fix plus live end-to-end verification against the real running pgadmin container (not a synthetic harness)
- Scope: lib/core/pgadmin_utils.sh
- Confirmation: yes
---
