### PR TITLE
Require removing superseded implementations in governance guidance (#1999)

### DIFF
--- a/docs/architecture/governance/01_ai_guidance.md
+++ b/docs/architecture/governance/01_ai_guidance.md
@@ -49,6 +49,16 @@ Agents **may** safely operate in:
 - Small, reversible steps
 - Clear grouping by responsibility
 - Minimal assumptions about upstream internals
+- When a design decision (an ADR or otherwise) supersedes an existing
+  implementation, remove the superseded code, config, and mounts in the
+  same change -- do not leave a dead implementation behind for a later
+  cleanup that may never happen. A dead implementation is not neutral: it
+  can still carry real credentials, mislead a future reader into thinking
+  it is the pattern to follow, and go unnoticed by mechanical checks,
+  since "is this file ever actually executed" is a behavioral question,
+  not a lint-able one. Update or remove any documentation
+  (`CONTEXT.md`, ADRs, cross-references) that pointed at the removed
+  files in the same change.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #1999

### Description of Changes
Adds a bullet to `01_ai_guidance.md` Section 4 ("Preferred Change Style"): when a design decision (an ADR or otherwise) supersedes an existing implementation, remove the superseded code, config, and mounts in the same change, and update or remove any documentation that referenced the removed files.

This is the process-level fix for the class of issue found in #1995: ADR 002 superseded the Vault Agent HCL configs with a shell-script pattern, but nobody removed the old files or the docs that still described them as load-bearing. A dead file with a real hardcoded token sat unnoticed because "is this file ever actually executed" is a behavioral question, not something a mechanical check can reliably answer -- a heuristic lint-based detector was considered and rejected as too fragile (false negatives on anything invoked indirectly, false positives on conditionally-read files). This document is the right place instead: it's the normative, agent-facing guidance AGENTS.md's cold-start reading list already points every session at, so the rule applies automatically going forward rather than depending on anyone remembering to reread a rules file.

The wording deliberately names no issue/PR numbers so it reads as evergreen guidance rather than a changelog entry.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly
- [x] Commit messages follow conventional style
- [x] All tests run and pass

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
- Confirmed no other tracked file anchors to a specific section number of `01_ai_guidance.md` before editing, so no renumbering risk
- `./aixcl checks all` green (ASCII, paths)
- Committed content re-verified directly (`git show HEAD:...`) rather than trusting `git log` alone, given an earlier staging mistake this session
- Commit GPG-signed by the operator

### Verification
To verify this change is complete:

- [x] Behavior works as expected
- [x] No regressions observed
- [x] Tests cover change

### Related Issues

- Closes #1999

---
- Agent: Claude Code (Fable 5)
- Date: 2026-07-24
- Method: Governance-doc addition drafted and reviewed with the operator before filing; direct verification of committed content
- Scope: docs/architecture/governance/01_ai_guidance.md
- Confirmation: yes
---
