### PR TITLE
Upgrade housekeeping to v3 and retrofit skill formatting (#1954)

### DIFF
--- a/.claude/skills/CONTEXT.md
+++ b/.claude/skills/CONTEXT.md
@@ -1,0 +1,48 @@
+# CONTEXT: skills/
+
+Agent skills following the [Agent Skills open standard](https://agentskills.io).
+This directory and its counterpart (`.claude/skills/` <-> `.opencode/skills/`)
+are byte-identical mirrors, enforced by `check-agents.sh` and CI
+(`check-opencode.yml`). **Edit both sides together, always.**
+
+## Catalog
+
+| Skill | Category | Purpose |
+|-------|----------|---------|
+| `add-service` | platform | Checklist for adding an operational service without breaking invariants |
+| `check-updates` | maintenance | Audit versioned components; manage updates issue-first |
+| `delegate` | workflow | Route mechanistic sub-tasks to the OpenCode peer (sequential, logged) |
+| `delegate-review` | workflow | Analytics over the delegation log |
+| `grill-with-docs` | workflow | Stress-test a plan against the codebase before implementing |
+| `housekeeping` | maintenance | Repo health + session-startup sweep, status report with priorities |
+| `investigate` | workflow | Root-cause-first bug investigation; no fixing until complete |
+| `issue-triage` | workflow | End-to-end GitHub issue workflow with design and CI-parity gates |
+| `release` | workflow | Cut a release (operator-gated via disable-model-invocation) |
+| `reviewing-skills` | maintenance | Audit SKILL.md files against authoring best practices |
+| `session-review` | workflow | End-of-session delegation feedback loop |
+| `workflow-guard` | workflow | Validate issue-first compliance before execution |
+
+How they interlock: `housekeeping` orients the session and may hand
+mechanical checks to `delegate`; `issue-triage` drives an issue end to end,
+calling `grill-with-docs` to validate the design and `investigate` for bugs;
+`session-review` closes the delegation loop that `delegate` logs;
+`reviewing-skills` lints all of the above.
+
+## Agent Guidance
+
+**You MAY:**
+- Add a new skill (directory + SKILL.md, kebab-case name matching frontmatter)
+- Update skills when policy or tooling changes (bump `metadata.version`)
+
+**You MUST NOT:**
+- Edit one side of the mirror without the other (`./aixcl checks agents`)
+- Merge a skill change without running the `reviewing-skills` audit on it
+- Use non-ASCII characters or reference tools the repository does not have
+
+## Conventions
+
+- Frontmatter: `name`, `description` (with trigger phrases), optional
+  `argument-hint`, `compatibility`, `metadata.category`/`metadata.version`
+- SKILL.md stays under 500 lines / 5KB; bulky material goes to
+  `references/` (one level deep, table of contents if over 100 lines)
+- Update this catalog in the same PR that adds, renames, or removes a skill

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -1,10 +1,16 @@
 ---
 name: add-service
-description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
+description: >
+  Guided checklist for safely adding a new operational service to the AIXCL
+  stack, preserving all platform invariants (host networking, pinned images,
+  runtime/operational boundary, profile registration). Use when adding a
+  service to docker-compose, wiring a new container into the stack, or asked
+  to "add a service", "add <tool> to the stack", "new compose service".
+argument-hint: <service name and purpose>
 compatibility: OpenCode, Claude Code
 metadata:
   category: platform
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Skill: add-service

--- a/.claude/skills/check-updates/SKILL.md
+++ b/.claude/skills/check-updates/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: check-updates
-description: Audit all versioned platform components and manage the update process following issue-first workflow
+description: >
+  Audit all versioned platform components (stack images, pre-commit hooks,
+  GitHub Actions, CLI tools) and manage updates through the issue-first
+  workflow. Use before a release cycle, after a long gap, or when asked to
+  "check updates", "audit versions", "what's outdated", "bump components".
+argument-hint: <optional: category to audit, or blank for all>
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Skill: check-updates
@@ -15,329 +20,91 @@ Audit every versioned component in the AIXCL platform and produce an
 actionable update report. For each outdated component, open a GitHub issue
 and apply the update following the issue-first workflow.
 
+The component inventory, version lookup commands, per-category update
+locations, and the issue body template live in
+[references/update-reference.md](references/update-reference.md).
+
 ## When to Run
 
 Before a release cycle or after a long gap between releases.
 
----
-
-## Component Inventory
-
-The platform versions four categories of components. Every line below is a
-canonical version source -- do not check anywhere else.
-
-### Category 1 -- Stack Services (services/docker-compose.yml)
-
-Extract all pinned image tags:
-
-```bash
-grep "image:" services/docker-compose.yml | grep -v "#" | \
-  sed 's/.*image: //' | sort
-```
-
-| Service | Compose key | Registry |
-|---------|------------|---------|
-| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
-| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
-| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
-| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
-| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
-| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
-| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
-| Grafana | `grafana/grafana:<tag>` | GitHub releases |
-| Loki | `grafana/loki:<tag>` | GitHub releases |
-| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
-| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
-| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
-| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
-
-### Category 2 -- Pre-commit Hooks (.pre-commit-config.yaml)
-
-```bash
-grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
-```
-
-| Hook | GitHub repo | Rev field |
-|------|-------------|-----------|
-| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
-| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
-| yamllint | adrienverge/yamllint | `rev:` |
-| gitleaks | gitleaks/gitleaks | `rev:` |
-
-### Category 3 -- GitHub Actions (.github/workflows/*.yml)
-
-```bash
-grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
-  sed 's/.*uses: //' | sort -u
-```
-
-| Action | Pinned in |
-|--------|-----------|
-| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
-| actions/dependency-review-action | dependency-review.yml |
-| docker/setup-buildx-action | bash-ci.yml |
-| github/codeql-action/init | codeql.yml |
-| github/codeql-action/analyze | codeql.yml |
-
-### Category 4 -- Developer CLI Tools (README.md + CI)
-
-Versions are pinned in two places that must stay in sync:
-
-| Tool | README.md install | CI workflow |
-|------|------------------|-------------|
-| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
-| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
-| git-cliff | README.md curl install | not used in CI |
-| yamllint | README.md pip install | documentation-checks.yml pip install |
-
----
-
 ## Step 1 -- Check Latest Versions
 
-Run these commands to look up the latest stable release for each component.
-Use GitHub releases (more reliable) wherever available; fall back to Docker Hub.
-
-```bash
-# Stack services -- GitHub releases
-for repo in \
-  "ollama/ollama" \
-  "open-webui/open-webui" \
-  "google/cadvisor" \
-  "grafana/loki" \
-  "prometheus/prometheus" \
-  "prometheus/alertmanager" \
-  "grafana/grafana" \
-  "prometheus/node_exporter" \
-  "prometheus-community/postgres_exporter" \
-  "utkuozdemir/nvidia_gpu_exporter"; do
-  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
-  echo "$repo: $latest"
-done
-
-# Stack services -- Docker Hub (for images without GitHub releases)
-for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
-  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
-    python3 -c "
-import sys, json, re
-data = json.load(sys.stdin)
-tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
-print(tags[0] if tags else 'check manually')
-" 2>/dev/null)
-  echo "$image: $latest"
-done
-
-# Pre-commit hooks and CLI tools
-for repo in \
-  "pre-commit/pre-commit-hooks" \
-  "shellcheck-py/shellcheck-py" \
-  "adrienverge/yamllint" \
-  "gitleaks/gitleaks" \
-  "orhun/git-cliff" \
-  "koalaman/shellcheck" \
-  "actions/checkout" \
-  "actions/dependency-review-action" \
-  "docker/setup-buildx-action" \
-  "github/codeql-action"; do
-  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
-  echo "$repo: $latest"
-done
-```
-
----
+Run the lookup commands from the reference (GitHub releases first, Docker Hub
+fallback) against all four categories: stack services, pre-commit hooks,
+GitHub Actions, developer CLI tools.
 
 ## Step 2 -- Build the Update Table
 
-Produce a table with four columns: Component, Category, Pinned, Latest.
-
-Mark each row:
-
-| Symbol | Meaning |
-|--------|---------|
-| current | Pinned == Latest |
-| UPDATE | Newer version available |
-| check | Could not determine latest (check manually) |
-
-Example output:
-
-```
-| Component          | Category       | Pinned   | Latest   | Status  |
-|--------------------|----------------|----------|----------|---------|
-| ollama             | stack-service  | 0.30.7   | 0.31.1   | UPDATE  |
-| prometheus         | stack-service  | v3.12.0  | v3.12.0  | current |
-```
-
----
+Produce a table: Component, Category, Pinned, Latest, Status. Status is one
+of `current` (pinned == latest), `UPDATE` (newer available), `check` (could
+not determine -- verify manually).
 
 ## Step 3 -- Triage Updates
 
-Before opening issues, classify each update:
-
 **Routine (open one issue per component):**
-- Patch version bumps (x.y.Z -> x.y.Z+1)
-- Minor version bumps with no breaking changes noted in release notes
+- Patch bumps (x.y.Z -> x.y.Z+1)
+- Minor bumps with no breaking changes in the release notes
 
 **Review required (open issue, flag for human review):**
-- Major version bumps (X.y.z -> X+1.y.z)
-- Any bump for a component listed in `docs/architecture/governance/00_invariants.md`
-  as a runtime core invariant (currently: Ollama)
-- Any bump where the release notes mention breaking API changes or schema migrations
+- Major version bumps
+- Any bump for a runtime core invariant component (currently: Ollama --
+  see `docs/architecture/governance/00_invariants.md`)
+- Release notes mentioning breaking API changes or schema migrations
 
-**Skip (do not open an issue):**
+**Skip (no issue):**
 - Pre-release tags (alpha, beta, rc, dev)
 - Architecture-specific tags (rocm, cuda, distroless suffixes)
-- Tags that differ only in suffix from the currently pinned version
+- Tags differing only in suffix from the pinned version
 
----
+## Step 4 -- Open Issues (issue-first)
 
-## Step 4 -- Open Issues (issue-first workflow)
-
-Open one issue per component that needs updating. Batch minor patch bumps
-across the same category into a single issue if there are more than three.
-
-```bash
-# Example: single component update
-gh issue create --repo xencon/aixcl \
-  --title "[TASK] Update <component> from <old> to <new>" \
-  --body "## Update
-
-- Component: \`<component>\`
-- Current: \`<old>\`
-- Latest: \`<new>\`
-- Release notes: <URL>
-
-## Checklist
-
-- [ ] Image tag updated in \`services/docker-compose.yml\`
-- [ ] Version updated in README.md install section (if CLI tool)
-- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
-- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
-- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
-- [ ] \`./aixcl stack status\` shows all services healthy" \
-  --assignee <assignee> \
-  --label "Task,component:infrastructure,Maintenance"
-```
-
-For Ollama (runtime core invariant), add to the issue body:
-
-```
-> [!WARNING]
-> Ollama is a runtime core invariant. Test inference with at least one
-> model before merging. Confirm the OpenAI-compatible API endpoint
-> (/v1/chat/completions) responds correctly after the upgrade.
-```
-
----
+One issue per component needing an update, using the template in the
+reference. Batch minor patch bumps in the same category into a single issue
+if there are more than three. Ollama updates get the runtime-core warning
+block.
 
 ## Step 5 -- Apply Updates
 
-Create a branch per issue:
-
-```bash
-git checkout dev
-git checkout -b issue-<N>/update-<component>-<new-version>
-```
-
-### Update locations by category
-
-**Stack service (docker-compose.yml):**
-```bash
-# Replace the image tag -- edit services/docker-compose.yml
-# For services with multiple instances (e.g. vault), update all occurrences
-grep -n "image:.*<component>" services/docker-compose.yml
-# Edit each line, then validate
-docker compose -f services/docker-compose.yml config > /dev/null
-```
-
-**Pre-commit hook (.pre-commit-config.yaml):**
-```bash
-# Update the rev: field for the relevant repo entry
-# Then run pre-commit to verify
-pre-commit autoupdate --repo https://github.com/<owner>/<repo>
-# Or edit manually, then:
-pre-commit run --all-files
-```
-
-**GitHub Action (.github/workflows/*.yml):**
-```bash
-# Update the uses: line in every workflow that references the action
-grep -rn "uses:.*<action>" .github/workflows/
-# Edit each file, then validate YAML
-yamllint -c .yamllint.yml .github/workflows/
-```
-
-**CLI tool (README.md + CI workflow):**
-```bash
-# Must update both locations atomically:
-# 1. README.md -- curl install URL and version comment
-# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
-#    or documentation-checks.yml pip install line (for yamllint)
-grep -n "<tool>" README.md
-grep -rn "<tool>" .github/workflows/
-```
-
----
+Branch per issue from `dev`: `issue-<N>/update-<component>-<new-version>`.
+Edit the locations listed in the reference for that category -- some tools
+are pinned in two places that must change atomically (README.md + CI
+workflow).
 
 ## Step 6 -- Validate and Commit
 
 ```bash
-# Run pre-commit checks
 bash scripts/checks/check-ai-elisions.sh --staged
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 yamllint -c .yamllint.yml .
-
-# Validate compose
 docker compose -f services/docker-compose.yml config > /dev/null
-
-# Stage and commit (GPG -- user must run)
-git add <changed files>
-# Provide commit message:
-# "chore: update <component> from <old> to <new>
-#
-# Fixes #<issue>"
 ```
 
----
+Stage the changes and hand the GPG commit command to the operator
+(`chore: update <component> from <old> to <new>` + `Fixes #<issue>`).
 
 ## Step 7 -- PR and CI
 
-```bash
-git push origin issue-<N>/update-<component>-<new-version>
-
-gh pr create \
-  --repo xencon/aixcl \
-  --base dev \
-  --title "Update <component> from <old> to <new> (#<N>)" \
-  --body "$(cat /tmp/update-pr-body.md)" \
-  --assignee <assignee> \
-  --label "Task,component:infrastructure,Maintenance"
-```
-
-Verify PR body with `check-pr-references.sh` before creating.
-
----
+Push to origin, create the PR against upstream `dev` with title
+`Update <component> from <old> to <new> (#<N>)`, assignee and labels at
+creation time. Validate the body with `check-pr-references.sh` first.
 
 ## Dependabot Coverage Note
 
-`.github/dependabot.yml` automatically opens PRs for:
-- Docker images in `/services` (weekly, Mondays)
-- GitHub Actions in `/.github/workflows` (weekly, Mondays)
-
-This skill covers the gaps Dependabot does not handle:
-- Pre-commit hook versions (`.pre-commit-config.yaml`)
-- CLI tool versions in `README.md` install instructions
-- Tool versions hard-coded in CI workflow `run:` steps (not `uses:`)
-- Cross-checking that Dependabot PRs have not stalled or been missed
-
-When Dependabot opens a PR for a component in this inventory, close the
-corresponding issue from this skill if one was opened for the same version bump.
-
----
+`.github/dependabot.yml` automatically opens PRs for Docker images in
+`/services` and GitHub Actions (weekly, Mondays). This skill covers the gaps:
+pre-commit hook versions, CLI tool versions in README.md, tool versions
+hard-coded in CI `run:` steps, and cross-checking that Dependabot PRs have
+not stalled. When Dependabot opens a PR for a component in this inventory,
+close the corresponding issue from this skill if one was opened for the same
+bump.
 
 ## Common Mistakes
 
 - Updating docker-compose.yml but not README.md for the same tool version
-- Updating pre-commit rev but not the matching CI workflow pin (yamllint, gitleaks)
-- Pulling an RC or architecture-specific tag (check for `-rc`, `-rocm`, `-cuda` suffixes)
+- Updating a pre-commit rev but not the matching CI workflow pin (yamllint,
+  gitleaks)
+- Pulling an RC or architecture-specific tag (`-rc`, `-rocm`, `-cuda`)
 - Updating Ollama without testing model inference after restart
 - Batching too many updates in one PR -- prefer one component per PR so
   regressions are easy to bisect

--- a/.claude/skills/check-updates/references/update-reference.md
+++ b/.claude/skills/check-updates/references/update-reference.md
@@ -1,0 +1,195 @@
+# Update reference -- component inventory, lookups, and update locations
+
+## Contents
+
+- Component inventory (four categories)
+- Version lookup commands
+- Update locations by category
+- Issue body template
+
+## Component inventory
+
+Every line below is a canonical version source -- do not check anywhere else.
+
+### Category 1 -- Stack services (services/docker-compose.yml)
+
+Extract all pinned image tags:
+
+```bash
+grep "image:" services/docker-compose.yml | grep -v "#" | \
+  sed 's/.*image: //' | sort
+```
+
+| Service | Compose key | Registry |
+|---------|------------|---------|
+| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
+| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
+| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
+| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
+| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
+| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
+| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
+| Grafana | `grafana/grafana:<tag>` | GitHub releases |
+| Loki | `grafana/loki:<tag>` | GitHub releases |
+| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
+| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
+| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
+| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
+
+### Category 2 -- Pre-commit hooks (.pre-commit-config.yaml)
+
+```bash
+grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
+```
+
+| Hook | GitHub repo | Rev field |
+|------|-------------|-----------|
+| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
+| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
+| yamllint | adrienverge/yamllint | `rev:` |
+| gitleaks | gitleaks/gitleaks | `rev:` |
+
+### Category 3 -- GitHub Actions (.github/workflows/*.yml)
+
+```bash
+grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
+  sed 's/.*uses: //' | sort -u
+```
+
+| Action | Pinned in |
+|--------|-----------|
+| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
+| actions/dependency-review-action | dependency-review.yml |
+| docker/setup-buildx-action | bash-ci.yml |
+| github/codeql-action/init | codeql.yml |
+| github/codeql-action/analyze | codeql.yml |
+
+### Category 4 -- Developer CLI tools (README.md + CI)
+
+Versions are pinned in two places that must stay in sync:
+
+| Tool | README.md install | CI workflow |
+|------|------------------|-------------|
+| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
+| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
+| git-cliff | README.md curl install | not used in CI |
+| yamllint | README.md pip install | documentation-checks.yml pip install |
+
+## Version lookup commands
+
+Use GitHub releases (more reliable) wherever available; fall back to Docker
+Hub.
+
+```bash
+# Stack services -- GitHub releases
+for repo in \
+  "ollama/ollama" \
+  "open-webui/open-webui" \
+  "google/cadvisor" \
+  "grafana/loki" \
+  "prometheus/prometheus" \
+  "prometheus/alertmanager" \
+  "grafana/grafana" \
+  "prometheus/node_exporter" \
+  "prometheus-community/postgres_exporter" \
+  "utkuozdemir/nvidia_gpu_exporter"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+
+# Stack services -- Docker Hub (for images without GitHub releases)
+for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
+  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
+    python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
+print(tags[0] if tags else 'check manually')
+" 2>/dev/null)
+  echo "$image: $latest"
+done
+
+# Pre-commit hooks and CLI tools
+for repo in \
+  "pre-commit/pre-commit-hooks" \
+  "shellcheck-py/shellcheck-py" \
+  "adrienverge/yamllint" \
+  "gitleaks/gitleaks" \
+  "orhun/git-cliff" \
+  "koalaman/shellcheck" \
+  "actions/checkout" \
+  "actions/dependency-review-action" \
+  "docker/setup-buildx-action" \
+  "github/codeql-action"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+```
+
+## Update locations by category
+
+**Stack service (docker-compose.yml):**
+```bash
+# For services with multiple instances (e.g. vault), update all occurrences
+grep -n "image:.*<component>" services/docker-compose.yml
+# Edit each line, then validate
+docker compose -f services/docker-compose.yml config > /dev/null
+```
+
+**Pre-commit hook (.pre-commit-config.yaml):**
+```bash
+# Update the rev: field for the relevant repo entry, then verify
+pre-commit autoupdate --repo https://github.com/<owner>/<repo>
+# Or edit manually, then:
+pre-commit run --all-files
+```
+
+**GitHub Action (.github/workflows/*.yml):**
+```bash
+# Update the uses: line in every workflow that references the action
+grep -rn "uses:.*<action>" .github/workflows/
+yamllint -c .yamllint.yml .github/workflows/
+```
+
+**CLI tool (README.md + CI workflow):**
+```bash
+# Must update both locations atomically:
+# 1. README.md -- curl install URL and version comment
+# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
+#    or documentation-checks.yml pip install line (for yamllint)
+grep -n "<tool>" README.md
+grep -rn "<tool>" .github/workflows/
+```
+
+## Issue body template
+
+```bash
+gh issue create --repo xencon/aixcl \
+  --title "[TASK] Update <component> from <old> to <new>" \
+  --body "## Update
+
+- Component: \`<component>\`
+- Current: \`<old>\`
+- Latest: \`<new>\`
+- Release notes: <URL>
+
+## Checklist
+
+- [ ] Image tag updated in \`services/docker-compose.yml\`
+- [ ] Version updated in README.md install section (if CLI tool)
+- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
+- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
+- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
+- [ ] \`./aixcl stack status\` shows all services healthy" \
+  --assignee <assignee> \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+For Ollama (runtime core invariant), add to the issue body:
+
+```
+> [!WARNING]
+> Ollama is a runtime core invariant. Test inference with at least one
+> model before merging. Confirm the OpenAI-compatible API endpoint
+> (/v1/chat/completions) responds correctly after the upgrade.
+```

--- a/.claude/skills/housekeeping/SKILL.md
+++ b/.claude/skills/housekeeping/SKILL.md
@@ -1,25 +1,31 @@
 ---
 name: housekeeping
-description: Comprehensive repository health check covering hygiene, security, and code quality
+description: >
+  Repository health check and session-startup status sweep: memory recall,
+  hygiene, security, code quality, and open-work triage, ending in a status
+  report with priorities. Use at session start, periodically, or before a
+  release. Triggers on "housekeeping", "start day", "what's the status",
+  "where did we leave off", "repo health check".
+argument-hint: <optional: 'all' or specific step numbers>
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance
-  version: "2.1"
+  version: "3.0"
 ---
 
 # Skill: housekeeping
 
 ## Purpose
 
-Catch accumulated debt across the repository: broken links, mirror drift,
-stale branches, permission problems, secrets, unpinned images, and shell
-regressions. The mechanical checks run through `./aixcl checks all`; this
-skill adds the checks that need GitHub state or human judgment.
+Catch accumulated debt across the repository and orient the session: broken
+links, mirror drift, stale branches, permission problems, secrets, unpinned
+images, shell regressions, and open-work state. Report findings and wait for
+direction -- take no corrective action until directed.
 
 ## When to Run
 
-Periodically, or before a release. Each check is independent -- a failure in
-one does not block the others.
+At session start, periodically, or before a release. Each check is
+independent -- a failure in one does not block the others.
 
 ## Preconditions
 
@@ -27,237 +33,116 @@ one does not block the others.
 - [ ] `gh` authenticated (`gh auth status`)
 - [ ] No uncommitted changes that would pollute diff checks
 
+## Delegation
+
+The mechanical steps (4, 5, 9, 10, 11) fit the delegate skill's tier rubric
+and may be delegated to the OpenCode peer -- strictly one at a time, per the
+delegate skill's sequential-only rule. If delegation fails, run the commands
+directly. Steps needing GitHub state or judgment (0, 2, 3, 12) stay with the
+primary agent.
+
+Command blocks for every step: [references/step-commands.md](references/step-commands.md).
+
 ## Steps
+
+### Step 0 -- Read Memory
+
+Read project memory (MEMORY.md index plus files relevant to open work). Note
+what was in progress, what was blocked, and what the last session
+recommended.
+
+- [ ] In-progress work, blockers, and last-session recommendations noted
 
 ### Step 1 -- Mechanical Sweep
 
-```bash
-./aixcl checks all
-```
+`./aixcl checks all` -- covers documentation paths, mirror parity, elision
+guard, generated and dated files (lean policy), ASCII markdown, image pins,
+profile-vs-contract reconciliation, yamllint, compose validation, and
+environment prerequisites. Fix anything red before continuing.
 
-Covers: documentation paths, mirror parity, elision guard, generated and
-dated files (lean policy), ASCII markdown, image pins, profile-vs-contract
-reconciliation, yamllint, compose validation, and environment
-prerequisites. Fix anything red before continuing.
+- [ ] All checks green
 
-### Step 2 -- Branch Hygiene (Merged Branches and Fork Sync)
+### Step 2 -- Branch Hygiene
 
-```bash
-git fetch --prune origin 2>/dev/null; git fetch --prune upstream 2>/dev/null || true
-
-# Stale merged branches
-git branch -r --merged upstream/dev 2>/dev/null \
-  | grep -v 'upstream/dev\|upstream/main\|origin/dev\|origin/main\|HEAD' \
-  || echo "ok: no stale merged remote branches"
-
-# Fork sync with upstream dev
-upstream_ahead=$(git rev-list origin/dev..upstream/dev 2>/dev/null | wc -l | tr -d ' ')
-if [ "$upstream_ahead" -gt 0 ]; then
-  echo "WARN: origin/dev is $upstream_ahead commit(s) behind upstream/dev"
-  echo "  Fix: git checkout dev && git pull upstream dev && git push origin dev"
-else
-  echo "ok: origin/dev is in sync with upstream/dev"
-fi
-```
+Stale merged branches; fork sync between `origin/dev` and `upstream/dev`.
 
 - [ ] No merged remote branches outstanding, or owner notified to delete
-- [ ] `origin/dev` is in sync with `upstream/dev`, or sync performed
+- [ ] `origin/dev` in sync with `upstream/dev`, or sync performed
 
 ### Step 3 -- Issue and PR Hygiene
 
-Open issues missing a required `component:*` label:
+Open issues missing a `component:*` label; open PRs missing an assignee.
 
-```bash
-gh issue list --repo xencon/aixcl --state open --limit 100 \
-  --json number,title,labels,assignees \
-  --jq '.[] | select(.labels | map(.name) | any(startswith("component:")) | not)
-        | "  #\(.number) \(.title)"'
-```
-
-Open PRs missing an assignee:
-
-```bash
-gh pr list --repo xencon/aixcl --state open --limit 100 \
-  --json number,title,assignees \
-  --jq '.[] | select(.assignees | length == 0) | "  #\(.number) \(.title)"'
-```
-
-- [ ] All open issues have at least one `component:*` label, or flagged for triage
-- [ ] All open PRs have an assignee, or flagged for triage
+- [ ] All open issues labeled, all open PRs assigned, or flagged for triage
 
 ### Step 4 -- Line Endings
 
-```bash
-grep -rlP "\r\n" --include="*.md" --include="*.sh" --include="*.yml" \
-  --exclude-dir=.git . 2>/dev/null \
-  && echo "FAIL: CRLF line endings found" || echo "ok: LF only"
-```
-
 - [ ] No CRLF line endings
 
-### Step 5 -- Generated Env File Integrity (Duplicate Keys)
+### Step 5 -- Env File Integrity
 
-Duplicate keys in `.env.*` or `*.env` files indicate an append bug (e.g. a
-setup script running multiple times and stacking entries instead of rewriting).
+Duplicate keys in env files indicate an append bug.
 
-```bash
-for f in $(find . \( -name ".env*" -o -name "*.env" \) \
-           -not -path "./.git/*" -not -name "*.example" -type f); do
-  dupes=$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$f" \
-          | cut -d= -f1 | sort | uniq -d)
-  if [ -n "$dupes" ]; then
-    echo "DUPLICATE KEYS in $f: $dupes"
-  else
-    echo "ok: $f"
-  fi
-done
-```
-
-- [ ] No duplicate keys found in any env file
+- [ ] No duplicate keys in any env file
 
 ### Step 6 -- File Permissions (Sensitive Files)
 
-Runtime env files must not be world-readable or world-writable. Expected
-mode: `600` (owner read/write only). Tracked config files in
-`config/profiles/` are excluded -- they contain service names and ports,
-not secrets.
+Runtime env files, keys, and certs must be mode `600`.
 
-```bash
-find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
-          -o -name "*.token" -o -name "*.pem" -o -name "*.crt" \) \
-  -not -path "./.git/*" \
-  -not -path "./config/profiles/*" \
-  -not -name "*.example" \
-  -type f \
-  | while read -r f; do
-      perms=$(stat -c "%a" "$f" 2>/dev/null || stat -f "%OLp" "$f" 2>/dev/null)
-      if echo "$perms" | grep -qE "[1-7]$"; then
-        echo "WORLD-READABLE or WRITABLE: $f ($perms) -- run: chmod 600 $f"
-      else
-        echo "ok: $f ($perms)"
-      fi
-    done
-```
-
-- [ ] No sensitive runtime env files are world-readable or world-writable
+- [ ] No sensitive runtime files world-readable or world-writable
 - [ ] Files under `vault/` or `security/` paths checked specifically
-- [ ] Note: to check whether a file is tracked in git, use `git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0 even when the file is not tracked, making `&& echo TRACKED` a false positive.
 
 ### Step 7 -- Secret Scanning
 
-Scan tracked files for common secret patterns. If `gitleaks` is installed,
-prefer it. Otherwise use grep patterns as a baseline.
+gitleaks if installed, grep baseline otherwise.
 
-```bash
-if command -v gitleaks > /dev/null 2>&1; then
-  gitleaks detect --source . --no-git 2>&1 | tail -20
-else
-  grep -rEn \
-    "(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_\-]{20,}|sk-[A-Za-z0-9]{40,}|xoxb-[A-Za-z0-9\-]+|VAULT_TOKEN=[A-Za-z0-9.\-]{20,})" \
-    --include="*.md" --include="*.yml" --include="*.yaml" \
-    --include="*.sh" --include="*.json" --include="*.env*" \
-    --exclude-dir=.git . 2>/dev/null \
-    && echo "FAIL: potential secrets found above" || echo "ok: no common secret patterns matched"
-fi
-```
-
-- [ ] No secrets detected
-- [ ] If gitleaks not installed, note it as a tooling gap
-- [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
+- [ ] No secrets detected (gitleaks absence noted as a tooling gap)
 
 ### Step 8 -- Container Image Pin Hygiene
 
-Covers compose files AND shell code under `lib/` and `scripts/` -- four
-unpinned alpine references hid in shell code because the old sweep only
-scanned compose (issue #1726). Legitimate `:latest` uses (locally built
-`localhost/` images, ollama model tags) are exempted via `localhost/`
-detection or an inline `pin-waiver:` comment.
+`./aixcl checks pins` -- covers compose files AND shell code under `lib/`
+and `scripts/` (unpinned references have hidden in shell code before, #1726).
 
-```bash
-./aixcl checks pins
-```
+- [ ] All image references pinned or carrying a `pin-waiver:` comment
 
-- [ ] All container image references are pinned (no `latest`, no bare image names), or carry an explicit `pin-waiver:` comment with a reason
+### Step 9 -- Shellcheck Sweep
 
-### Step 9 -- Shellcheck Sweep (All Scripts)
-
-```bash
-issues=$(find . -name "*.sh" -not -path "./.git/*" \
-  | xargs shellcheck --severity=warning --exclude=SC1091 2>&1)
-if [ -n "$issues" ]; then
-  echo "$issues" | head -40
-  echo "FAIL: shellcheck issues found"
-else
-  echo "ok: all scripts clean"
-fi
-```
-
-- [ ] No shellcheck warnings or errors at severity `warning` or above
+- [ ] No warnings at severity `warning` or above across all scripts
 
 ### Step 10 -- UPSTREAM-ISSUES.md Staleness
 
-```bash
-if [ -f UPSTREAM-ISSUES.md ]; then
-  echo "UPSTREAM-ISSUES.md exists -- review entries manually:"
-  grep -E "^##|^- " UPSTREAM-ISSUES.md | head -30
-  echo ""
-  echo "File last modified: $(git log -1 --format='%ar' -- UPSTREAM-ISSUES.md)"
-else
-  echo "ok: UPSTREAM-ISSUES.md does not exist"
-fi
-```
-
-- [ ] No entries older than 7 days without a corresponding upstream issue
-- [ ] Entries that have been filed upstream are removed from the file
+- [ ] No entries older than 7 days without a filed upstream issue
+- [ ] Filed entries removed from the file
 
 ### Step 11 -- Agent Scratch/Temp File Hygiene
 
-Verification work (podman test harnesses, permission/capability checks) leaves
-temporary artifacts outside the repository tree -- stub secrets directories,
-throwaway config copies, test containers/volumes, scratchpad drafts of PR and
-issue bodies. None of the steps above catch this since they only look inside
-the repo; it was found here by chance, not by systematic check.
+Stray `/tmp` harness directories, lingering podman test containers/volumes,
+stale scratchpad drafts. Detection only -- review before deleting anything.
 
-```bash
-# Stray /tmp directories from prior harness/verification runs (adjust the
-# glob to match your own session's naming convention if it differs)
-find /tmp -maxdepth 1 \( -iname "aixcl-harness-*" -o -iname "*-harness-*" \) 2>/dev/null
+- [ ] No stray harness artifacts or stale scratchpad drafts
 
-# Lingering podman test containers/volumes from harness runs
-podman ps -a --filter "name=harness" --format "{{.Names}}" 2>&1
-podman volume ls --filter "name=harness" --format "{{.Name}}" 2>&1
+### Step 12 -- Status Report and Priorities
 
-# This session's scratchpad directory -- safe to clear once every draft's
-# real content has landed on GitHub (issue/PR bodies, once filed, live
-# there; the local draft file is disposable afterward)
-ls -la "$CLAUDE_SCRATCHPAD_DIR" 2>/dev/null || true
-```
-
-- [ ] No stray `/tmp` directories from this or prior sessions' test harnesses
-- [ ] No lingering podman test containers/volumes matching a harness naming pattern
-- [ ] Scratchpad cleared of drafts whose content has already landed on GitHub
-- [ ] Note: this step only lists/detects -- review what's found before deleting anything, same as every other step in this skill; never blind-delete a match without confirming it's actually stale
-
-## Verification
-
-Record findings after all steps:
+Compile the single report:
 
 ```
-Step 1  -- Mechanical sweep (aixcl checks all):  [ ] clean  [ ] failures
-Step 2  -- Branch hygiene:                       [ ] clean  [ ] stale branches / fork drift
-Step 3  -- Issue/PR hygiene:                     [ ] clean  [ ] missing labels/assignees
-Step 4  -- Line endings:                         [ ] clean  [ ] CRLF found
-Step 5  -- Env file integrity:                   [ ] clean  [ ] duplicates
-Step 6  -- File permissions:                     [ ] clean  [ ] overexposed
-Step 7  -- Secret scanning:                      [ ] clean  [ ] matches
-Step 8  -- Image pin hygiene:                    [ ] clean  [ ] unpinned
-Step 9  -- Shellcheck sweep:                     [ ] clean  [ ] warnings
-Step 10 -- UPSTREAM-ISSUES.md:                   [ ] clean  [ ] stale entries
-Step 11 -- Agent scratch/temp file hygiene:      [ ] clean  [ ] stray /tmp or scratchpad debt
+Step 0  -- Memory recall:            <in-progress work / blockers>
+Step 1  -- Mechanical sweep:         [ ] clean  [ ] failures
+Step 2  -- Branch hygiene:           [ ] clean  [ ] drift/stale
+Step 3  -- Issue/PR hygiene:         [ ] clean  [ ] gaps
+Step 4  -- Line endings:             [ ] clean  [ ] CRLF
+Step 5  -- Env file integrity:       [ ] clean  [ ] duplicates
+Step 6  -- File permissions:         [ ] clean  [ ] overexposed
+Step 7  -- Secret scanning:          [ ] clean  [ ] matches
+Step 8  -- Image pin hygiene:        [ ] clean  [ ] unpinned
+Step 9  -- Shellcheck sweep:         [ ] clean  [ ] warnings
+Step 10 -- UPSTREAM-ISSUES.md:       [ ] clean  [ ] stale
+Step 11 -- Scratch/temp hygiene:     [ ] clean  [ ] debt
 ```
 
-Any `items found` result should become a follow-up issue before the next
-release. Critical findings from steps 6 and 7 should be treated as P1.
+Follow with a recommended priority order for anything found (critical
+findings from steps 6 and 7 are P1; other findings become follow-up issues
+before the next release) and **wait for direction**.
 
 ## Common Mistakes
 
@@ -268,3 +153,5 @@ release. Critical findings from steps 6 and 7 should be treated as P1.
   allowlist the path in `.gitleaks.toml` instead
 - Deleting a remote branch that has an open PR -- check the PR state is
   MERGED first (a closed PR is not a merged PR)
+- Running delegated checks in parallel -- the delegation log is
+  sequential-only

--- a/.claude/skills/housekeeping/references/step-commands.md
+++ b/.claude/skills/housekeeping/references/step-commands.md
@@ -1,0 +1,170 @@
+# Housekeeping step commands
+
+Command blocks for each housekeeping step. Run from the repository root.
+
+## Contents
+
+- Step 2: Branch hygiene
+- Step 3: Issue and PR hygiene
+- Step 4: Line endings
+- Step 5: Env file integrity
+- Step 6: File permissions
+- Step 7: Secret scanning
+- Step 9: Shellcheck sweep
+- Step 10: UPSTREAM-ISSUES.md staleness
+- Step 11: Agent scratch/temp file hygiene
+
+## Step 2: Branch hygiene
+
+```bash
+git fetch --prune origin 2>/dev/null; git fetch --prune upstream 2>/dev/null || true
+
+# Stale merged branches
+git branch -r --merged upstream/dev 2>/dev/null \
+  | grep -v 'upstream/dev\|upstream/main\|origin/dev\|origin/main\|HEAD' \
+  || echo "ok: no stale merged remote branches"
+
+# Fork sync with upstream dev
+upstream_ahead=$(git rev-list origin/dev..upstream/dev 2>/dev/null | wc -l | tr -d ' ')
+if [ "$upstream_ahead" -gt 0 ]; then
+  echo "WARN: origin/dev is $upstream_ahead commit(s) behind upstream/dev"
+  echo "  Fix: git checkout dev && git pull upstream dev && git push origin dev"
+else
+  echo "ok: origin/dev is in sync with upstream/dev"
+fi
+```
+
+## Step 3: Issue and PR hygiene
+
+```bash
+# Open issues missing a required component:* label
+gh issue list --repo xencon/aixcl --state open --limit 100 \
+  --json number,title,labels,assignees \
+  --jq '.[] | select(.labels | map(.name) | any(startswith("component:")) | not)
+        | "  #\(.number) \(.title)"'
+
+# Open PRs missing an assignee
+gh pr list --repo xencon/aixcl --state open --limit 100 \
+  --json number,title,assignees \
+  --jq '.[] | select(.assignees | length == 0) | "  #\(.number) \(.title)"'
+```
+
+## Step 4: Line endings
+
+```bash
+grep -rlP "\r\n" --include="*.md" --include="*.sh" --include="*.yml" \
+  --exclude-dir=.git . 2>/dev/null \
+  && echo "FAIL: CRLF line endings found" || echo "ok: LF only"
+```
+
+## Step 5: Env file integrity (duplicate keys)
+
+Duplicate keys in `.env.*` or `*.env` files indicate an append bug (e.g. a
+setup script running multiple times and stacking entries instead of
+rewriting).
+
+```bash
+for f in $(find . \( -name ".env*" -o -name "*.env" \) \
+           -not -path "./.git/*" -not -name "*.example" -type f); do
+  dupes=$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$f" \
+          | cut -d= -f1 | sort | uniq -d)
+  if [ -n "$dupes" ]; then
+    echo "DUPLICATE KEYS in $f: $dupes"
+  else
+    echo "ok: $f"
+  fi
+done
+```
+
+## Step 6: File permissions (sensitive files)
+
+Runtime env files must not be world-readable or world-writable. Expected
+mode: `600`. Tracked config files in `config/profiles/` are excluded -- they
+contain service names and ports, not secrets.
+
+```bash
+find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
+          -o -name "*.token" -o -name "*.pem" -o -name "*.crt" \) \
+  -not -path "./.git/*" \
+  -not -path "./config/profiles/*" \
+  -not -name "*.example" \
+  -type f \
+  | while read -r f; do
+      perms=$(stat -c "%a" "$f" 2>/dev/null || stat -f "%OLp" "$f" 2>/dev/null)
+      if echo "$perms" | grep -qE "[1-7]$"; then
+        echo "WORLD-READABLE or WRITABLE: $f ($perms) -- run: chmod 600 $f"
+      else
+        echo "ok: $f ($perms)"
+      fi
+    done
+```
+
+Note: to check whether a file is tracked in git, use
+`git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0
+even when the file is not tracked, making `&& echo TRACKED` a false positive.
+
+## Step 7: Secret scanning
+
+```bash
+if command -v gitleaks > /dev/null 2>&1; then
+  gitleaks detect --source . --no-git 2>&1 | tail -20
+else
+  grep -rEn \
+    "(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_\-]{20,}|sk-[A-Za-z0-9]{40,}|xoxb-[A-Za-z0-9\-]+|VAULT_TOKEN=[A-Za-z0-9.\-]{20,})" \
+    --include="*.md" --include="*.yml" --include="*.yaml" \
+    --include="*.sh" --include="*.json" --include="*.env*" \
+    --exclude-dir=.git . 2>/dev/null \
+    && echo "FAIL: potential secrets found above" || echo "ok: no common secret patterns matched"
+fi
+```
+
+Note: `--no-git` scans ALL files on disk, including gitignored runtime files
+(e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in
+the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
+
+## Step 9: Shellcheck sweep
+
+```bash
+issues=$(find . -name "*.sh" -not -path "./.git/*" \
+  | xargs shellcheck --severity=warning --exclude=SC1091 2>&1)
+if [ -n "$issues" ]; then
+  echo "$issues" | head -40
+  echo "FAIL: shellcheck issues found"
+else
+  echo "ok: all scripts clean"
+fi
+```
+
+## Step 10: UPSTREAM-ISSUES.md staleness
+
+```bash
+if [ -f UPSTREAM-ISSUES.md ]; then
+  echo "UPSTREAM-ISSUES.md exists -- review entries manually:"
+  grep -E "^##|^- " UPSTREAM-ISSUES.md | head -30
+  echo ""
+  echo "File last modified: $(git log -1 --format='%ar' -- UPSTREAM-ISSUES.md)"
+else
+  echo "ok: UPSTREAM-ISSUES.md does not exist"
+fi
+```
+
+## Step 11: Agent scratch/temp file hygiene
+
+Verification work (podman test harnesses, permission/capability checks)
+leaves temporary artifacts outside the repository tree. Detection only --
+review what is found before deleting anything.
+
+```bash
+# Stray /tmp directories from prior harness/verification runs (adjust the
+# glob to match your own session's naming convention if it differs)
+find /tmp -maxdepth 1 \( -iname "aixcl-harness-*" -o -iname "*-harness-*" \) 2>/dev/null
+
+# Lingering podman test containers/volumes from harness runs
+podman ps -a --filter "name=harness" --format "{{.Names}}" 2>&1
+podman volume ls --filter "name=harness" --format "{{.Name}}" 2>&1
+
+# This session's scratchpad directory -- safe to clear once every draft's
+# real content has landed on GitHub (issue/PR bodies, once filed, live
+# there; the local draft file is disposable afterward)
+ls -la "$CLAUDE_SCRATCHPAD_DIR" 2>/dev/null || true
+```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: release
-description: Guided workflow for cutting an AIXCL release, fronting the aixcl release command
+description: >
+  Guided workflow for cutting an AIXCL release, fronting the aixcl release
+  command: retrospective, changelog judgment, tag, announcement, and sync.
+  Operator-gated (disable-model-invocation) -- run only when the maintainer
+  explicitly asks to cut a release.
 compatibility: OpenCode, Claude Code
 disable-model-invocation: true
 metadata:
   category: workflow
-  version: "2.0"
+  version: "2.1"
 ---
 
 # Skill: release
@@ -54,6 +58,8 @@ advisory -- the human may proceed once formal CI and review checks are
 complete, even if one agent has nothing material to add.
 
 ```bash
+# Repository and category IDs are xencon/aixcl constants; re-derive with
+# `gh api graphql` repository/discussionCategories queries if they change
 gh api graphql -f query='
 mutation {
   createDiscussion(input: {

--- a/.claude/skills/workflow-guard/SKILL.md
+++ b/.claude/skills/workflow-guard/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: workflow-guard
-description: Validates Issue-First workflow compliance before execution
+description: >
+  Validates Issue-First workflow compliance before execution: issue, branch,
+  commit, PR, and security requirements. Use before starting any code change
+  and again before creating a PR. Triggers on "check workflow compliance",
+  "validate the workflow", "am I following the process", or starting work
+  without a clear issue reference.
+argument-hint: <issue or PR number to validate>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
   security_level: critical
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Skill: workflow-guard
@@ -50,17 +56,18 @@ creating a PR.
 - [ ] PR references issue: `Fixes #<number>` in body
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
-- [ ] All CI checks pass (validate this with @verify agent)
+- [ ] All CI checks pass (`gh pr checks <number>`)
 - [ ] Agent identification block present in PR body (agent-authored PRs only)
   ```bash
   echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
   ```
 
 ### 5. Security Requirements
-- [ ] Security-gate agent has scanned changes
-- [ ] No secrets detected
-- [ ] No CRITICAL or HIGH severity vulnerabilities
-- [ ] Human approval obtained for critical actions
+- [ ] No secrets in the diff (gitleaks runs in CI; grep the staged diff for
+      token patterns before pushing)
+- [ ] No CRITICAL or HIGH severity findings from CI security workflows
+      (ShellCheck, dependency review, obfuscation patterns)
+- [ ] Human approval obtained for critical actions (see below)
 
 ## Workflow State Machine
 
@@ -127,33 +134,32 @@ gh pr view <number> --json assignees,labels,title,body
 
 If any validation step fails:
 
-1. **Log the failure** with full context
-2. **Block execution** of the action
-3. **Provide remediation** guidance
-4. **Alert human** via @security-gate agent
+1. **Stop** -- do not proceed with the blocked action
+2. **Report** the failure with full context and remediation guidance
+3. **Escalate** security concerns to the operator with a `[SECURITY]` prefix
+   (AGENTS.md Section 7); everything else per the escalation procedures
 
 ## Example Usage
 
 ```
-@orchestrator Please validate the workflow for issue #917
-
-Agent loads this skill and runs validation:
+Validate the workflow for issue #917:
 1. Check issue #917 exists [x]
-2. Check issue is assigned [x]
-3. Check branch issue-917/security-first-agentic-foundation format [x]
+2. Check issue is assigned and labeled [x]
+3. Check branch issue-917/<description> format [x]
 4. Check branch from dev [x]
 5. Check commits reference #917 [x]
-6. Check security-gate approval [x]
+6. Check no secrets or elisions in the staged diff [x]
 
 Result: All validations passed. Workflow approved.
 ```
 
 ## Integration
 
-This skill is automatically invoked by:
-- @orchestrator agent for workflow coordination
-- @security-gate agent for compliance validation
-- GitHub Actions for CI/CD enforcement
+Run this skill yourself before starting code changes and again before
+creating a PR. CI independently enforces the same rules
+(`pr-validation.yml`, `bash-ci.yml`, `security.yml`), and
+`./aixcl checks pr-ready <N>` re-validates everything at merge time --
+this skill exists to catch violations before they reach CI.
 
 ## Compliance Rules
 
@@ -172,5 +178,5 @@ Before claiming compliance, verify:
 - [ ] All AGENTS.md rules followed
 - [ ] All DEVELOPMENT.md rules followed
 - [ ] All platform invariants preserved
-- [ ] Security gate approval obtained
+- [ ] Security requirements above checked
 - [ ] Audit trail will be complete

--- a/.opencode/skills/CONTEXT.md
+++ b/.opencode/skills/CONTEXT.md
@@ -1,0 +1,48 @@
+# CONTEXT: skills/
+
+Agent skills following the [Agent Skills open standard](https://agentskills.io).
+This directory and its counterpart (`.claude/skills/` <-> `.opencode/skills/`)
+are byte-identical mirrors, enforced by `check-agents.sh` and CI
+(`check-opencode.yml`). **Edit both sides together, always.**
+
+## Catalog
+
+| Skill | Category | Purpose |
+|-------|----------|---------|
+| `add-service` | platform | Checklist for adding an operational service without breaking invariants |
+| `check-updates` | maintenance | Audit versioned components; manage updates issue-first |
+| `delegate` | workflow | Route mechanistic sub-tasks to the OpenCode peer (sequential, logged) |
+| `delegate-review` | workflow | Analytics over the delegation log |
+| `grill-with-docs` | workflow | Stress-test a plan against the codebase before implementing |
+| `housekeeping` | maintenance | Repo health + session-startup sweep, status report with priorities |
+| `investigate` | workflow | Root-cause-first bug investigation; no fixing until complete |
+| `issue-triage` | workflow | End-to-end GitHub issue workflow with design and CI-parity gates |
+| `release` | workflow | Cut a release (operator-gated via disable-model-invocation) |
+| `reviewing-skills` | maintenance | Audit SKILL.md files against authoring best practices |
+| `session-review` | workflow | End-of-session delegation feedback loop |
+| `workflow-guard` | workflow | Validate issue-first compliance before execution |
+
+How they interlock: `housekeeping` orients the session and may hand
+mechanical checks to `delegate`; `issue-triage` drives an issue end to end,
+calling `grill-with-docs` to validate the design and `investigate` for bugs;
+`session-review` closes the delegation loop that `delegate` logs;
+`reviewing-skills` lints all of the above.
+
+## Agent Guidance
+
+**You MAY:**
+- Add a new skill (directory + SKILL.md, kebab-case name matching frontmatter)
+- Update skills when policy or tooling changes (bump `metadata.version`)
+
+**You MUST NOT:**
+- Edit one side of the mirror without the other (`./aixcl checks agents`)
+- Merge a skill change without running the `reviewing-skills` audit on it
+- Use non-ASCII characters or reference tools the repository does not have
+
+## Conventions
+
+- Frontmatter: `name`, `description` (with trigger phrases), optional
+  `argument-hint`, `compatibility`, `metadata.category`/`metadata.version`
+- SKILL.md stays under 500 lines / 5KB; bulky material goes to
+  `references/` (one level deep, table of contents if over 100 lines)
+- Update this catalog in the same PR that adds, renames, or removes a skill

--- a/.opencode/skills/add-service/SKILL.md
+++ b/.opencode/skills/add-service/SKILL.md
@@ -1,10 +1,16 @@
 ---
 name: add-service
-description: Guided checklist for safely adding a new platform service to AIXCL, preserving all invariants
+description: >
+  Guided checklist for safely adding a new operational service to the AIXCL
+  stack, preserving all platform invariants (host networking, pinned images,
+  runtime/operational boundary, profile registration). Use when adding a
+  service to docker-compose, wiring a new container into the stack, or asked
+  to "add a service", "add <tool> to the stack", "new compose service".
+argument-hint: <service name and purpose>
 compatibility: OpenCode, Claude Code
 metadata:
   category: platform
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Skill: add-service

--- a/.opencode/skills/check-updates/SKILL.md
+++ b/.opencode/skills/check-updates/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: check-updates
-description: Audit all versioned platform components and manage the update process following issue-first workflow
+description: >
+  Audit all versioned platform components (stack images, pre-commit hooks,
+  GitHub Actions, CLI tools) and manage updates through the issue-first
+  workflow. Use before a release cycle, after a long gap, or when asked to
+  "check updates", "audit versions", "what's outdated", "bump components".
+argument-hint: <optional: category to audit, or blank for all>
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Skill: check-updates
@@ -15,329 +20,91 @@ Audit every versioned component in the AIXCL platform and produce an
 actionable update report. For each outdated component, open a GitHub issue
 and apply the update following the issue-first workflow.
 
+The component inventory, version lookup commands, per-category update
+locations, and the issue body template live in
+[references/update-reference.md](references/update-reference.md).
+
 ## When to Run
 
 Before a release cycle or after a long gap between releases.
 
----
-
-## Component Inventory
-
-The platform versions four categories of components. Every line below is a
-canonical version source -- do not check anywhere else.
-
-### Category 1 -- Stack Services (services/docker-compose.yml)
-
-Extract all pinned image tags:
-
-```bash
-grep "image:" services/docker-compose.yml | grep -v "#" | \
-  sed 's/.*image: //' | sort
-```
-
-| Service | Compose key | Registry |
-|---------|------------|---------|
-| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
-| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
-| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
-| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
-| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
-| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
-| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
-| Grafana | `grafana/grafana:<tag>` | GitHub releases |
-| Loki | `grafana/loki:<tag>` | GitHub releases |
-| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
-| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
-| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
-| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
-
-### Category 2 -- Pre-commit Hooks (.pre-commit-config.yaml)
-
-```bash
-grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
-```
-
-| Hook | GitHub repo | Rev field |
-|------|-------------|-----------|
-| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
-| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
-| yamllint | adrienverge/yamllint | `rev:` |
-| gitleaks | gitleaks/gitleaks | `rev:` |
-
-### Category 3 -- GitHub Actions (.github/workflows/*.yml)
-
-```bash
-grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
-  sed 's/.*uses: //' | sort -u
-```
-
-| Action | Pinned in |
-|--------|-----------|
-| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
-| actions/dependency-review-action | dependency-review.yml |
-| docker/setup-buildx-action | bash-ci.yml |
-| github/codeql-action/init | codeql.yml |
-| github/codeql-action/analyze | codeql.yml |
-
-### Category 4 -- Developer CLI Tools (README.md + CI)
-
-Versions are pinned in two places that must stay in sync:
-
-| Tool | README.md install | CI workflow |
-|------|------------------|-------------|
-| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
-| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
-| git-cliff | README.md curl install | not used in CI |
-| yamllint | README.md pip install | documentation-checks.yml pip install |
-
----
-
 ## Step 1 -- Check Latest Versions
 
-Run these commands to look up the latest stable release for each component.
-Use GitHub releases (more reliable) wherever available; fall back to Docker Hub.
-
-```bash
-# Stack services -- GitHub releases
-for repo in \
-  "ollama/ollama" \
-  "open-webui/open-webui" \
-  "google/cadvisor" \
-  "grafana/loki" \
-  "prometheus/prometheus" \
-  "prometheus/alertmanager" \
-  "grafana/grafana" \
-  "prometheus/node_exporter" \
-  "prometheus-community/postgres_exporter" \
-  "utkuozdemir/nvidia_gpu_exporter"; do
-  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
-  echo "$repo: $latest"
-done
-
-# Stack services -- Docker Hub (for images without GitHub releases)
-for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
-  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
-    python3 -c "
-import sys, json, re
-data = json.load(sys.stdin)
-tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
-print(tags[0] if tags else 'check manually')
-" 2>/dev/null)
-  echo "$image: $latest"
-done
-
-# Pre-commit hooks and CLI tools
-for repo in \
-  "pre-commit/pre-commit-hooks" \
-  "shellcheck-py/shellcheck-py" \
-  "adrienverge/yamllint" \
-  "gitleaks/gitleaks" \
-  "orhun/git-cliff" \
-  "koalaman/shellcheck" \
-  "actions/checkout" \
-  "actions/dependency-review-action" \
-  "docker/setup-buildx-action" \
-  "github/codeql-action"; do
-  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
-  echo "$repo: $latest"
-done
-```
-
----
+Run the lookup commands from the reference (GitHub releases first, Docker Hub
+fallback) against all four categories: stack services, pre-commit hooks,
+GitHub Actions, developer CLI tools.
 
 ## Step 2 -- Build the Update Table
 
-Produce a table with four columns: Component, Category, Pinned, Latest.
-
-Mark each row:
-
-| Symbol | Meaning |
-|--------|---------|
-| current | Pinned == Latest |
-| UPDATE | Newer version available |
-| check | Could not determine latest (check manually) |
-
-Example output:
-
-```
-| Component          | Category       | Pinned   | Latest   | Status  |
-|--------------------|----------------|----------|----------|---------|
-| ollama             | stack-service  | 0.30.7   | 0.31.1   | UPDATE  |
-| prometheus         | stack-service  | v3.12.0  | v3.12.0  | current |
-```
-
----
+Produce a table: Component, Category, Pinned, Latest, Status. Status is one
+of `current` (pinned == latest), `UPDATE` (newer available), `check` (could
+not determine -- verify manually).
 
 ## Step 3 -- Triage Updates
 
-Before opening issues, classify each update:
-
 **Routine (open one issue per component):**
-- Patch version bumps (x.y.Z -> x.y.Z+1)
-- Minor version bumps with no breaking changes noted in release notes
+- Patch bumps (x.y.Z -> x.y.Z+1)
+- Minor bumps with no breaking changes in the release notes
 
 **Review required (open issue, flag for human review):**
-- Major version bumps (X.y.z -> X+1.y.z)
-- Any bump for a component listed in `docs/architecture/governance/00_invariants.md`
-  as a runtime core invariant (currently: Ollama)
-- Any bump where the release notes mention breaking API changes or schema migrations
+- Major version bumps
+- Any bump for a runtime core invariant component (currently: Ollama --
+  see `docs/architecture/governance/00_invariants.md`)
+- Release notes mentioning breaking API changes or schema migrations
 
-**Skip (do not open an issue):**
+**Skip (no issue):**
 - Pre-release tags (alpha, beta, rc, dev)
 - Architecture-specific tags (rocm, cuda, distroless suffixes)
-- Tags that differ only in suffix from the currently pinned version
+- Tags differing only in suffix from the pinned version
 
----
+## Step 4 -- Open Issues (issue-first)
 
-## Step 4 -- Open Issues (issue-first workflow)
-
-Open one issue per component that needs updating. Batch minor patch bumps
-across the same category into a single issue if there are more than three.
-
-```bash
-# Example: single component update
-gh issue create --repo xencon/aixcl \
-  --title "[TASK] Update <component> from <old> to <new>" \
-  --body "## Update
-
-- Component: \`<component>\`
-- Current: \`<old>\`
-- Latest: \`<new>\`
-- Release notes: <URL>
-
-## Checklist
-
-- [ ] Image tag updated in \`services/docker-compose.yml\`
-- [ ] Version updated in README.md install section (if CLI tool)
-- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
-- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
-- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
-- [ ] \`./aixcl stack status\` shows all services healthy" \
-  --assignee <assignee> \
-  --label "Task,component:infrastructure,Maintenance"
-```
-
-For Ollama (runtime core invariant), add to the issue body:
-
-```
-> [!WARNING]
-> Ollama is a runtime core invariant. Test inference with at least one
-> model before merging. Confirm the OpenAI-compatible API endpoint
-> (/v1/chat/completions) responds correctly after the upgrade.
-```
-
----
+One issue per component needing an update, using the template in the
+reference. Batch minor patch bumps in the same category into a single issue
+if there are more than three. Ollama updates get the runtime-core warning
+block.
 
 ## Step 5 -- Apply Updates
 
-Create a branch per issue:
-
-```bash
-git checkout dev
-git checkout -b issue-<N>/update-<component>-<new-version>
-```
-
-### Update locations by category
-
-**Stack service (docker-compose.yml):**
-```bash
-# Replace the image tag -- edit services/docker-compose.yml
-# For services with multiple instances (e.g. vault), update all occurrences
-grep -n "image:.*<component>" services/docker-compose.yml
-# Edit each line, then validate
-docker compose -f services/docker-compose.yml config > /dev/null
-```
-
-**Pre-commit hook (.pre-commit-config.yaml):**
-```bash
-# Update the rev: field for the relevant repo entry
-# Then run pre-commit to verify
-pre-commit autoupdate --repo https://github.com/<owner>/<repo>
-# Or edit manually, then:
-pre-commit run --all-files
-```
-
-**GitHub Action (.github/workflows/*.yml):**
-```bash
-# Update the uses: line in every workflow that references the action
-grep -rn "uses:.*<action>" .github/workflows/
-# Edit each file, then validate YAML
-yamllint -c .yamllint.yml .github/workflows/
-```
-
-**CLI tool (README.md + CI workflow):**
-```bash
-# Must update both locations atomically:
-# 1. README.md -- curl install URL and version comment
-# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
-#    or documentation-checks.yml pip install line (for yamllint)
-grep -n "<tool>" README.md
-grep -rn "<tool>" .github/workflows/
-```
-
----
+Branch per issue from `dev`: `issue-<N>/update-<component>-<new-version>`.
+Edit the locations listed in the reference for that category -- some tools
+are pinned in two places that must change atomically (README.md + CI
+workflow).
 
 ## Step 6 -- Validate and Commit
 
 ```bash
-# Run pre-commit checks
 bash scripts/checks/check-ai-elisions.sh --staged
 shellcheck --severity=warning --exclude=SC1091 $(find . -name "*.sh" -not -path "./.git/*")
 yamllint -c .yamllint.yml .
-
-# Validate compose
 docker compose -f services/docker-compose.yml config > /dev/null
-
-# Stage and commit (GPG -- user must run)
-git add <changed files>
-# Provide commit message:
-# "chore: update <component> from <old> to <new>
-#
-# Fixes #<issue>"
 ```
 
----
+Stage the changes and hand the GPG commit command to the operator
+(`chore: update <component> from <old> to <new>` + `Fixes #<issue>`).
 
 ## Step 7 -- PR and CI
 
-```bash
-git push origin issue-<N>/update-<component>-<new-version>
-
-gh pr create \
-  --repo xencon/aixcl \
-  --base dev \
-  --title "Update <component> from <old> to <new> (#<N>)" \
-  --body "$(cat /tmp/update-pr-body.md)" \
-  --assignee <assignee> \
-  --label "Task,component:infrastructure,Maintenance"
-```
-
-Verify PR body with `check-pr-references.sh` before creating.
-
----
+Push to origin, create the PR against upstream `dev` with title
+`Update <component> from <old> to <new> (#<N>)`, assignee and labels at
+creation time. Validate the body with `check-pr-references.sh` first.
 
 ## Dependabot Coverage Note
 
-`.github/dependabot.yml` automatically opens PRs for:
-- Docker images in `/services` (weekly, Mondays)
-- GitHub Actions in `/.github/workflows` (weekly, Mondays)
-
-This skill covers the gaps Dependabot does not handle:
-- Pre-commit hook versions (`.pre-commit-config.yaml`)
-- CLI tool versions in `README.md` install instructions
-- Tool versions hard-coded in CI workflow `run:` steps (not `uses:`)
-- Cross-checking that Dependabot PRs have not stalled or been missed
-
-When Dependabot opens a PR for a component in this inventory, close the
-corresponding issue from this skill if one was opened for the same version bump.
-
----
+`.github/dependabot.yml` automatically opens PRs for Docker images in
+`/services` and GitHub Actions (weekly, Mondays). This skill covers the gaps:
+pre-commit hook versions, CLI tool versions in README.md, tool versions
+hard-coded in CI `run:` steps, and cross-checking that Dependabot PRs have
+not stalled. When Dependabot opens a PR for a component in this inventory,
+close the corresponding issue from this skill if one was opened for the same
+bump.
 
 ## Common Mistakes
 
 - Updating docker-compose.yml but not README.md for the same tool version
-- Updating pre-commit rev but not the matching CI workflow pin (yamllint, gitleaks)
-- Pulling an RC or architecture-specific tag (check for `-rc`, `-rocm`, `-cuda` suffixes)
+- Updating a pre-commit rev but not the matching CI workflow pin (yamllint,
+  gitleaks)
+- Pulling an RC or architecture-specific tag (`-rc`, `-rocm`, `-cuda`)
 - Updating Ollama without testing model inference after restart
 - Batching too many updates in one PR -- prefer one component per PR so
   regressions are easy to bisect

--- a/.opencode/skills/check-updates/references/update-reference.md
+++ b/.opencode/skills/check-updates/references/update-reference.md
@@ -1,0 +1,195 @@
+# Update reference -- component inventory, lookups, and update locations
+
+## Contents
+
+- Component inventory (four categories)
+- Version lookup commands
+- Update locations by category
+- Issue body template
+
+## Component inventory
+
+Every line below is a canonical version source -- do not check anywhere else.
+
+### Category 1 -- Stack services (services/docker-compose.yml)
+
+Extract all pinned image tags:
+
+```bash
+grep "image:" services/docker-compose.yml | grep -v "#" | \
+  sed 's/.*image: //' | sort
+```
+
+| Service | Compose key | Registry |
+|---------|------------|---------|
+| Ollama | `ollama/ollama:<tag>` | hub.docker.com |
+| Vault | `hashicorp/vault:<tag>` | hub.docker.com |
+| PostgreSQL | `library/postgres:<tag>` | hub.docker.com |
+| Open WebUI | `ghcr.io/open-webui/open-webui:<tag>` | ghcr.io (GitHub releases) |
+| pgAdmin 4 | `dpage/pgadmin4:<tag>` | hub.docker.com |
+| Prometheus | `prom/prometheus:<tag>` | GitHub releases |
+| Alertmanager | `prom/alertmanager:<tag>` | GitHub releases |
+| Grafana | `grafana/grafana:<tag>` | GitHub releases |
+| Loki | `grafana/loki:<tag>` | GitHub releases |
+| cAdvisor | `ghcr.io/google/cadvisor:<tag>` | GitHub releases |
+| Node Exporter | `prom/node-exporter:<tag>` | GitHub releases |
+| Postgres Exporter | `prometheuscommunity/postgres-exporter:<tag>` | GitHub releases |
+| NVIDIA GPU Exporter | `utkuozdemir/nvidia_gpu_exporter:<tag>` | GitHub releases |
+
+### Category 2 -- Pre-commit hooks (.pre-commit-config.yaml)
+
+```bash
+grep -E "repo:|rev:" .pre-commit-config.yaml | paste - -
+```
+
+| Hook | GitHub repo | Rev field |
+|------|-------------|-----------|
+| pre-commit-hooks | pre-commit/pre-commit-hooks | `rev:` |
+| shellcheck-py | shellcheck-py/shellcheck-py | `rev:` |
+| yamllint | adrienverge/yamllint | `rev:` |
+| gitleaks | gitleaks/gitleaks | `rev:` |
+
+### Category 3 -- GitHub Actions (.github/workflows/*.yml)
+
+```bash
+grep -rh "uses:" .github/workflows/ | grep -v "#" | grep "@" | \
+  sed 's/.*uses: //' | sort -u
+```
+
+| Action | Pinned in |
+|--------|-----------|
+| actions/checkout | bash-ci.yml, codeql.yml, security.yml, others |
+| actions/dependency-review-action | dependency-review.yml |
+| docker/setup-buildx-action | bash-ci.yml |
+| github/codeql-action/init | codeql.yml |
+| github/codeql-action/analyze | codeql.yml |
+
+### Category 4 -- Developer CLI tools (README.md + CI)
+
+Versions are pinned in two places that must stay in sync:
+
+| Tool | README.md install | CI workflow |
+|------|------------------|-------------|
+| shellcheck | README.md curl install | security.yml (uses shellcheck-py action) |
+| gitleaks | README.md curl install | security.yml `GITLEAKS_VERSION` var |
+| git-cliff | README.md curl install | not used in CI |
+| yamllint | README.md pip install | documentation-checks.yml pip install |
+
+## Version lookup commands
+
+Use GitHub releases (more reliable) wherever available; fall back to Docker
+Hub.
+
+```bash
+# Stack services -- GitHub releases
+for repo in \
+  "ollama/ollama" \
+  "open-webui/open-webui" \
+  "google/cadvisor" \
+  "grafana/loki" \
+  "prometheus/prometheus" \
+  "prometheus/alertmanager" \
+  "grafana/grafana" \
+  "prometheus/node_exporter" \
+  "prometheus-community/postgres_exporter" \
+  "utkuozdemir/nvidia_gpu_exporter"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+
+# Stack services -- Docker Hub (for images without GitHub releases)
+for image in "hashicorp/vault" "dpage/pgadmin4" "library/postgres"; do
+  latest=$(curl -s "https://hub.docker.com/v2/repositories/$image/tags?page_size=50&ordering=last_updated" | \
+    python3 -c "
+import sys, json, re
+data = json.load(sys.stdin)
+tags = [t['name'] for t in data.get('results',[]) if re.match(r'^[0-9]+\.[0-9]+\.[0-9]+$', t['name'])]
+print(tags[0] if tags else 'check manually')
+" 2>/dev/null)
+  echo "$image: $latest"
+done
+
+# Pre-commit hooks and CLI tools
+for repo in \
+  "pre-commit/pre-commit-hooks" \
+  "shellcheck-py/shellcheck-py" \
+  "adrienverge/yamllint" \
+  "gitleaks/gitleaks" \
+  "orhun/git-cliff" \
+  "koalaman/shellcheck" \
+  "actions/checkout" \
+  "actions/dependency-review-action" \
+  "docker/setup-buildx-action" \
+  "github/codeql-action"; do
+  latest=$(gh api repos/$repo/releases/latest --jq '.tag_name' 2>/dev/null || echo "N/A")
+  echo "$repo: $latest"
+done
+```
+
+## Update locations by category
+
+**Stack service (docker-compose.yml):**
+```bash
+# For services with multiple instances (e.g. vault), update all occurrences
+grep -n "image:.*<component>" services/docker-compose.yml
+# Edit each line, then validate
+docker compose -f services/docker-compose.yml config > /dev/null
+```
+
+**Pre-commit hook (.pre-commit-config.yaml):**
+```bash
+# Update the rev: field for the relevant repo entry, then verify
+pre-commit autoupdate --repo https://github.com/<owner>/<repo>
+# Or edit manually, then:
+pre-commit run --all-files
+```
+
+**GitHub Action (.github/workflows/*.yml):**
+```bash
+# Update the uses: line in every workflow that references the action
+grep -rn "uses:.*<action>" .github/workflows/
+yamllint -c .yamllint.yml .github/workflows/
+```
+
+**CLI tool (README.md + CI workflow):**
+```bash
+# Must update both locations atomically:
+# 1. README.md -- curl install URL and version comment
+# 2. .github/workflows/security.yml GITLEAKS_VERSION (for gitleaks)
+#    or documentation-checks.yml pip install line (for yamllint)
+grep -n "<tool>" README.md
+grep -rn "<tool>" .github/workflows/
+```
+
+## Issue body template
+
+```bash
+gh issue create --repo xencon/aixcl \
+  --title "[TASK] Update <component> from <old> to <new>" \
+  --body "## Update
+
+- Component: \`<component>\`
+- Current: \`<old>\`
+- Latest: \`<new>\`
+- Release notes: <URL>
+
+## Checklist
+
+- [ ] Image tag updated in \`services/docker-compose.yml\`
+- [ ] Version updated in README.md install section (if CLI tool)
+- [ ] Version updated in CI workflow (if pinned in .github/workflows/)
+- [ ] Version updated in \`.pre-commit-config.yaml\` (if pre-commit hook)
+- [ ] Stack starts cleanly after update (\`./aixcl stack start --profile sys\`)
+- [ ] \`./aixcl stack status\` shows all services healthy" \
+  --assignee <assignee> \
+  --label "Task,component:infrastructure,Maintenance"
+```
+
+For Ollama (runtime core invariant), add to the issue body:
+
+```
+> [!WARNING]
+> Ollama is a runtime core invariant. Test inference with at least one
+> model before merging. Confirm the OpenAI-compatible API endpoint
+> (/v1/chat/completions) responds correctly after the upgrade.
+```

--- a/.opencode/skills/housekeeping/SKILL.md
+++ b/.opencode/skills/housekeeping/SKILL.md
@@ -1,25 +1,31 @@
 ---
 name: housekeeping
-description: Comprehensive repository health check covering hygiene, security, and code quality
+description: >
+  Repository health check and session-startup status sweep: memory recall,
+  hygiene, security, code quality, and open-work triage, ending in a status
+  report with priorities. Use at session start, periodically, or before a
+  release. Triggers on "housekeeping", "start day", "what's the status",
+  "where did we leave off", "repo health check".
+argument-hint: <optional: 'all' or specific step numbers>
 compatibility: OpenCode, Claude Code
 metadata:
   category: maintenance
-  version: "2.1"
+  version: "3.0"
 ---
 
 # Skill: housekeeping
 
 ## Purpose
 
-Catch accumulated debt across the repository: broken links, mirror drift,
-stale branches, permission problems, secrets, unpinned images, and shell
-regressions. The mechanical checks run through `./aixcl checks all`; this
-skill adds the checks that need GitHub state or human judgment.
+Catch accumulated debt across the repository and orient the session: broken
+links, mirror drift, stale branches, permission problems, secrets, unpinned
+images, shell regressions, and open-work state. Report findings and wait for
+direction -- take no corrective action until directed.
 
 ## When to Run
 
-Periodically, or before a release. Each check is independent -- a failure in
-one does not block the others.
+At session start, periodically, or before a release. Each check is
+independent -- a failure in one does not block the others.
 
 ## Preconditions
 
@@ -27,237 +33,116 @@ one does not block the others.
 - [ ] `gh` authenticated (`gh auth status`)
 - [ ] No uncommitted changes that would pollute diff checks
 
+## Delegation
+
+The mechanical steps (4, 5, 9, 10, 11) fit the delegate skill's tier rubric
+and may be delegated to the OpenCode peer -- strictly one at a time, per the
+delegate skill's sequential-only rule. If delegation fails, run the commands
+directly. Steps needing GitHub state or judgment (0, 2, 3, 12) stay with the
+primary agent.
+
+Command blocks for every step: [references/step-commands.md](references/step-commands.md).
+
 ## Steps
+
+### Step 0 -- Read Memory
+
+Read project memory (MEMORY.md index plus files relevant to open work). Note
+what was in progress, what was blocked, and what the last session
+recommended.
+
+- [ ] In-progress work, blockers, and last-session recommendations noted
 
 ### Step 1 -- Mechanical Sweep
 
-```bash
-./aixcl checks all
-```
+`./aixcl checks all` -- covers documentation paths, mirror parity, elision
+guard, generated and dated files (lean policy), ASCII markdown, image pins,
+profile-vs-contract reconciliation, yamllint, compose validation, and
+environment prerequisites. Fix anything red before continuing.
 
-Covers: documentation paths, mirror parity, elision guard, generated and
-dated files (lean policy), ASCII markdown, image pins, profile-vs-contract
-reconciliation, yamllint, compose validation, and environment
-prerequisites. Fix anything red before continuing.
+- [ ] All checks green
 
-### Step 2 -- Branch Hygiene (Merged Branches and Fork Sync)
+### Step 2 -- Branch Hygiene
 
-```bash
-git fetch --prune origin 2>/dev/null; git fetch --prune upstream 2>/dev/null || true
-
-# Stale merged branches
-git branch -r --merged upstream/dev 2>/dev/null \
-  | grep -v 'upstream/dev\|upstream/main\|origin/dev\|origin/main\|HEAD' \
-  || echo "ok: no stale merged remote branches"
-
-# Fork sync with upstream dev
-upstream_ahead=$(git rev-list origin/dev..upstream/dev 2>/dev/null | wc -l | tr -d ' ')
-if [ "$upstream_ahead" -gt 0 ]; then
-  echo "WARN: origin/dev is $upstream_ahead commit(s) behind upstream/dev"
-  echo "  Fix: git checkout dev && git pull upstream dev && git push origin dev"
-else
-  echo "ok: origin/dev is in sync with upstream/dev"
-fi
-```
+Stale merged branches; fork sync between `origin/dev` and `upstream/dev`.
 
 - [ ] No merged remote branches outstanding, or owner notified to delete
-- [ ] `origin/dev` is in sync with `upstream/dev`, or sync performed
+- [ ] `origin/dev` in sync with `upstream/dev`, or sync performed
 
 ### Step 3 -- Issue and PR Hygiene
 
-Open issues missing a required `component:*` label:
+Open issues missing a `component:*` label; open PRs missing an assignee.
 
-```bash
-gh issue list --repo xencon/aixcl --state open --limit 100 \
-  --json number,title,labels,assignees \
-  --jq '.[] | select(.labels | map(.name) | any(startswith("component:")) | not)
-        | "  #\(.number) \(.title)"'
-```
-
-Open PRs missing an assignee:
-
-```bash
-gh pr list --repo xencon/aixcl --state open --limit 100 \
-  --json number,title,assignees \
-  --jq '.[] | select(.assignees | length == 0) | "  #\(.number) \(.title)"'
-```
-
-- [ ] All open issues have at least one `component:*` label, or flagged for triage
-- [ ] All open PRs have an assignee, or flagged for triage
+- [ ] All open issues labeled, all open PRs assigned, or flagged for triage
 
 ### Step 4 -- Line Endings
 
-```bash
-grep -rlP "\r\n" --include="*.md" --include="*.sh" --include="*.yml" \
-  --exclude-dir=.git . 2>/dev/null \
-  && echo "FAIL: CRLF line endings found" || echo "ok: LF only"
-```
-
 - [ ] No CRLF line endings
 
-### Step 5 -- Generated Env File Integrity (Duplicate Keys)
+### Step 5 -- Env File Integrity
 
-Duplicate keys in `.env.*` or `*.env` files indicate an append bug (e.g. a
-setup script running multiple times and stacking entries instead of rewriting).
+Duplicate keys in env files indicate an append bug.
 
-```bash
-for f in $(find . \( -name ".env*" -o -name "*.env" \) \
-           -not -path "./.git/*" -not -name "*.example" -type f); do
-  dupes=$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$f" \
-          | cut -d= -f1 | sort | uniq -d)
-  if [ -n "$dupes" ]; then
-    echo "DUPLICATE KEYS in $f: $dupes"
-  else
-    echo "ok: $f"
-  fi
-done
-```
-
-- [ ] No duplicate keys found in any env file
+- [ ] No duplicate keys in any env file
 
 ### Step 6 -- File Permissions (Sensitive Files)
 
-Runtime env files must not be world-readable or world-writable. Expected
-mode: `600` (owner read/write only). Tracked config files in
-`config/profiles/` are excluded -- they contain service names and ports,
-not secrets.
+Runtime env files, keys, and certs must be mode `600`.
 
-```bash
-find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
-          -o -name "*.token" -o -name "*.pem" -o -name "*.crt" \) \
-  -not -path "./.git/*" \
-  -not -path "./config/profiles/*" \
-  -not -name "*.example" \
-  -type f \
-  | while read -r f; do
-      perms=$(stat -c "%a" "$f" 2>/dev/null || stat -f "%OLp" "$f" 2>/dev/null)
-      if echo "$perms" | grep -qE "[1-7]$"; then
-        echo "WORLD-READABLE or WRITABLE: $f ($perms) -- run: chmod 600 $f"
-      else
-        echo "ok: $f ($perms)"
-      fi
-    done
-```
-
-- [ ] No sensitive runtime env files are world-readable or world-writable
+- [ ] No sensitive runtime files world-readable or world-writable
 - [ ] Files under `vault/` or `security/` paths checked specifically
-- [ ] Note: to check whether a file is tracked in git, use `git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0 even when the file is not tracked, making `&& echo TRACKED` a false positive.
 
 ### Step 7 -- Secret Scanning
 
-Scan tracked files for common secret patterns. If `gitleaks` is installed,
-prefer it. Otherwise use grep patterns as a baseline.
+gitleaks if installed, grep baseline otherwise.
 
-```bash
-if command -v gitleaks > /dev/null 2>&1; then
-  gitleaks detect --source . --no-git 2>&1 | tail -20
-else
-  grep -rEn \
-    "(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_\-]{20,}|sk-[A-Za-z0-9]{40,}|xoxb-[A-Za-z0-9\-]+|VAULT_TOKEN=[A-Za-z0-9.\-]{20,})" \
-    --include="*.md" --include="*.yml" --include="*.yaml" \
-    --include="*.sh" --include="*.json" --include="*.env*" \
-    --exclude-dir=.git . 2>/dev/null \
-    && echo "FAIL: potential secrets found above" || echo "ok: no common secret patterns matched"
-fi
-```
-
-- [ ] No secrets detected
-- [ ] If gitleaks not installed, note it as a tooling gap
-- [ ] Note: `--no-git` scans ALL files on disk, including gitignored runtime files (e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
+- [ ] No secrets detected (gitleaks absence noted as a tooling gap)
 
 ### Step 8 -- Container Image Pin Hygiene
 
-Covers compose files AND shell code under `lib/` and `scripts/` -- four
-unpinned alpine references hid in shell code because the old sweep only
-scanned compose (issue #1726). Legitimate `:latest` uses (locally built
-`localhost/` images, ollama model tags) are exempted via `localhost/`
-detection or an inline `pin-waiver:` comment.
+`./aixcl checks pins` -- covers compose files AND shell code under `lib/`
+and `scripts/` (unpinned references have hidden in shell code before, #1726).
 
-```bash
-./aixcl checks pins
-```
+- [ ] All image references pinned or carrying a `pin-waiver:` comment
 
-- [ ] All container image references are pinned (no `latest`, no bare image names), or carry an explicit `pin-waiver:` comment with a reason
+### Step 9 -- Shellcheck Sweep
 
-### Step 9 -- Shellcheck Sweep (All Scripts)
-
-```bash
-issues=$(find . -name "*.sh" -not -path "./.git/*" \
-  | xargs shellcheck --severity=warning --exclude=SC1091 2>&1)
-if [ -n "$issues" ]; then
-  echo "$issues" | head -40
-  echo "FAIL: shellcheck issues found"
-else
-  echo "ok: all scripts clean"
-fi
-```
-
-- [ ] No shellcheck warnings or errors at severity `warning` or above
+- [ ] No warnings at severity `warning` or above across all scripts
 
 ### Step 10 -- UPSTREAM-ISSUES.md Staleness
 
-```bash
-if [ -f UPSTREAM-ISSUES.md ]; then
-  echo "UPSTREAM-ISSUES.md exists -- review entries manually:"
-  grep -E "^##|^- " UPSTREAM-ISSUES.md | head -30
-  echo ""
-  echo "File last modified: $(git log -1 --format='%ar' -- UPSTREAM-ISSUES.md)"
-else
-  echo "ok: UPSTREAM-ISSUES.md does not exist"
-fi
-```
-
-- [ ] No entries older than 7 days without a corresponding upstream issue
-- [ ] Entries that have been filed upstream are removed from the file
+- [ ] No entries older than 7 days without a filed upstream issue
+- [ ] Filed entries removed from the file
 
 ### Step 11 -- Agent Scratch/Temp File Hygiene
 
-Verification work (podman test harnesses, permission/capability checks) leaves
-temporary artifacts outside the repository tree -- stub secrets directories,
-throwaway config copies, test containers/volumes, scratchpad drafts of PR and
-issue bodies. None of the steps above catch this since they only look inside
-the repo; it was found here by chance, not by systematic check.
+Stray `/tmp` harness directories, lingering podman test containers/volumes,
+stale scratchpad drafts. Detection only -- review before deleting anything.
 
-```bash
-# Stray /tmp directories from prior harness/verification runs (adjust the
-# glob to match your own session's naming convention if it differs)
-find /tmp -maxdepth 1 \( -iname "aixcl-harness-*" -o -iname "*-harness-*" \) 2>/dev/null
+- [ ] No stray harness artifacts or stale scratchpad drafts
 
-# Lingering podman test containers/volumes from harness runs
-podman ps -a --filter "name=harness" --format "{{.Names}}" 2>&1
-podman volume ls --filter "name=harness" --format "{{.Name}}" 2>&1
+### Step 12 -- Status Report and Priorities
 
-# This session's scratchpad directory -- safe to clear once every draft's
-# real content has landed on GitHub (issue/PR bodies, once filed, live
-# there; the local draft file is disposable afterward)
-ls -la "$CLAUDE_SCRATCHPAD_DIR" 2>/dev/null || true
-```
-
-- [ ] No stray `/tmp` directories from this or prior sessions' test harnesses
-- [ ] No lingering podman test containers/volumes matching a harness naming pattern
-- [ ] Scratchpad cleared of drafts whose content has already landed on GitHub
-- [ ] Note: this step only lists/detects -- review what's found before deleting anything, same as every other step in this skill; never blind-delete a match without confirming it's actually stale
-
-## Verification
-
-Record findings after all steps:
+Compile the single report:
 
 ```
-Step 1  -- Mechanical sweep (aixcl checks all):  [ ] clean  [ ] failures
-Step 2  -- Branch hygiene:                       [ ] clean  [ ] stale branches / fork drift
-Step 3  -- Issue/PR hygiene:                     [ ] clean  [ ] missing labels/assignees
-Step 4  -- Line endings:                         [ ] clean  [ ] CRLF found
-Step 5  -- Env file integrity:                   [ ] clean  [ ] duplicates
-Step 6  -- File permissions:                     [ ] clean  [ ] overexposed
-Step 7  -- Secret scanning:                      [ ] clean  [ ] matches
-Step 8  -- Image pin hygiene:                    [ ] clean  [ ] unpinned
-Step 9  -- Shellcheck sweep:                     [ ] clean  [ ] warnings
-Step 10 -- UPSTREAM-ISSUES.md:                   [ ] clean  [ ] stale entries
-Step 11 -- Agent scratch/temp file hygiene:      [ ] clean  [ ] stray /tmp or scratchpad debt
+Step 0  -- Memory recall:            <in-progress work / blockers>
+Step 1  -- Mechanical sweep:         [ ] clean  [ ] failures
+Step 2  -- Branch hygiene:           [ ] clean  [ ] drift/stale
+Step 3  -- Issue/PR hygiene:         [ ] clean  [ ] gaps
+Step 4  -- Line endings:             [ ] clean  [ ] CRLF
+Step 5  -- Env file integrity:       [ ] clean  [ ] duplicates
+Step 6  -- File permissions:         [ ] clean  [ ] overexposed
+Step 7  -- Secret scanning:          [ ] clean  [ ] matches
+Step 8  -- Image pin hygiene:        [ ] clean  [ ] unpinned
+Step 9  -- Shellcheck sweep:         [ ] clean  [ ] warnings
+Step 10 -- UPSTREAM-ISSUES.md:       [ ] clean  [ ] stale
+Step 11 -- Scratch/temp hygiene:     [ ] clean  [ ] debt
 ```
 
-Any `items found` result should become a follow-up issue before the next
-release. Critical findings from steps 6 and 7 should be treated as P1.
+Follow with a recommended priority order for anything found (critical
+findings from steps 6 and 7 are P1; other findings become follow-up issues
+before the next release) and **wait for direction**.
 
 ## Common Mistakes
 
@@ -268,3 +153,5 @@ release. Critical findings from steps 6 and 7 should be treated as P1.
   allowlist the path in `.gitleaks.toml` instead
 - Deleting a remote branch that has an open PR -- check the PR state is
   MERGED first (a closed PR is not a merged PR)
+- Running delegated checks in parallel -- the delegation log is
+  sequential-only

--- a/.opencode/skills/housekeeping/references/step-commands.md
+++ b/.opencode/skills/housekeeping/references/step-commands.md
@@ -1,0 +1,170 @@
+# Housekeeping step commands
+
+Command blocks for each housekeeping step. Run from the repository root.
+
+## Contents
+
+- Step 2: Branch hygiene
+- Step 3: Issue and PR hygiene
+- Step 4: Line endings
+- Step 5: Env file integrity
+- Step 6: File permissions
+- Step 7: Secret scanning
+- Step 9: Shellcheck sweep
+- Step 10: UPSTREAM-ISSUES.md staleness
+- Step 11: Agent scratch/temp file hygiene
+
+## Step 2: Branch hygiene
+
+```bash
+git fetch --prune origin 2>/dev/null; git fetch --prune upstream 2>/dev/null || true
+
+# Stale merged branches
+git branch -r --merged upstream/dev 2>/dev/null \
+  | grep -v 'upstream/dev\|upstream/main\|origin/dev\|origin/main\|HEAD' \
+  || echo "ok: no stale merged remote branches"
+
+# Fork sync with upstream dev
+upstream_ahead=$(git rev-list origin/dev..upstream/dev 2>/dev/null | wc -l | tr -d ' ')
+if [ "$upstream_ahead" -gt 0 ]; then
+  echo "WARN: origin/dev is $upstream_ahead commit(s) behind upstream/dev"
+  echo "  Fix: git checkout dev && git pull upstream dev && git push origin dev"
+else
+  echo "ok: origin/dev is in sync with upstream/dev"
+fi
+```
+
+## Step 3: Issue and PR hygiene
+
+```bash
+# Open issues missing a required component:* label
+gh issue list --repo xencon/aixcl --state open --limit 100 \
+  --json number,title,labels,assignees \
+  --jq '.[] | select(.labels | map(.name) | any(startswith("component:")) | not)
+        | "  #\(.number) \(.title)"'
+
+# Open PRs missing an assignee
+gh pr list --repo xencon/aixcl --state open --limit 100 \
+  --json number,title,assignees \
+  --jq '.[] | select(.assignees | length == 0) | "  #\(.number) \(.title)"'
+```
+
+## Step 4: Line endings
+
+```bash
+grep -rlP "\r\n" --include="*.md" --include="*.sh" --include="*.yml" \
+  --exclude-dir=.git . 2>/dev/null \
+  && echo "FAIL: CRLF line endings found" || echo "ok: LF only"
+```
+
+## Step 5: Env file integrity (duplicate keys)
+
+Duplicate keys in `.env.*` or `*.env` files indicate an append bug (e.g. a
+setup script running multiple times and stacking entries instead of
+rewriting).
+
+```bash
+for f in $(find . \( -name ".env*" -o -name "*.env" \) \
+           -not -path "./.git/*" -not -name "*.example" -type f); do
+  dupes=$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$f" \
+          | cut -d= -f1 | sort | uniq -d)
+  if [ -n "$dupes" ]; then
+    echo "DUPLICATE KEYS in $f: $dupes"
+  else
+    echo "ok: $f"
+  fi
+done
+```
+
+## Step 6: File permissions (sensitive files)
+
+Runtime env files must not be world-readable or world-writable. Expected
+mode: `600`. Tracked config files in `config/profiles/` are excluded -- they
+contain service names and ports, not secrets.
+
+```bash
+find . \( -name ".env" -o -name ".env.*" -o -name "*.key" \
+          -o -name "*.token" -o -name "*.pem" -o -name "*.crt" \) \
+  -not -path "./.git/*" \
+  -not -path "./config/profiles/*" \
+  -not -name "*.example" \
+  -type f \
+  | while read -r f; do
+      perms=$(stat -c "%a" "$f" 2>/dev/null || stat -f "%OLp" "$f" 2>/dev/null)
+      if echo "$perms" | grep -qE "[1-7]$"; then
+        echo "WORLD-READABLE or WRITABLE: $f ($perms) -- run: chmod 600 $f"
+      else
+        echo "ok: $f ($perms)"
+      fi
+    done
+```
+
+Note: to check whether a file is tracked in git, use
+`git ls-files --error-unmatch <file>` -- plain `git ls-files <file>` exits 0
+even when the file is not tracked, making `&& echo TRACKED` a false positive.
+
+## Step 7: Secret scanning
+
+```bash
+if command -v gitleaks > /dev/null 2>&1; then
+  gitleaks detect --source . --no-git 2>&1 | tail -20
+else
+  grep -rEn \
+    "(AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9_\-]{20,}|sk-[A-Za-z0-9]{40,}|xoxb-[A-Za-z0-9\-]+|VAULT_TOKEN=[A-Za-z0-9.\-]{20,})" \
+    --include="*.md" --include="*.yml" --include="*.yaml" \
+    --include="*.sh" --include="*.json" --include="*.env*" \
+    --exclude-dir=.git . 2>/dev/null \
+    && echo "FAIL: potential secrets found above" || echo "ok: no common secret patterns matched"
+fi
+```
+
+Note: `--no-git` scans ALL files on disk, including gitignored runtime files
+(e.g. `pgadmin-servers.json`). Findings in gitignored runtime files belong in
+the `.gitleaks.toml` `paths` allowlist, not the `commits` allowlist.
+
+## Step 9: Shellcheck sweep
+
+```bash
+issues=$(find . -name "*.sh" -not -path "./.git/*" \
+  | xargs shellcheck --severity=warning --exclude=SC1091 2>&1)
+if [ -n "$issues" ]; then
+  echo "$issues" | head -40
+  echo "FAIL: shellcheck issues found"
+else
+  echo "ok: all scripts clean"
+fi
+```
+
+## Step 10: UPSTREAM-ISSUES.md staleness
+
+```bash
+if [ -f UPSTREAM-ISSUES.md ]; then
+  echo "UPSTREAM-ISSUES.md exists -- review entries manually:"
+  grep -E "^##|^- " UPSTREAM-ISSUES.md | head -30
+  echo ""
+  echo "File last modified: $(git log -1 --format='%ar' -- UPSTREAM-ISSUES.md)"
+else
+  echo "ok: UPSTREAM-ISSUES.md does not exist"
+fi
+```
+
+## Step 11: Agent scratch/temp file hygiene
+
+Verification work (podman test harnesses, permission/capability checks)
+leaves temporary artifacts outside the repository tree. Detection only --
+review what is found before deleting anything.
+
+```bash
+# Stray /tmp directories from prior harness/verification runs (adjust the
+# glob to match your own session's naming convention if it differs)
+find /tmp -maxdepth 1 \( -iname "aixcl-harness-*" -o -iname "*-harness-*" \) 2>/dev/null
+
+# Lingering podman test containers/volumes from harness runs
+podman ps -a --filter "name=harness" --format "{{.Names}}" 2>&1
+podman volume ls --filter "name=harness" --format "{{.Name}}" 2>&1
+
+# This session's scratchpad directory -- safe to clear once every draft's
+# real content has landed on GitHub (issue/PR bodies, once filed, live
+# there; the local draft file is disposable afterward)
+ls -la "$CLAUDE_SCRATCHPAD_DIR" 2>/dev/null || true
+```

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: release
-description: Guided workflow for cutting an AIXCL release, fronting the aixcl release command
+description: >
+  Guided workflow for cutting an AIXCL release, fronting the aixcl release
+  command: retrospective, changelog judgment, tag, announcement, and sync.
+  Operator-gated (disable-model-invocation) -- run only when the maintainer
+  explicitly asks to cut a release.
 compatibility: OpenCode, Claude Code
 disable-model-invocation: true
 metadata:
   category: workflow
-  version: "2.0"
+  version: "2.1"
 ---
 
 # Skill: release
@@ -54,6 +58,8 @@ advisory -- the human may proceed once formal CI and review checks are
 complete, even if one agent has nothing material to add.
 
 ```bash
+# Repository and category IDs are xencon/aixcl constants; re-derive with
+# `gh api graphql` repository/discussionCategories queries if they change
 gh api graphql -f query='
 mutation {
   createDiscussion(input: {

--- a/.opencode/skills/workflow-guard/SKILL.md
+++ b/.opencode/skills/workflow-guard/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: workflow-guard
-description: Validates Issue-First workflow compliance before execution
+description: >
+  Validates Issue-First workflow compliance before execution: issue, branch,
+  commit, PR, and security requirements. Use before starting any code change
+  and again before creating a PR. Triggers on "check workflow compliance",
+  "validate the workflow", "am I following the process", or starting work
+  without a clear issue reference.
+argument-hint: <issue or PR number to validate>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
   security_level: critical
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Skill: workflow-guard
@@ -50,17 +56,18 @@ creating a PR.
 - [ ] PR references issue: `Fixes #<number>` in body
 - [ ] PR has assignee set
 - [ ] PR has at least one `component:*` label
-- [ ] All CI checks pass (validate this with @verify agent)
+- [ ] All CI checks pass (`gh pr checks <number>`)
 - [ ] Agent identification block present in PR body (agent-authored PRs only)
   ```bash
   echo "$PR_BODY" | bash scripts/checks/check-agent-id-block.sh
   ```
 
 ### 5. Security Requirements
-- [ ] Security-gate agent has scanned changes
-- [ ] No secrets detected
-- [ ] No CRITICAL or HIGH severity vulnerabilities
-- [ ] Human approval obtained for critical actions
+- [ ] No secrets in the diff (gitleaks runs in CI; grep the staged diff for
+      token patterns before pushing)
+- [ ] No CRITICAL or HIGH severity findings from CI security workflows
+      (ShellCheck, dependency review, obfuscation patterns)
+- [ ] Human approval obtained for critical actions (see below)
 
 ## Workflow State Machine
 
@@ -127,33 +134,32 @@ gh pr view <number> --json assignees,labels,title,body
 
 If any validation step fails:
 
-1. **Log the failure** with full context
-2. **Block execution** of the action
-3. **Provide remediation** guidance
-4. **Alert human** via @security-gate agent
+1. **Stop** -- do not proceed with the blocked action
+2. **Report** the failure with full context and remediation guidance
+3. **Escalate** security concerns to the operator with a `[SECURITY]` prefix
+   (AGENTS.md Section 7); everything else per the escalation procedures
 
 ## Example Usage
 
 ```
-@orchestrator Please validate the workflow for issue #917
-
-Agent loads this skill and runs validation:
+Validate the workflow for issue #917:
 1. Check issue #917 exists [x]
-2. Check issue is assigned [x]
-3. Check branch issue-917/security-first-agentic-foundation format [x]
+2. Check issue is assigned and labeled [x]
+3. Check branch issue-917/<description> format [x]
 4. Check branch from dev [x]
 5. Check commits reference #917 [x]
-6. Check security-gate approval [x]
+6. Check no secrets or elisions in the staged diff [x]
 
 Result: All validations passed. Workflow approved.
 ```
 
 ## Integration
 
-This skill is automatically invoked by:
-- @orchestrator agent for workflow coordination
-- @security-gate agent for compliance validation
-- GitHub Actions for CI/CD enforcement
+Run this skill yourself before starting code changes and again before
+creating a PR. CI independently enforces the same rules
+(`pr-validation.yml`, `bash-ci.yml`, `security.yml`), and
+`./aixcl checks pr-ready <N>` re-validates everything at merge time --
+this skill exists to catch violations before they reach CI.
 
 ## Compliance Rules
 
@@ -172,5 +178,5 @@ Before claiming compliance, verify:
 - [ ] All AGENTS.md rules followed
 - [ ] All DEVELOPMENT.md rules followed
 - [ ] All platform invariants preserved
-- [ ] Security gate approval obtained
+- [ ] Security requirements above checked
 - [ ] Audit trail will be complete

--- a/docs/developer/ai-file-naming.md
+++ b/docs/developer/ai-file-naming.md
@@ -41,9 +41,9 @@ Agent files:
 
 - **Location**: `.claude/skills/<name>/SKILL.md` and `.opencode/skills/<name>/SKILL.md` (byte-identical mirrors -- edit both sides)
 - **Filename pattern**: directory-based (`<name>/SKILL.md`), directory name in kebab-case
-  - Examples: `housekeeping/SKILL.md`, `cut-release/SKILL.md`
+  - Examples: `housekeeping/SKILL.md`, `release/SKILL.md`
 
-Skill files follow the [Agent Skills open standard](https://agentskills.io): keep SKILL.md lean and move bulky reference material to separate files loaded on demand (progressive disclosure).
+Skill files follow the [Agent Skills open standard](https://agentskills.io): keep SKILL.md lean and move bulky reference material to separate `references/` files loaded on demand (progressive disclosure). The catalog and authoring conventions live in `.claude/skills/CONTEXT.md` (mirrored); update it in the same PR that adds, renames, or removes a skill. Audit skill changes with the `reviewing-skills` skill before merging.
 
 ## Rules
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1954

### Description of Changes
PR 4 of 4, closing out the skill pack adoption tracked in #1950. Consolidation and retrofit pass over the pre-existing skills:

- housekeeping v3.0: gains the pack's session-startup pattern (Step 0 memory recall, Step 12 status report with priorities and wait-for-direction) and an explicit sequential-only delegation option for the mechanical steps; command blocks moved to references/step-commands.md (10.0KB body down to 5.5KB)
- check-updates 1.1: component inventory, lookup commands, update locations, and the issue template moved to references/update-reference.md (10.6KB body down to 4.1KB)
- workflow-guard 1.2: audit FAIL fixed -- all references to nonexistent agents (orchestrator, security-gate, verify) removed; security requirements now name the real mechanisms (gitleaks in CI, dependency review, [SECURITY] escalation per AGENTS.md Section 7); integration section now describes self-run validation backed by CI and the pr-ready gate
- add-service 1.2 and release 2.1: trigger-rich descriptions; release additionally documents its operator gating and the provenance of the hardcoded GraphQL IDs
- New .claude/skills/CONTEXT.md: skill catalog, interlock map, and authoring contract for the directory (mirrored)
- docs/developer/ai-file-naming.md: stale cut-release example fixed, references/ convention and CONTEXT.md catalog pointer added

The large line deletions in the two restructured SKILL.md files are content moved to references/ files, stated in the commit message with the AIXCL_ALLOW_MASS_DELETE token for the elision guard.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
- `./aixcl checks all` green (parity, ASCII, paths, elisions with documented override)
- Elision guard verified both ways: fails without the override (as designed), passes with `AIXCL_ALLOW_MASS_DELETE=1`; commit message carries the token for CI range mode
- Final reviewing-skills audit across all 12 skills posted on #1950: zero FAIL findings; remaining WARNs documented there
- Commit GPG-signed by the operator

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1954
- Part of #1950

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-23
- Method: Audit-driven retrofit per the baseline review posted on #1950; local CI parity sweep
- Scope: .claude/skills/, .opencode/skills/, docs/developer/ai-file-naming.md
- Confirmation: yes
---
