### PR TITLE
Disable pgadmin's unused postfix mail relay (#1942)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -438,33 +438,23 @@ services:
     container_name: pgadmin
     pull_policy: missing
     network_mode: host
-    # cap_drop: ALL + minimal cap_add (#1921, superseding #1667's "no
-    # restrictions" exception -- verified against the current pinned
-    # image, not the older one #1667 was written against):
-    #   SETUID/SETGID  -- the image's own /entrypoint.sh invokes sudo
-    #                     internally even though this container already
-    #                     runs as the non-root pgadmin user (5050); sudo's
-    #                     setresuid/setresgid calls need these to work at
-    #                     all, regardless of any actual privilege change.
+    # cap_drop: ALL + minimal cap_add (#1921, #1942). pgAdmin's bundled
+    # postfix mail relay (used only for its own self-service
+    # password-reset emails, a feature AIXCL doesn't use -- credentials
+    # are Vault-managed) is disabled outright via PGADMIN_DISABLE_POSTFIX
+    # below, since it never worked under this platform's network_mode:
+    # host invariant anyway. With postfix disabled, the image's
+    # /entrypoint.sh no longer invokes sudo at all, so SETUID/SETGID
+    # (previously added for sudo's setresuid/setresgid calls) are no
+    # longer needed. The one remaining capability:
     #   NET_BIND_SERVICE -- /usr/local/bin/python3.14 in this image has a
     #                     cap_net_bind_service file capability set. Any
     #                     binary with file capabilities set fails to exec
     #                     entirely under cap_drop: ALL (EPERM), regardless
     #                     of the port actually used (5050, unprivileged).
-    # Deliberately NOT setting security_opt: no-new-privileges here: it
-    # blocks sudo's setuid mechanism outright, which stops the bundled
-    # postfix mail relay from starting. Verified live: with these three
-    # caps and no no-new-privileges, pgAdmin boots normally AND postfix's
-    # master process starts successfully -- an improvement over the
-    # current unrestricted-capability deployment, where postfix already
-    # fails to start today regardless (its effective capability set is
-    # only cap_net_bind_service, since the entrypoint never runs a root
-    # phase under this image's non-root default user).
     cap_drop:
       - ALL
     cap_add:
-      - SETUID
-      - SETGID
       - NET_BIND_SERVICE
     environment:
       PGADMIN_LISTEN_PORT: 5050
@@ -473,6 +463,10 @@ services:
       PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
       PGADMIN_USER_ID: "5050"
       PGADMIN_GROUP_ID: "5050"
+      # Unused feature (see comment above); also never worked under
+      # network_mode: host, so disable it rather than leave it failing
+      # loudly on every boot (#1942).
+      PGADMIN_DISABLE_POSTFIX: "1"
     volumes:
       - aixcl-pgadmin-storage:/var/lib/pgadmin/storage
       - aixcl-pgadmin-main:/var/lib/pgadmin


### PR DESCRIPTION
# Pull Request

## Summary

Closes #1942

### Description of Changes

`postfix` (pgAdmin's bundled mail relay) exists only to send self-service password-reset emails -- a feature AIXCL doesn't use, since credentials are Vault-managed and static (`PGADMIN_DEFAULT_EMAIL`/`PGADMIN_DEFAULT_PASSWORD`, sourced from Vault at first start). It also never actually worked under `network_mode: host` (this platform's invariant): re-testing #1921's capability set specifically under host networking showed postfix fails deterministically, contradicting that PR's "fixes postfix" claim, which was verified only against an offline harness's `--network none` default.

Rather than leave it perpetually failing (14+ `Permission denied` lines and a fatal error logged on every single container boot), disabled it via the officially supported `PGADMIN_DISABLE_POSTFIX` environment variable (confirmed in dpage/pgadmin4's own native `/entrypoint.sh`: `if [ -z "${PGADMIN_DISABLE_POSTFIX}" ]; then sudo /usr/sbin/postfix start; fi`).

With postfix disabled, the image's `/entrypoint.sh` no longer invokes `sudo` at all (confirmed: it was the script's only `sudo` call), so `SETUID`/`SETGID` -- added in #1921 specifically for `sudo`'s `setresuid`/`setresgid` calls -- are no longer needed either. Net result: a *simpler* capability set than #1921 shipped (`cap_add: [NET_BIND_SERVICE]` alone) with zero postfix-related log noise.

Also corrects a citation error that had propagated through #1909/#1921/#1933: those referenced "#1667" as the historical issue that removed capability restrictions here due to postfix/python breakage. #1667 turned out to be an unrelated CLI-alignment PR, and #778 (cited nearby in #705's tracking issue) turned out to be about Alloy, not pgAdmin -- no issue in the tracker actually substantiates that specific historical claim, so it's removed rather than repeated further. Corrective comments posted on #1921 and PR #1933.

- `services/docker-compose.yml` -- `PGADMIN_DISABLE_POSTFIX: "1"` added; `cap_add` simplified to `[NET_BIND_SERVICE]`; comment rewritten to remove the unverifiable citation and explain the current state accurately

### Change Checklist

- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass (see Testing Notes)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

### Testing Notes

- `docker compose -f services/docker-compose.yml config`, `yamllint`, `./aixcl checks all` -- all clean (11/11)
- Verified against a real offline harness (pinned image, real `pgadmin-entrypoint.sh`, `network_mode: host` to match production) with `cap_add: [NET_BIND_SERVICE]` alone and `PGADMIN_DISABLE_POSTFIX=1`:
  - No postfix-related log lines at all (previously 14+ `Permission denied` lines plus a fatal error on every boot)
  - Real servers.json content still imports correctly (`Added 0 Server Group(s) and 1 Server(s)`)
  - gunicorn boots and serves (`302 FOUND` on the login redirect)
  - Confirmed `sudo` is the native entrypoint's *only* use of postfix (`grep -n sudo /entrypoint.sh` inside the image returns exactly one line), justifying dropping `SETUID`/`SETGID`

### Verification

To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change (offline harness directly exercises the exact fixed configuration under the same network mode as production, see Testing Notes)

### Related Issues

- Closes #1942

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Compose change plus offline harness verification under network_mode: host (matching production); corrective comments posted on the two prior artifacts (#1921, PR #1933) whose claims this corrects
- Scope: services/docker-compose.yml; corrective comments on #1921 and PR #1933 (no code changes there)
- Confirmation: yes
---
