### PR TITLE
Add delegation skill trio with sequential JSONL logging (#1952)

### DIFF
--- a/.claude/skills/delegate-review/SKILL.md
+++ b/.claude/skills/delegate-review/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: delegate-review
+description: >
+  Review delegation history from the JSONL delegation log: what was delegated,
+  how often, success rates, duration stats, and what else could be delegated.
+  Use when asked to review delegations, check delegation stats, or tune the
+  delegation workflow. Triggers on "delegation review", "delegation stats",
+  "what have we delegated".
+argument-hint: <timeframe, e.g. 'last week', 'today', or blank for all>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Delegation Review
+
+Analyze the delegation log and produce a review. The log lives at
+`.opencode/delegation-log.jsonl` in the repository root.
+
+## Step 1: Read the log
+
+```bash
+cat .opencode/delegation-log.jsonl 2>/dev/null
+```
+
+If the file is missing or empty, report that no delegations have been
+recorded yet and stop.
+
+## Step 2: Produce analytics
+
+Parse the JSONL entries (filter to the requested timeframe if given) and
+report:
+
+### Usage Summary
+- Total delegations (completed entries only -- ignore "started" entries with
+  no matching completion; flag them as interrupted runs)
+- Success rate (successful / total)
+- Date range covered and delegations per day
+
+### Duration Stats
+- Average duration; fastest and slowest tasks
+- Tasks over 60 seconds (candidates for a tighter prompt or a cloud model)
+
+### Task Breakdown
+- Group tasks by type (search, lint, test, edit, check, ...)
+- Most common task types and success rate per type
+
+### Quality Assessment
+For each completed delegation: did it succeed, was it appropriately scoped
+for the delegate model, and do failures suggest the task was too complex to
+delegate?
+
+## Step 3: Recommendations
+
+Based on the history, suggest:
+
+1. **More delegation candidates** -- recurring primary-agent tasks that fit
+   the delegate skill's tier rubric
+2. **Tasks to stop delegating** -- patterns with high failure rates
+3. **Prompt improvements** -- failures that point at missing context in the
+   delegation prompts
+
+Present as a markdown report: tables for stats, bullets for recommendations.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: delegate
+description: >
+  Delegate a mechanistic sub-task to the OpenCode peer agent via opencode run,
+  logging every delegation. Use for search/grep, read-and-summarize, lint and
+  check runs, git/gh status queries, and simple mechanical edits that do not
+  need the primary model's reasoning. Invoke with /delegate <task>, or
+  proactively when a sub-task fits the tier rubric. For delegating a whole
+  GitHub issue to the peer agent, use the agent label instead (AGENTS.md).
+argument-hint: <task description or instructions>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Delegate to OpenCode
+
+Delegate the given task to the OpenCode peer agent and log it for tracking.
+
+**SEQUENTIAL ONLY -- HARD RULE**: run at most one `opencode run` at a time.
+Never launch delegations in parallel: concurrent appends corrupt ordering in
+the shared JSONL log. Queue multiple tasks and run them one after another.
+
+`LOGFILE` is `.opencode/delegation-log.jsonl` at the repository root
+(gitignored; create with `mkdir -p .opencode` if missing).
+
+## Step 1: Assess the task
+
+Confirm the task fits delegation. Good candidates:
+
+**Tier 1 -- read-only, zero risk:**
+- File search, grep, symbol lookup; read and summarize files
+- Line/file counts, directory stats
+- `git status`, `git log`, branch info; `gh pr list`, `gh issue list` (read-only)
+- Check env var presence (name/length/prefix only -- never full values)
+- Probe an HTTP endpoint and report status (e.g. `curl` against Ollama's API)
+- Parse config schemas or JSON and report structure
+
+**Tier 2 -- side-effect-free analysis:**
+- Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)
+- `./aixcl test lib` (shell library unit tests, no stack needed)
+- `shellcheck --severity=warning --exclude=SC1091 <files>`; `bash -n <file>`
+- `yamllint -c .yamllint.yml <file>`
+- `./aixcl stack status` (read-only health report)
+
+**Tier 3 -- writes files, reviewable:**
+- Simple single-file mechanical edits (rename, ASCII conversion, import sort)
+- Mechanical find-replace across explicitly listed files
+- Generate boilerplate from an existing template in the repo
+
+Do NOT delegate:
+- Multi-file or architectural changes; anything security-sensitive
+- Stack state changes (start/stop/restart/purge) -- operator territory
+- git commit/push/merge, or any GitHub write (issues, PRs, comments) --
+  workflow rules and the agent identification block stay with the primary agent
+- Complex debugging needing deep reasoning or conversation context
+- Interactive commands
+
+If the task does not fit, say so and handle it directly.
+
+## Step 2: Pick the model
+
+The default OpenCode model is the local stack's Ollama model and only works
+when the stack is running (`./aixcl stack status`). If the stack is down, add
+`-m <provider/model>` with a cloud model from `opencode.json` (e.g.
+`-m nvidia/deepseek-ai/deepseek-v4-flash`). Never start the stack just to
+delegate -- stack operations belong to the operator.
+
+## Step 3: Prepare the prompt
+
+Write a self-contained prompt -- the delegate has none of your conversation
+context. Include absolute file paths, the exact commands or edits wanted, and
+the expected output format. Concrete ("in /path/file.sh change X to Y"), not
+vague ("fix the bug").
+
+## Step 4: Log and execute
+
+Log the start:
+
+    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"started"}' >> .opencode/delegation-log.jsonl
+
+Execute (one at a time; bound the runtime):
+
+    START_MS=$(date +%s%3N)
+    timeout -k 10 600 opencode run --auto --dir <WORKING_DIR> [-m <provider/model>] "<PROMPT>"
+    END_MS=$(date +%s%3N)
+
+## Step 5: Log the result
+
+    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"completed","success":<true|false>,"duration_ms":'$((END_MS - START_MS))',"result_summary":"<ONE_LINE_SUMMARY>"}' >> .opencode/delegation-log.jsonl
+
+On failure set `"status":"failed"` and `"success":false`.
+
+**If delegation fails** (error, timeout, model unavailable): retry once with
+an alternate model from `opencode.json`. If that also fails, handle the task
+directly and log the completion entry with `"status":"fallback-primary"`.
+
+## Step 6: Report
+
+Return the result to the user. If output is long (over 200 lines), extract the
+key findings. If files were modified (Tier 3), list them, summarize the
+changes, and review the diff before anything is staged.

