### PR TITLE
Apply minimal cap_drop/cap_add to pgadmin (#1921)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -438,6 +438,34 @@ services:
     container_name: pgadmin
     pull_policy: missing
     network_mode: host
+    # cap_drop: ALL + minimal cap_add (#1921, superseding #1667's "no
+    # restrictions" exception -- verified against the current pinned
+    # image, not the older one #1667 was written against):
+    #   SETUID/SETGID  -- the image's own /entrypoint.sh invokes sudo
+    #                     internally even though this container already
+    #                     runs as the non-root pgadmin user (5050); sudo's
+    #                     setresuid/setresgid calls need these to work at
+    #                     all, regardless of any actual privilege change.
+    #   NET_BIND_SERVICE -- /usr/local/bin/python3.14 in this image has a
+    #                     cap_net_bind_service file capability set. Any
+    #                     binary with file capabilities set fails to exec
+    #                     entirely under cap_drop: ALL (EPERM), regardless
+    #                     of the port actually used (5050, unprivileged).
+    # Deliberately NOT setting security_opt: no-new-privileges here: it
+    # blocks sudo's setuid mechanism outright, which stops the bundled
+    # postfix mail relay from starting. Verified live: with these three
+    # caps and no no-new-privileges, pgAdmin boots normally AND postfix's
+    # master process starts successfully -- an improvement over the
+    # current unrestricted-capability deployment, where postfix already
+    # fails to start today regardless (its effective capability set is
+    # only cap_net_bind_service, since the entrypoint never runs a root
+    # phase under this image's non-root default user).
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
     environment:
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1921

### Description of Changes

pgadmin was the only hardened-entrypoint service in `services/docker-compose.yml` with no `cap_drop`/`cap_add` at all, per `#1667`'s historical "restrictions break postfix/python" exception. Re-verified against the currently pinned image (`docker.io/dpage/pgadmin4:9.15.0`) via a real podman harness rather than reusing that older, now-stale justification:

- **SETUID/SETGID** -- dpage/pgadmin4's own `/entrypoint.sh` invokes `sudo` internally even though the container already runs as the non-root `pgadmin` user (5050). `sudo`'s `setresuid`/`setresgid` calls need these capabilities just to execute, independent of any actual privilege change taking place.
- **NET_BIND_SERVICE** -- `/usr/local/bin/python3.14` in this image has a `cap_net_bind_service` FILE capability set (confirmed via `getcap`). Any binary with file capabilities set fails to exec entirely under `cap_drop: ALL` (`EPERM` at the kernel `exec()` level), regardless of what port is actually used (pgadmin listens on 5050, unprivileged).

`security_opt: no-new-privileges` is deliberately **not** set alongside these -- it blocks sudo's setuid mechanism outright regardless of capabilities, which stops the bundled postfix mail relay from starting.

- `services/docker-compose.yml` -- pgadmin service block gets `cap_drop: [ALL]` + `cap_add: [SETUID, SETGID, NET_BIND_SERVICE]`, with an inline comment explaining each capability's purpose and why `no-new-privileges` is deliberately absent

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `docker compose -f services/docker-compose.yml config`, `yamllint`, `./aixcl checks all` -- all clean (11/11)
- Verified against a real offline podman harness (the actual pinned image, the actual `scripts/runtime/pgadmin-entrypoint.sh`, throwaway volumes per scenario, stubbed Vault secrets) across all three #1909 scenarios:
  - **Empty volume** (first-start): gunicorn boots, and `Added 0 Server Group(s) and 1 Server(s)` confirms real servers.json content imports correctly
  - **Partial volume** (restart, seeded from a completed first-start): correctly takes the restart path (`pgAdmin config DB found... restart mode`), boots cleanly
  - **Capability-withheld** (`cap_drop: ALL` alone, no `cap_add`): fails loudly -- `sudo: setresuid(...): Operation not permitted` and `python3: Operation not permitted` -- confirming the three added capabilities are genuinely required, not superfluous
- **Surprise finding, also verified**: postfix is already broken in the *current, unrestricted* production deployment. `podman exec pgadmin ps aux` against the live running container shows no postfix process at all, and its boot log shows `fatal: mail system startup failed` on every start -- because the entrypoint never runs a root phase under this image's non-root default user, so `podman exec pgadmin cat /proc/1/status` shows the live container's actual `CapEff` is already just `cap_net_bind_service`, regardless of "no cap_drop" in compose. Under the new capability set, postfix's `master` process actually starts successfully (confirmed via `ps aux` inside the harness container) -- this change is a strict improvement over today, not a tradeoff.
- Not yet applied to the live running stack -- per the established pattern, a compose change needs a full `./aixcl stack restart --profile sys` to take effect (not just a container restart), which has not been done as part of this PR

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (offline harness covers all three #1909 scenarios plus a live comparison against the current production container's actual effective capabilities)

### Related Issues

- Closes #1921

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Compose change plus extensive offline podman harness verification (real pinned image, real entrypoint script) and live inspection of the running production container's actual effective capabilities for comparison
- Scope: services/docker-compose.yml; read-only inspection of the live pgadmin container
- Confirmation: yes
---
