### PR TITLE
Release v1.1.65 (#1935)

### DIFF
--- a/.claude/rules/ci-checks.md
+++ b/.claude/rules/ci-checks.md
@@ -69,7 +69,7 @@ All 12 workflows:
 
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
-| pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
+| pr-validation.yml | PR open/edit | Title format (Dependabot exempt), assignee, component label, body reference style |
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review, gitleaks, shell obfuscation patterns |

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -3,8 +3,17 @@ permissions:
   issues: write
   pull-requests: read
 
+# pull_request_target (not pull_request): this repo's PRs always come from
+# a fork (origin -> upstream, see AGENTS.md). GitHub Actions forces a
+# read-only GITHUB_TOKEN on pull_request-triggered workflows whenever the
+# head is a fork, regardless of the permissions block above or the repo's
+# default -- silently breaking gh issue close (#1928). pull_request_target
+# runs with the base repo's token instead, which is safe here specifically
+# because this workflow has no actions/checkout step and never executes
+# code from the PR head; it only reads the (already env-var-scoped, not
+# directly interpolated) PR body text and calls the GitHub API.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - dev
     types: [closed]

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,8 +26,18 @@ jobs:
       - name: Check PR title format
         env:
           PR_TITLE: "${{ github.event.pull_request.title }}"
+          PR_AUTHOR: "${{ github.event.pull_request.user.login }}"
         run: |
-          echo "Checking PR title: $PR_TITLE"
+          echo "Checking PR title: $PR_TITLE (author: $PR_AUTHOR)"
+
+          # Dependabot generates its own title (a commit-message prefix colon,
+          # no issue reference since dependency bumps aren't tied to an issue)
+          # and has no way to follow this repo's convention -- exempt it
+          # rather than force a manual title rewrite on every bump PR (#1923).
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "✅ Skipping title format check for Dependabot PR"
+            exit 0
+          fi
 
           # Check for issue reference (#number)
           if ! echo "$PR_TITLE" | grep -qE '\(#[0-9]+\)$'; then

--- a/.opencode/CONTEXT.md
+++ b/.opencode/CONTEXT.md
@@ -20,7 +20,7 @@ notes) inside those two directories, or they register as a bogus
 
 | File | Mode | Purpose |
 |------|------|---------|
-| `agents/agent-context.md` | primary | Worker for the `agent` issue queue -- operational guidance, tool discipline, memory conventions |
+| `agents/agent-context.md` | primary | Executes tasks delegated via the `agent` label -- a peer to Claude Code, not a supervised junior; operational guidance, tool discipline, memory conventions |
 | `agents/reviewer.md` | subagent | Read-only reviewer: `edit` denied, inspection-only bash allowlist |
 
 ## Commands

--- a/.opencode/agents/agent-context.md
+++ b/.opencode/agents/agent-context.md
@@ -17,21 +17,27 @@ is specific to this agent.
 
 ## Finding Your Work
 
-Issues queued for this agent carry the `agent` label. At session
-start, or whenever the human asks what to work on next, list the queue:
+You are a peer to Claude Code, not a junior worker whose output gets
+graded -- the only real difference is that you run a cloud/local model
+rather than Claude's. Tasks reach you by delegation, not by
+self-service backlog-pulling: a human, or Claude working with the
+human, marks a task for you with the `agent` label. At session start,
+or whenever the human asks what to work on next, list what has been
+delegated to you:
 
 ```bash
 gh issue list --repo xencon/aixcl --label agent --state open
 ```
 
-Rules for working the queue:
+Rules for working delegated tasks:
 
 - Work one issue at a time, following the Issue-First workflow (the issue
   already exists -- start at the branch step)
 - The issue body is the task specification; if it is ambiguous, post a
   clarifying question as an issue comment and wait rather than guessing
 - Do not pick up issues without the `agent` label unless the human
-  directs you to in the live session
+  directs you to in the live session -- that label is how a task is
+  delegated to you specifically
 
 Prefer the guided commands for procedural work -- they embed the correct
 sequence and its guardrails:

--- a/.opencode/rules/ci-checks.md
+++ b/.opencode/rules/ci-checks.md
@@ -69,7 +69,7 @@ All 12 workflows:
 
 | Workflow | Trigger | Key Checks |
 |----------|---------|------------|
-| pr-validation.yml | PR open/edit | Title format, assignee, component label, body reference style |
+| pr-validation.yml | PR open/edit | Title format (Dependabot exempt), assignee, component label, body reference style |
 | bash-ci.yml | PR + push | check-env, CRLF, ASCII markdown, check-ai-elisions |
 | quick-tests.yml | Push to dev (.sh files) | Security tests, bash -n, ./aixcl help |
 | security.yml | PR + push | ShellCheck (warning+, no SC1091), dependency review, gitleaks, shell obfuscation patterns |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 | field | value |
 |-------|-------|
 | file | AGENTS.md |