--- a/.claude/skills/session-review/SKILL.md
+++ b/.claude/skills/session-review/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: session-review
+description: >
+  Review the work done this session and identify tasks that could have been
+  delegated to the OpenCode peer instead of running on the primary model.
+  Builds the delegation feedback loop: surfaces missed opportunities and grows
+  the always-delegate list over time. Use at the end of a session or when
+  asked to review the session's work. Triggers on "session review", "what did
+  we do today", "review this session".
+argument-hint: <optional focus area or timeframe>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Session Review
+
+Review the current session's work to identify delegation opportunities.
+
+## Step 1: Self-report task list
+
+List every distinct task performed this session:
+
+| # | Task description | Category | Ran on | Could delegate? | Why / why not |
+|---|-----------------|----------|--------|-----------------|---------------|
+
+Categories: search, read, edit, test, lint, check, git, gh, ci, plan, debug,
+review, scaffold, other. "Ran on" is "primary" or "delegated".
+
+"Could delegate?" applies the delegate skill's tier rubric:
+- YES: read-only search/grep, file stats, git/gh status queries, lint, check
+  runs, simple mechanical edits, boilerplate
+- NO: needed conversation context, multi-file reasoning, security judgment,
+  stack or GitHub writes, interactive back-and-forth, planning/design
+
+## Step 2: Score the session
+
+- Total tasks; tasks on primary; tasks delegated
+- Missed opportunities (ran on primary but delegable)
+- Delegation rate: delegated / (delegated + missed)
+- Efficiency: tasks-that-needed-primary / total-primary-tasks (higher is
+  better use of the primary model)
+
+## Step 3: Identify new patterns
+
+For recurring missed opportunities, draft an always-delegate entry: pattern
+name, tier (1 read-only / 2 analysis / 3 writes), example delegation prompt,
+why it is safe.
+
+## Step 4: Cross-check the log
+
+Read `.opencode/delegation-log.jsonl` and confirm every delegated task from
+Step 1 is logged (delegations run sequentially, so entries should be ordered).
+Also note any whole issues delegated via the `agent` label this session --
+they count as delegated work but live in GitHub, not the log. If project
+memory contains delegation-candidate notes, check whether any known pattern
+was missed.
+
+## Step 5: Report
+
+- **Session summary**: date, total tasks, delegation rate, efficiency score
+- **What was delegated**: table with duration and success
+- **Missed opportunities**: table with suggested delegation prompts
+- **New patterns**: recurring misses that should become standard candidates
+- **Recommendations**: what to delegate next session; patterns to drop
+  (failed delegations); suggested updates to the delegate skill

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ bun.lock
 # OpenCode generated artifacts
 .opencode/package-lock.json
 .opencode/bun.lock
