### PR TITLE
[OVERRIDE] Fix .env mode 644 regression after prune/recreate (#1940)

### DIFF
--- a/lib/aixcl/commands/stack.sh
+++ b/lib/aixcl/commands/stack.sh
@@ -167,6 +167,11 @@ function init_stack() {
     if [ ! -f "$env_file" ]; then
         if [ -f "$env_example" ]; then
             cp "$env_example" "$env_file"
+            # config/.env.example is tracked in git at mode 644; a fresh
+            # copy inherits that, leaving .env world-readable until some
+            # later service-start path happens to tighten it. Enforce 600
+            # here at creation time instead of relying on that.
+            chmod 600 "$env_file"
             echo "Created .env from config/.env.example"
         else
             echo "Error: config/.env.example not found"


### PR DESCRIPTION
# Pull Request

## Summary

`[OVERRIDE]` -- operator authorized proceeding without issue-first approval ("No issue required. Push the change"), per AGENTS.md Section 8. Retroactive issue #1940 filed for the documentation trail; all other rules (branch naming, GPG signing, PR, CI) followed as normal. Closes #1940

### Description of Changes

`init_stack()`'s "Step 2: Create .env from example" recreates `.env` from `config/.env.example` whenever it's missing -- e.g. after `./aixcl utils prune` (or `prune --all`) deletes it as part of a full reset, by design, same as the other state files it removes. `config/.env.example` is tracked in git at mode 644, and a fresh `cp` inherits that, leaving the recreated `.env` world-readable.

This isn't the first fix for this class of bug -- `lib/core/service_utils.sh` and `lib/aixcl/commands/engine.sh` already unconditionally `chmod 600` on service start, with a comment confirming that was a deliberate prior fix. But that protection only covers `open-webui`/`postgres`/`pgadmin` service starts, not the initial creation path -- so a freshly-recreated `.env` slips through world-readable until (and unless) one of those specific services happens to start afterward. Traced during a session review after the reversion was observed twice across housekeeping runs in the same session.

- `lib/aixcl/commands/stack.sh` -- `chmod 600 "$env_file"` added immediately after the `cp` in Step 2

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `bash -n` and `shellcheck --severity=warning --exclude=SC1091` on `stack.sh` -- clean
- `./aixcl checks all` -- 11/11 passing
- Isolated functional test (without touching the real running `.env`): copied `config/.env.example` to a scratch dir at 644, applied the exact `cp` + `chmod 600` sequence now in the code, confirmed the result is mode 600

### Verification

To verify this change is complete:

- [ ] Behavior works as expected
- [ ] No regressions observed
- [x] Tests cover change (isolated functional test directly exercises the fixed sequence, see Testing Notes)

### Related Issues

- Closes #1940

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Traced via static code inspection during a session review, then implemented and verified with an isolated functional test
- Scope: lib/aixcl/commands/stack.sh
- Confirmation: yes
---