-| version | 2.2 |
+| version | 2.3 |
 | purpose | agent_contract |
 | priority | critical |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, MCP-compatible systems |
-| last_updated | 2026-07-18 |
+| last_updated | 2026-07-22 |
 
 # AGENTS.md
 
@@ -126,8 +126,9 @@ AIXCL is client-agnostic above the OpenAI-compatible API layer. OpenCode and Cla
 - Priority: `P1`, `P2`, `P3`
 - Profile: `profile:bld`, `profile:sys`
 - Category: `Fix`, `Enhancement`, `Refactor`, `Maintenance`
-- Agent queue: `agent` (issues queued for agent execution; an agent
-  discovers its work by listing open issues with this label)
+- Agent delegation: `agent` (issues delegated to a peer agent -- e.g.
+  the OpenCode agent -- for execution; the agent discovers delegated
+  work by listing open issues with this label)
 
 ### Lean Repository Policy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the AIXCL project will be documented in this file.
 ## [Unreleased]
 
 
+## [v1.1.65] - 2026-07-22
+
+### Summary
+
+Release v1.1.65 -- Security and reliability release: a full capability audit of every hardened entrypoint (pgadmin, grafana, ollama, open-webui), a plaintext-password permission fix and a minimal-capability set for pgadmin that also repairs its previously-broken postfix integration, a CI fix for Dependabot PRs, and a fork-PR token bug that had silently disabled automated issue closing since introduction.
+
+### Fixed
+
+- [x] **Capability-hardened entrypoints failed silently instead of loudly**: pgadmin, grafana, ollama, and open-webui entrypoints silenced `2>/dev/null || true` on privileged filesystem operations, masking capability regressions until a clean init; required operations now fail fast naming the missing capability, optional operations emit a visible WARN instead of hiding the failure. Verified against a 3-scenario harness (empty volume, partial volume, capability-withheld) for all four services, then confirmed live against a real clean-init purge: 21/21 healthy, zero restarts, every WARN firing as designed (#1909).
+- [x] **Grafana ignored SIGTERM on first start**: the first-start entrypoint backgrounded its process and stayed PID 1 with no signal trap, so every stop of a freshly-initialised container stalled the full SIGKILL grace period; a trap now forwards TERM/INT (measured 9.0s pre-fix vs 0.25s post-fix) (#1920).
+- [x] **pgadmin ran with no capability restrictions at all**: re-verified against the currently pinned image (the #1667 exception predates it) via a real harness -- the minimal set is `cap_add: [SETUID, SETGID, NET_BIND_SERVICE]` (sudo's internal privilege calls and a python3 file capability both need them to execute at all, independent of any actual privilege change). Also fixes postfix, which was already broken under the previous unrestricted configuration (#1921).
+- [x] **pgadmin-servers.json exposed a plaintext Postgres password world-readable on the host**: the file was `chmod 644` to work around rootless podman's UID mapping, not an oversight; now uses `podman unshare chown` to give the file the pgadmin container's actual mapped identity, so it stays `600` and the container can still read it (#1922).
+- [x] **Dependabot PRs failed the title-format CI check by design**: dependency-bump PRs have no issue reference and use a `commit-message.prefix` that adds a colon, so they could never pass and had to be merged past a red check; the title-format job now exempts `dependabot[bot]` specifically, leaving every other author's check unchanged (#1923).
+- [x] **close-linked-issues.yml silently failed to close any issue since introduction**: GitHub Actions forces a read-only token on `pull_request`-triggered workflows when the PR head is a fork, which every PR in this repo's two-remote workflow is; switched to `pull_request_target`, which resolves against the base repository's token instead (#1928).
+
+### Documentation
+
+- [x] **Reoriented OpenCode agent docs from junior to peer delegation**: reframed the OpenCode agent's documented relationship to Claude Code from a supervised junior worker to a peer running a cloud/local model, with tasks reaching it by delegation rather than self-service queue-pulling; purely a framing change, every mechanized rail (hard gates, denies) is unchanged (#1930).
+- [x] **Baked capability hardening into the BYO app scaffold template**: `etc/app-scaffold/docker-compose.yml`'s example service now demonstrates `cap_drop: ALL` as the default, with both safe patterns (a `user:` override, or a minimal `cap_add`) documented inline, scoped explicitly as greenfield guidance distinct from the existing retrofit guidance for hardening an already-shipped image (#1925).
+
+
+
 ## [v1.1.64] - 2026-07-18
 
 ### Summary

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 | field         | value                                                                      |
 |---------------|----------------------------------------------------------------------------|
 | file          | DEVELOPMENT.md                                                             |
-| version       | 2.1 (tracks workflow evolution; subordinate to AGENTS.md v2.2)             |
+| version       | 2.1 (tracks workflow evolution; subordinate to AGENTS.md v2.3)             |
 | scope         | all agents                                                                 |
 | priority      | high                                                                       |
 | compatibility | OpenCode, Claude Code, Cursor, Copilot, any MCP-compatible agent           |

--- a/docs/developer/adding-apps.md
+++ b/docs/developer/adding-apps.md
@@ -256,6 +256,39 @@ docker run --rm --entrypoint id redis:7
 on startup (e.g. the Vault image, which starts as a non-root user by
 default) can use `cap_drop: ALL` without the `user:` override.
 
+### Building a new app's entrypoint hardened from day one
+
+The section above is about *retrofitting* `cap_drop: ALL` onto an
+existing third-party image whose entrypoint wasn't designed around it --
+that risk (crash-loops discovered the hard way, restart counts climbing
+into the thousands) comes from not knowing what the image's entrypoint
+needs in advance. If you are writing your *own* entrypoint for a new
+app, design it around the hardened capability set from the start
+instead: there is no existing behavior to accidentally break.
+
+`etc/app-scaffold/docker-compose.yml`'s `example-service` demonstrates
+the default pattern: `cap_drop: ALL` plus either a `user:` override (for
+images with no root-phase setup) or a minimal `cap_add` (for a custom
+entrypoint that does its own chown/user-creation before dropping
+privileges) -- see the comments in that file for both paths.
+
+If your entrypoint needs the second path, follow the capped-entrypoint
+rules in `docs/developer/adding-services.md` (learned auditing the
+platform's own hardened entrypoints in #1909):
+
+1. Create directories while still root, then `chown` -- root without
+   `CAP_DAC_OVERRIDE` cannot `mkdir` inside a directory it no longer
+   owns, so create everything the root phase needs before chowning it
+   away.
+2. Fail fast, naming the capability, on REQUIRED operations (e.g. a
+   data-volume chown your service cannot start without).
+3. WARN visibly, never silently swallow (`2>/dev/null || true`), on
+   OPTIONAL operations.
+4. Test against the three-scenario matrix before shipping: a truly-empty
+   volume, a partially-initialised volume, and a capability-withheld run
+   (which should fail loudly for required operations, or WARN-and-continue
+   for optional ones).
+
 ## External App Repos
 
 Apps do not need to live inside the platform tree. If your app source is in its

--- a/docs/developer/adding-services.md
+++ b/docs/developer/adding-services.md
@@ -39,6 +39,13 @@ Define the service configuration:
       - /tmp:noexec,nosuid,size=50m
 ```
 
+**Capped entrypoint rules** (learned from #1891/#1901; audited in #1909). If your entrypoint does privileged filesystem work under a restricted capability set:
+
+1. **Create before chown.** Root without CAP_DAC_OVERRIDE cannot `mkdir` inside a directory it has already chowned to another UID. Create missing directories while the parent is still root-owned, then chown recursively; defer any creation that must happen later to the non-root phase, which owns the parent by then.
+2. **Fail fast on REQUIRED operations, naming the capability.** A silenced failure (`2>/dev/null || true`) on an operation the service needs (data-volume chown, privilege-drop user creation) guarantees a later crash with no cause in the logs. Fail with a message naming the likely missing capability (e.g. `container likely lacks CAP_CHOWN`).
+3. **WARN visibly on OPTIONAL operations.** Operations the service can survive without (GPU group membership, cosmetic chowns) get a visible `[WARN]` with the consequence, never a silent `|| true`.
+4. **Test against the three-scenario matrix** before merging: a truly-empty volume (clean init), a partially-initialised volume (prior failed run), and a capability-regression run (required cap withheld) that must fail loudly. Long-lived stacks mask init bugs -- a fresh volume is the only honest fixture.
+
 ### 2. `lib/cli/profile.sh`
 
 Add the service to **all applicable profile mappings** in `get_profile_services_for_profile()`:

--- a/etc/app-scaffold/CONTEXT.md
+++ b/etc/app-scaffold/CONTEXT.md
@@ -9,7 +9,7 @@ of an existing app.
 | File | Purpose |
 |------|---------|
 | `app.yaml` | Canonical app manifest template. Shows every supported field with comments. This is the schema that `lib/core/app_parser.sh` parses. |
-| `docker-compose.yml` | Compose scaffold for app services. Shows the minimum required structure and recommended patterns. |
+| `docker-compose.yml` | Compose scaffold for app services. Shows the minimum required structure and recommended patterns, including capability hardening (`cap_drop: ALL` + a `user:` override or minimal `cap_add`) baked in as the default -- see #1925. |
 
 ## How app.yaml Maps to Shell Variables
 
@@ -31,7 +31,8 @@ See `docs/architecture/decisions/004-topological-sort-depends-on.md`.
 2. Copy `etc/app-scaffold/docker-compose.yml` to `apps/<your-app-name>/docker-compose.yml`
 3. Fill in the required fields
 4. Read `docs/developer/adding-apps.md` for the full guide (includes `depends_on`
-   semantics and `cap_drop: ALL` compatibility guidance)
+   semantics and `cap_drop: ALL` guidance -- both retrofitting an existing
+   image and hardening a new entrypoint from day one)
 
 ## Agent Guidance
 

--- a/etc/app-scaffold/docker-compose.yml
+++ b/etc/app-scaffold/docker-compose.yml
@@ -21,3 +21,27 @@ services:
       - "9000:9000"
     environment:
       - "EXAMPLE_VAR=default"
+
+    # --- Capability hardening (default for new apps -- see
+    #     docs/developer/adding-apps.md, "Building a new app's entrypoint
+    #     hardened from day one") ---
+    #
+    # Path A -- most third-party images (no root-phase setup needed):
+    # find the image's default UID with `docker run --rm --entrypoint id
+    # <image>` and pin it below, then drop every capability.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    user: "1000:1000"   # replace with your image's actual default UID:GID
+    #
+    # Path B -- your own entrypoint that does root-phase setup (chown,
+    # user creation, privilege drop): delete the `user:` line above, keep
+    # cap_drop: ALL, and add only the specific capabilities your
+    # entrypoint needs, e.g.:
+    #   cap_add:
+    #     - CHOWN
+    #     - SETUID
+    #     - SETGID
+    # Follow the create-before-chown and fail-fast/WARN rules in
+    # docs/developer/adding-services.md before writing that entrypoint.

--- a/lib/core/pgadmin_utils.sh
+++ b/lib/core/pgadmin_utils.sh
@@ -7,20 +7,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Generate pgAdmin configuration
 generate_pgadmin_config() {
     echo "Generating pgAdmin server configuration..."
-    
+
     # Note: With Vault integration, credentials are dynamic
     # pgAdmin will need to use static bootstrap credentials or Vault-generated credentials
     local pg_user="${POSTGRES_USER:-admin}"
     local pg_pass="${POSTGRES_PASSWORD:-}"
-    
+    local pgadmin_uid="${PGADMIN_USER_ID:-5050}"
+    local pgadmin_gid="${PGADMIN_GROUP_ID:-5050}"
+
     # Remove old file if it exists (may have wrong permissions from container)
     # NOTE: If Podman previously created this as a directory mount point,
     # rmdir the empty directory first, then rm the file.
     if [ -d "${SCRIPT_DIR}/pgadmin-servers.json" ]; then
         rmdir "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
     fi
-    rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
-    
+    # A prior run of this function may have chowned the file into the
+    # pgadmin container's rootless-mapped UID (see below) -- the invoking
+    # host user cannot rm a file it no longer owns, so remove it from
+    # within the same user namespace that owns it (#1922).
+    podman unshare rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null \
+        || rm -f "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null || true
+
     # Create pgadmin-servers.json with populated environment values
     cat > "${SCRIPT_DIR}/pgadmin-servers.json" << EOF
 {
@@ -39,10 +46,28 @@ generate_pgadmin_config() {
   }
 }
 EOF
-    
-    # Set file permissions (read/write for owner, read for others - needed for container)
-    chmod 644 "${SCRIPT_DIR}/pgadmin-servers.json"
-    
-    echo "✅ Generated pgadmin-servers.json with populated values and secure permissions"
+
+    # Restrict to owner-only before handing ownership to the container's
+    # identity, minimizing the window where the file is host-user-owned
+    # and could be group/other readable.
+    chmod 600 "${SCRIPT_DIR}/pgadmin-servers.json"
+
+    # This file is bind-mounted into the pgadmin container, which runs as
+    # a non-root UID (5050 by default) under rootless podman's user
+    # namespace -- that UID maps to a HOST uid outside the invoking
+    # user's own identity (verified: container uid 5050 -> host uid
+    # 105049 in one deployment), so a plain 644 was previously used to
+    # let the container read a file it doesn't match by owner. That made
+    # a file containing a live Postgres password world-readable on the
+    # host. `podman unshare chown` performs the chown from within the
+    # rootless user namespace, translating the container-relative
+    # UID:GID into the correct host-mapped identity, so the file can stay
+    # 600 and still be readable by the one process that needs it (#1922).
+    if podman unshare chown "${pgadmin_uid}:${pgadmin_gid}" "${SCRIPT_DIR}/pgadmin-servers.json" 2>/dev/null; then
+        echo "✅ Generated pgadmin-servers.json, restricted to the pgadmin container's UID (600)"
+    else
+        chmod 644 "${SCRIPT_DIR}/pgadmin-servers.json"
+        echo "⚠️  Could not map servers.json to the pgadmin container's UID (podman unshare failed) -- left world-readable (644) as a fallback so the container can still read it"
+    fi
     echo "   Note: With Vault enabled, use dynamic credentials from './aixcl vault credentials'"
 }

--- a/scripts/runtime/CONTEXT.md
+++ b/scripts/runtime/CONTEXT.md
@@ -9,7 +9,7 @@ via volume mounts defined in `services/docker-compose.yml`.
 | File | Service | Notes |
 |------|---------|-------|
 | `ollama-entrypoint.sh` | `ollama` | Sets permissions, switches to ubuntu user, starts Ollama. |
-| `grafana-entrypoint.sh` | `grafana` | Waits for Prometheus, then starts Grafana. |
+| `grafana-entrypoint.sh` | `grafana` | First start: waits for the Vault admin password, then starts Grafana. Restart: starts directly. |
 | `openwebui-entrypoint.sh` | `openwebui` | Standard OpenWebUI startup. |
 | `openwebui-vault-entrypoint.sh` | `openwebui` (vault profile) | Fetches credentials from Vault before starting OpenWebUI. |
 | `pgadmin-entrypoint.sh` | `pgadmin` | Configures pgAdmin servers.json, starts pgAdmin. |
@@ -23,6 +23,24 @@ via volume mounts defined in `services/docker-compose.yml`.
 - Do not add host-path references. Only paths inside the container or
   mounted volumes are accessible.
 - `docker_utils.sh` is NOT available here -- these scripts are container-side.
+
+## Capped Entrypoint Rules (#1891/#1901/#1909)
+
+For entrypoints doing privileged filesystem work under `cap_drop`:
+
+- **Create before chown**: root without CAP_DAC_OVERRIDE cannot mkdir
+  inside a directory it already chowned away. Create missing dirs while
+  the parent is root-owned; defer later creation to the non-root phase.
+- **REQUIRED ops fail fast, naming the capability** (e.g. "container
+  likely lacks CAP_CHOWN"). Never `2>/dev/null || true` an operation the
+  service cannot run without -- that converts a clear startup error into
+  an unexplained crash-loop later.
+- **OPTIONAL ops get a visible `[WARN]`** stating the consequence, never
+  a silent `|| true`. (Probe no-matches like `pkill` on an absent
+  process are the one exception: no-match is the normal case.)
+- **Verify with the three-scenario matrix**: truly-empty volume,
+  partially-initialised volume, and a withheld-capability run that must
+  fail loudly. See docs/developer/adding-services.md.
 
 ## Agent Guidance
 

--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -46,7 +46,8 @@ fi
 echo "[Vault] Configuring Grafana with initial admin password..."
 GRAFANA_PASS_FILE="/tmp/grafana-admin-password"
 echo "$GRAFANA_ADMIN_PASSWORD" > "$GRAFANA_PASS_FILE"
-chown 472:472 "$GRAFANA_PASS_FILE" 2>/dev/null || true
+chown 472:472 "$GRAFANA_PASS_FILE" \
+    || echo "[WARN] chown of $GRAFANA_PASS_FILE failed (no CAP_CHOWN); continuing — chmod 600 below still applies"
 chmod 600 "$GRAFANA_PASS_FILE"
 export GF_SECURITY_ADMIN_PASSWORD__FILE="$GRAFANA_PASS_FILE"
 

--- a/scripts/runtime/grafana-entrypoint.sh
+++ b/scripts/runtime/grafana-entrypoint.sh
@@ -55,6 +55,12 @@ export GF_SECURITY_ADMIN_PASSWORD__FILE="$GRAFANA_PASS_FILE"
 /run.sh &
 GRAFANA_PID=$!
 
+# Forward stop signals to Grafana. PID 1 does not get the default signal
+# disposition, so without this trap `wait` below ignores SIGTERM entirely
+# and the container only stops after the orchestrator's SIGKILL grace
+# period elapses on every first-start container (#1920).
+trap 'kill -TERM "$GRAFANA_PID" 2>/dev/null' TERM INT
+
 # Wait for Grafana to be ready
 echo "[Vault] Waiting for Grafana to be ready..."
 for _ in {1..60}; do
@@ -77,6 +83,7 @@ fi
 unset GF_SECURITY_ADMIN_PASSWORD__FILE
 rm -f "$GRAFANA_PASS_FILE"
 
-# Keep Grafana running as PID 1 for clean signal handling
+# Wait for Grafana to exit; the trap above forwards a stop signal so this
+# returns promptly instead of stalling until SIGKILL.
 echo "[Vault] Grafana is running (PID: $GRAFANA_PID)"
 wait $GRAFANA_PID

--- a/scripts/runtime/ollama-entrypoint.sh
+++ b/scripts/runtime/ollama-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Ollama entrypoint wrapper - ensures correct permissions for Ollama data directory
 
-set -e
+set -euo pipefail
 
 # Configuration
 OLLAMA_USER="ubuntu"
@@ -15,12 +15,19 @@ if ! id "$OLLAMA_USER" &>/dev/null; then
     useradd -m -u "$OLLAMA_UID" "$OLLAMA_USER"
 fi
 
-# Ensure .ollama directory exists with correct ownership
+# Ensure .ollama directory exists with correct ownership. Model store
+# ownership is REQUIRED before the privilege drop: ollama cannot write
+# models as UID 1000 into a root-owned volume.
 mkdir -p "$OLLAMA_DATA"
-chown -R "$OLLAMA_USER:$OLLAMA_USER" "$OLLAMA_HOME"
+if ! chown -R "$OLLAMA_USER:$OLLAMA_USER" "$OLLAMA_HOME"; then
+    echo "[ERROR] chown of $OLLAMA_HOME failed — container likely lacks CAP_CHOWN"
+    exit 1
+fi
 
-# Add user to video and render groups for GPU access (if they exist)
-usermod -aG video,render "$OLLAMA_USER" 2>/dev/null || true
+# Add user to video and render groups for GPU access (optional: the
+# groups do not exist on hosts without GPU device nodes)
+usermod -aG video,render "$OLLAMA_USER" \
+    || echo "[WARN] could not add $OLLAMA_USER to video/render groups; GPU device access may be unavailable (normal on CPU-only hosts)"
 
 echo "Starting Ollama as $OLLAMA_USER user..."
 

--- a/scripts/runtime/openwebui-entrypoint.sh
+++ b/scripts/runtime/openwebui-entrypoint.sh
@@ -77,6 +77,12 @@ if [ "$(id -u)" = "0" ]; then
         useradd -u "$USER_ID" -g "$GROUP_ID" -o -m -s /bin/bash webui 2>/dev/null || true
     fi
 
+    # setpriv below works with numeric IDs, so a missing user is not fatal,
+    # but surface it: HOME=/home/webui will not exist without useradd -m
+    if ! id webui >/dev/null 2>&1; then
+        echo "[WARN] webui user could not be created; continuing with numeric IDs ($USER_ID:$GROUP_ID), /home/webui may be missing"
+    fi
+
     # Create missing directories BEFORE chowning their parents: on a fresh
     # volume the parent is still root-owned so mkdir needs no extra
     # capability, and the recursive chown below covers the new children.
@@ -110,11 +116,14 @@ if [ "$(id -u)" = "0" ]; then
     done
 
     if [ -f "/app/backend/openwebui.sh" ]; then
-        chmod +x /app/backend/openwebui.sh 2>/dev/null || true
-        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh 2>/dev/null || true
+        chmod +x /app/backend/openwebui.sh \
+            || echo "[WARN] chmod +x /app/backend/openwebui.sh failed; launcher script may not be executable"
+        chown "$USER_ID:$GROUP_ID" /app/backend/openwebui.sh \
+            || echo "[WARN] chown of /app/backend/openwebui.sh failed (CAP_CHOWN?); launcher stays image-owned"
     fi
 
-    chown -R "$USER_ID:$GROUP_ID" /tmp 2>/dev/null || true
+    chown -R "$USER_ID:$GROUP_ID" /tmp \
+        || echo "[WARN] chown of /tmp failed; sticky-bit world-writable /tmp below is sufficient"
     chmod 1777 /tmp
 
     echo "Switching to webui user (UID: $USER_ID)..."

--- a/scripts/runtime/pgadmin-entrypoint.sh
+++ b/scripts/runtime/pgadmin-entrypoint.sh
@@ -22,35 +22,50 @@ if [ "$IS_FIRST_START" = false ]; then
     # Still need to set up directories and permissions
     USER_ID="${PGADMIN_USER_ID:-5050}"
     GROUP_ID="${PGADMIN_GROUP_ID:-5050}"
-    
+
     if [ "$(id -u)" = "0" ]; then
         echo "Running as root — setting up permissions for restart..."
-        
+
         mkdir -p /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
-        
+
         if ! getent group pgadmin >/dev/null 2>&1; then
             groupadd -g "$GROUP_ID" pgadmin 2>/dev/null || groupadd pgadmin 2>/dev/null || true
         fi
-        
+
         if ! id pgadmin >/dev/null 2>&1; then
             useradd -u "$USER_ID" -g "$GROUP_ID" -s /bin/false -M pgadmin 2>/dev/null || true
         fi
-        
-        chown -R "$USER_ID:$GROUP_ID" /var/lib/pgadmin 2>/dev/null || true
-        chown -R "$USER_ID:$GROUP_ID" /var/log/pgadmin 2>/dev/null || true
-        chown "$USER_ID:$GROUP_ID" /pgadmin4/servers.json 2>/dev/null || true
-        chmod +x /entrypoint.sh 2>/dev/null || true
-        
-        # Stop postfix if running
+
+        # su below requires the pgadmin user; creation failure is fatal, so
+        # verify the outcome instead of silencing it
+        if ! id pgadmin >/dev/null 2>&1; then
+            echo "[ERROR] pgadmin user could not be created — cannot drop privileges (check SETUID/SETGID caps and a writable /etc/passwd)"
+            exit 1
+        fi
+
+        # Data volume ownership is REQUIRED: pgAdmin crashes after the
+        # privilege drop if it cannot write /var/lib/pgadmin
+        if ! chown -R "$USER_ID:$GROUP_ID" /var/lib/pgadmin; then
+            echo "[ERROR] chown of /var/lib/pgadmin failed — container likely lacks CAP_CHOWN"
+            exit 1
+        fi
+        chown -R "$USER_ID:$GROUP_ID" /var/log/pgadmin \
+            || echo "[WARN] chown of /var/log/pgadmin failed (host bind mount); log writes may fail"
+        chown "$USER_ID:$GROUP_ID" /pgadmin4/servers.json \
+            || echo "[WARN] chown of /pgadmin4/servers.json failed (single-file bind mount); server list may not load"
+        chmod +x /entrypoint.sh \
+            || echo "[WARN] chmod +x /entrypoint.sh failed; assuming image default permissions"
+
+        # Stop postfix if running (pkill no-match is the normal case, not a failure)
         if [ -f /usr/libexec/postfix/master ]; then
             pkill -f "postfix/master" 2>/dev/null || true
         fi
-        
+
         echo "Switching to pgadmin user (UID: $USER_ID)..."
         export PGADMIN_LISTEN_PORT PGADMIN_LISTEN_ADDRESS PGADMIN_SERVER_JSON_FILE PGADMIN_REPLACE_SERVERS_ON_STARTUP
         exec su -m -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'
     fi
-    
+
     # Non-root restart: just start
     echo "Running as user: $(id -u):$(id -g)"
     echo "Starting pgAdmin (restart) — admin credentials unchanged"
@@ -115,26 +130,42 @@ chmod 600 /var/lib/pgadmin/.pgadmin-passwd /var/lib/pgadmin/.pg-connect-passwd
 # --- Root setup block (only on first start) ---
 if [ "$(id -u)" = "0" ]; then
     echo "Running as root — setting up permissions for first start..."
-    
+
     mkdir -p /var/lib/pgadmin/sessions /var/lib/pgadmin/storage
-    
+
     if ! getent group pgadmin >/dev/null 2>&1; then
         groupadd -g "${PGADMIN_GROUP_ID:-5050}" pgadmin 2>/dev/null || groupadd pgadmin 2>/dev/null || true
     fi
-    
+
     if ! id pgadmin >/dev/null 2>&1; then
         useradd -u "${PGADMIN_USER_ID:-5050}" -g "${PGADMIN_GROUP_ID:-5050}" -s /bin/false -M pgadmin 2>/dev/null || true
     fi
-    
-    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/lib/pgadmin 2>/dev/null || true
-    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/log/pgadmin 2>/dev/null || true
-    chown "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /pgadmin4/servers.json 2>/dev/null || true
-    chmod +x /entrypoint.sh 2>/dev/null || true
-    
+
+    # su below requires the pgadmin user; creation failure is fatal, so
+    # verify the outcome instead of silencing it
+    if ! id pgadmin >/dev/null 2>&1; then
+        echo "[ERROR] pgadmin user could not be created — cannot drop privileges (check SETUID/SETGID caps and a writable /etc/passwd)"
+        exit 1
+    fi
+
+    # Data volume ownership is REQUIRED: pgAdmin crashes after the
+    # privilege drop if it cannot write /var/lib/pgadmin
+    if ! chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/lib/pgadmin; then
+        echo "[ERROR] chown of /var/lib/pgadmin failed — container likely lacks CAP_CHOWN"
+        exit 1
+    fi
+    chown -R "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /var/log/pgadmin \
+        || echo "[WARN] chown of /var/log/pgadmin failed (host bind mount); log writes may fail"
+    chown "${PGADMIN_USER_ID:-5050}:${PGADMIN_GROUP_ID:-5050}" /pgadmin4/servers.json \
+        || echo "[WARN] chown of /pgadmin4/servers.json failed (single-file bind mount); server list may not load"
+    chmod +x /entrypoint.sh \
+        || echo "[WARN] chmod +x /entrypoint.sh failed; assuming image default permissions"
+
+    # Stop postfix if running (pkill no-match is the normal case, not a failure)
     if [ -f /usr/libexec/postfix/master ]; then
         pkill -f "postfix/master" 2>/dev/null || true
     fi
-    
+
     # Create servers.json with Vault password
     cat > /pgadmin4/servers.json << EOF
 {
@@ -154,7 +185,7 @@ if [ "$(id -u)" = "0" ]; then
 }
 EOF
     chmod 644 /pgadmin4/servers.json
-    
+
     echo "Switching to pgadmin user (UID: ${PGADMIN_USER_ID:-5050})..."
     export PGADMIN_DEFAULT_EMAIL PGADMIN_DEFAULT_PASSWORD PGADMIN_LISTEN_PORT PGADMIN_LISTEN_ADDRESS PGADMIN_SERVER_JSON_FILE PGADMIN_REPLACE_SERVERS_ON_STARTUP
     exec su -m -s /bin/bash pgadmin -c 'exec /usr/local/bin/pgadmin-entrypoint.sh'

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -438,6 +438,34 @@ services:
     container_name: pgadmin
     pull_policy: missing
     network_mode: host
+    # cap_drop: ALL + minimal cap_add (#1921, superseding #1667's "no
+    # restrictions" exception -- verified against the current pinned
+    # image, not the older one #1667 was written against):
+    #   SETUID/SETGID  -- the image's own /entrypoint.sh invokes sudo
+    #                     internally even though this container already
+    #                     runs as the non-root pgadmin user (5050); sudo's
+    #                     setresuid/setresgid calls need these to work at
+    #                     all, regardless of any actual privilege change.
+    #   NET_BIND_SERVICE -- /usr/local/bin/python3.14 in this image has a
+    #                     cap_net_bind_service file capability set. Any
+    #                     binary with file capabilities set fails to exec
+    #                     entirely under cap_drop: ALL (EPERM), regardless
+    #                     of the port actually used (5050, unprivileged).
+    # Deliberately NOT setting security_opt: no-new-privileges here: it
+    # blocks sudo's setuid mechanism outright, which stops the bundled
+    # postfix mail relay from starting. Verified live: with these three
+    # caps and no no-new-privileges, pgAdmin boots normally AND postfix's
+    # master process starts successfully -- an improvement over the
+    # current unrestricted-capability deployment, where postfix already
+    # fails to start today regardless (its effective capability set is
+    # only cap_net_bind_service, since the entrypoint never runs a root
+    # phase under this image's non-root default user).
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
     environment:
       PGADMIN_LISTEN_PORT: 5050
       PGADMIN_LISTEN_ADDRESS: 127.0.0.1


### PR DESCRIPTION
# Pull Request

## Summary

Release v1.1.65 to `main`. Fixes #1935

### Description of Changes

Security and reliability release: a full capability audit of every hardened entrypoint (pgadmin, grafana, ollama, open-webui), a plaintext-password permission fix and a minimal-capability set for pgadmin that also repairs its previously-broken postfix integration, a CI fix for Dependabot PRs, a fix for a fork-PR token bug that had silently disabled automated issue closing since introduction, and an OpenCode agent documentation reorientation. See `CHANGELOG.md`'s `[v1.1.65]` entry for the full itemized list with issue references.

Pre-release retrospective: https://github.com/xencon/aixcl/discussions/1934

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (each underlying PR passed CI and the pr-ready merge gate individually before landing on dev; see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

Every commit in this release was independently verified and merged to `dev` through its own PR and CI run before being bundled here:

- #1919 (#1909): 3-scenario harness across all four entrypoints, plus live confirmation on a real clean-init purge (21/21 healthy, zero restarts)
- #1926 (#1920): timed podman-stop comparison, 9.0s pre-fix vs 0.25s post-fix
- #1933 (#1921): offline harness across all three #1909 scenarios against the real pinned pgadmin image, plus live comparison of actual effective capabilities against the running production container
- #1932 (#1922): live verification against the real running pgadmin container, confirming the actual runtime UID (not `podman exec`'s default root) can read the re-secured file
- #1924 (#1923): local extraction and test of the modified title-check logic against both a dependabot and non-dependabot author
- #1929 (#1928): confirmed via reading GitHub's own workflow-run logs on four historical merges; live re-verification is pending this release's main sync (see Verification)
- #1927 (#1925): real-image fresh-volume verification of the scaffold's documented capability pattern
- #1931 (#1930): diff-scope confirmation that no mechanical file (`next-task.md`, `reviewer.md`, `opencode.json.example`) was touched

`./aixcl checks all` -- 11/11 passing on this branch.

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (every underlying commit individually verified per-PR before bundling here, see Testing Notes; `./aixcl checks all` 11/11 on this branch)

### Related Issues

- Fixes #1935

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Release bundling PR following .claude/skills/release/SKILL.md; all underlying work individually verified in its own PR
- Scope: CHANGELOG.md only (the release commits themselves already landed on dev individually)
- Confirmation: yes
---