+.opencode/delegation-log.jsonl
 
 # macOS
 .DS_Store

--- a/.opencode/skills/delegate-review/SKILL.md
+++ b/.opencode/skills/delegate-review/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: delegate-review
+description: >
+  Review delegation history from the JSONL delegation log: what was delegated,
+  how often, success rates, duration stats, and what else could be delegated.
+  Use when asked to review delegations, check delegation stats, or tune the
+  delegation workflow. Triggers on "delegation review", "delegation stats",
+  "what have we delegated".
+argument-hint: <timeframe, e.g. 'last week', 'today', or blank for all>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Delegation Review
+
+Analyze the delegation log and produce a review. The log lives at
+`.opencode/delegation-log.jsonl` in the repository root.
+
+## Step 1: Read the log
+
+```bash
+cat .opencode/delegation-log.jsonl 2>/dev/null
+```
+
+If the file is missing or empty, report that no delegations have been
+recorded yet and stop.
+
+## Step 2: Produce analytics
+
+Parse the JSONL entries (filter to the requested timeframe if given) and
+report:
+
+### Usage Summary
+- Total delegations (completed entries only -- ignore "started" entries with
+  no matching completion; flag them as interrupted runs)
+- Success rate (successful / total)
+- Date range covered and delegations per day
+
+### Duration Stats
+- Average duration; fastest and slowest tasks
+- Tasks over 60 seconds (candidates for a tighter prompt or a cloud model)
+
+### Task Breakdown
+- Group tasks by type (search, lint, test, edit, check, ...)
+- Most common task types and success rate per type
+
+### Quality Assessment
+For each completed delegation: did it succeed, was it appropriately scoped
+for the delegate model, and do failures suggest the task was too complex to
+delegate?
+
+## Step 3: Recommendations
+
+Based on the history, suggest:
+
+1. **More delegation candidates** -- recurring primary-agent tasks that fit
+   the delegate skill's tier rubric
+2. **Tasks to stop delegating** -- patterns with high failure rates
+3. **Prompt improvements** -- failures that point at missing context in the
+   delegation prompts
+
+Present as a markdown report: tables for stats, bullets for recommendations.

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: delegate
+description: >
+  Delegate a mechanistic sub-task to the OpenCode peer agent via opencode run,
+  logging every delegation. Use for search/grep, read-and-summarize, lint and
+  check runs, git/gh status queries, and simple mechanical edits that do not
+  need the primary model's reasoning. Invoke with /delegate <task>, or
+  proactively when a sub-task fits the tier rubric. For delegating a whole
+  GitHub issue to the peer agent, use the agent label instead (AGENTS.md).
+argument-hint: <task description or instructions>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Delegate to OpenCode
+
+Delegate the given task to the OpenCode peer agent and log it for tracking.
+
+**SEQUENTIAL ONLY -- HARD RULE**: run at most one `opencode run` at a time.
+Never launch delegations in parallel: concurrent appends corrupt ordering in
+the shared JSONL log. Queue multiple tasks and run them one after another.
+
+`LOGFILE` is `.opencode/delegation-log.jsonl` at the repository root
+(gitignored; create with `mkdir -p .opencode` if missing).
+
+## Step 1: Assess the task
+
+Confirm the task fits delegation. Good candidates:
+
+**Tier 1 -- read-only, zero risk:**
+- File search, grep, symbol lookup; read and summarize files
+- Line/file counts, directory stats
+- `git status`, `git log`, branch info; `gh pr list`, `gh issue list` (read-only)
+- Check env var presence (name/length/prefix only -- never full values)
+- Probe an HTTP endpoint and report status (e.g. `curl` against Ollama's API)
+- Parse config schemas or JSON and report structure
+
+**Tier 2 -- side-effect-free analysis:**
+- Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)
+- `./aixcl test lib` (shell library unit tests, no stack needed)
+- `shellcheck --severity=warning --exclude=SC1091 <files>`; `bash -n <file>`
+- `yamllint -c .yamllint.yml <file>`
+- `./aixcl stack status` (read-only health report)
+
+**Tier 3 -- writes files, reviewable:**
+- Simple single-file mechanical edits (rename, ASCII conversion, import sort)
+- Mechanical find-replace across explicitly listed files
+- Generate boilerplate from an existing template in the repo
+
+Do NOT delegate:
+- Multi-file or architectural changes; anything security-sensitive
+- Stack state changes (start/stop/restart/purge) -- operator territory
+- git commit/push/merge, or any GitHub write (issues, PRs, comments) --
+  workflow rules and the agent identification block stay with the primary agent
+- Complex debugging needing deep reasoning or conversation context
+- Interactive commands
+
+If the task does not fit, say so and handle it directly.
+
+## Step 2: Pick the model
+
+The default OpenCode model is the local stack's Ollama model and only works
+when the stack is running (`./aixcl stack status`). If the stack is down, add
+`-m <provider/model>` with a cloud model from `opencode.json` (e.g.
+`-m nvidia/deepseek-ai/deepseek-v4-flash`). Never start the stack just to
+delegate -- stack operations belong to the operator.
+
+## Step 3: Prepare the prompt
+
+Write a self-contained prompt -- the delegate has none of your conversation
+context. Include absolute file paths, the exact commands or edits wanted, and
+the expected output format. Concrete ("in /path/file.sh change X to Y"), not
+vague ("fix the bug").
+
+## Step 4: Log and execute
+
+Log the start:
+
+    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"started"}' >> .opencode/delegation-log.jsonl
+
+Execute (one at a time; bound the runtime):
+
+    START_MS=$(date +%s%3N)
+    timeout -k 10 600 opencode run --auto --dir <WORKING_DIR> [-m <provider/model>] "<PROMPT>"
+    END_MS=$(date +%s%3N)
+
+## Step 5: Log the result
+
+    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"completed","success":<true|false>,"duration_ms":'$((END_MS - START_MS))',"result_summary":"<ONE_LINE_SUMMARY>"}' >> .opencode/delegation-log.jsonl
+
+On failure set `"status":"failed"` and `"success":false`.
+
+**If delegation fails** (error, timeout, model unavailable): retry once with
+an alternate model from `opencode.json`. If that also fails, handle the task
+directly and log the completion entry with `"status":"fallback-primary"`.
+
+## Step 6: Report
+
+Return the result to the user. If output is long (over 200 lines), extract the
+key findings. If files were modified (Tier 3), list them, summarize the
+changes, and review the diff before anything is staged.

--- a/.opencode/skills/session-review/SKILL.md
+++ b/.opencode/skills/session-review/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: session-review
+description: >
+  Review the work done this session and identify tasks that could have been
+  delegated to the OpenCode peer instead of running on the primary model.
+  Builds the delegation feedback loop: surfaces missed opportunities and grows
+  the always-delegate list over time. Use at the end of a session or when
+  asked to review the session's work. Triggers on "session review", "what did
+  we do today", "review this session".
+argument-hint: <optional focus area or timeframe>
+compatibility: OpenCode, Claude Code
+metadata:
+  category: workflow
+  version: "1.0"
+---
+
+# Session Review
+
+Review the current session's work to identify delegation opportunities.
+
+## Step 1: Self-report task list
+
+List every distinct task performed this session:
+
+| # | Task description | Category | Ran on | Could delegate? | Why / why not |
+|---|-----------------|----------|--------|-----------------|---------------|
+
+Categories: search, read, edit, test, lint, check, git, gh, ci, plan, debug,
+review, scaffold, other. "Ran on" is "primary" or "delegated".
+
+"Could delegate?" applies the delegate skill's tier rubric:
+- YES: read-only search/grep, file stats, git/gh status queries, lint, check
+  runs, simple mechanical edits, boilerplate
+- NO: needed conversation context, multi-file reasoning, security judgment,
+  stack or GitHub writes, interactive back-and-forth, planning/design
+
+## Step 2: Score the session
+
+- Total tasks; tasks on primary; tasks delegated
+- Missed opportunities (ran on primary but delegable)
+- Delegation rate: delegated / (delegated + missed)
+- Efficiency: tasks-that-needed-primary / total-primary-tasks (higher is
+  better use of the primary model)
+
+## Step 3: Identify new patterns
+
+For recurring missed opportunities, draft an always-delegate entry: pattern
+name, tier (1 read-only / 2 analysis / 3 writes), example delegation prompt,
+why it is safe.
+
+## Step 4: Cross-check the log
+
+Read `.opencode/delegation-log.jsonl` and confirm every delegated task from
+Step 1 is logged (delegations run sequentially, so entries should be ordered).
+Also note any whole issues delegated via the `agent` label this session --
+they count as delegated work but live in GitHub, not the log. If project
+memory contains delegation-candidate notes, check whether any known pattern
+was missed.
+
+## Step 5: Report
+
+- **Session summary**: date, total tasks, delegation rate, efficiency score
+- **What was delegated**: table with duration and success
+- **Missed opportunities**: table with suggested delegation prompts
+- **New patterns**: recurring misses that should become standard candidates
+- **Recommendations**: what to delegate next session; patterns to drop
+  (failed delegations); suggested updates to the delegate skill


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1952

### Description of Changes
PR 2 of 4 for the skill pack adoption tracked in #1950. Adds the delegation skill trio: delegate (routes mechanistic sub-tasks to the OpenCode peer via opencode run, with a 3-tier safety rubric, a do-not-delegate list, a model-selection guardrail, and a JSONL logging protocol), delegate-review (analytics over the delegation log), and session-review (end-of-session audit of missed delegation opportunities, closing the feedback loop). Complements the async agent-label delegation from #1930: /delegate handles sub-tasks inside a session, the label delegates whole issues.

The sequential-only rule is stated as a hard rule in the delegate skill: at most one opencode run at a time, because concurrent appends corrupt ordering in the shared JSONL log. The log lives at .opencode/delegation-log.jsonl and is gitignored.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
- Live end-to-end smoke test performed per the skill's own protocol: delegated `shellcheck --severity=warning --exclude=SC1091 lib/core/color.sh` to OpenCode via `opencode run --auto -m nvidia/deepseek-ai/deepseek-v4-flash` (cloud model, since the local stack is stopped -- exactly the guardrail path the skill documents). Result: clean, 43.9s, both started and completed JSONL entries written in order
- `git check-ignore .opencode/delegation-log.jsonl` confirms the log is ignored
- `./aixcl checks all` green; elision check clean on the staged diff
- Commit GPG-signed by the operator

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1952
- Part of #1950

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Skill adaptation from reviewed external pack with live opencode run smoke test; local CI parity sweep
- Scope: .claude/skills/, .opencode/skills/, .gitignore
- Confirmation: yes
---
