### PR TITLE
Use unless-stopped restart policy for postgres and open-webui (#2004)

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -327,7 +327,7 @@ services:
       - ../scripts/runtime/postgres-secret-entrypoint.sh:/usr/local/bin/postgres-secret-entrypoint.sh:ro
       - ../scripts/db/init:/docker-entrypoint-initdb.d:ro
     network_mode: host
-    restart: always
+    restart: unless-stopped
     entrypoint: ["/usr/local/bin/postgres-secret-entrypoint.sh"]
     cap_drop:
       - ALL
@@ -397,7 +397,7 @@ services:
     depends_on:
       - postgres
     network_mode: host
-    restart: always
+    restart: unless-stopped
     entrypoint: ["/usr/local/bin/openwebui-entrypoint.sh"]
     command: []
     cap_drop:


### PR DESCRIPTION
## Summary

- `services/docker-compose.yml`: change `restart: always` to `restart: unless-stopped` for `postgres` and `open-webui`, matching all 15 other `unless-stopped` services in the file.

## Why

`postgres` and `open-webui` were the only two services out of 17 restart-managed services set to `restart: always`. That policy restarts a container on host/daemon startup regardless of whether the operator intentionally stopped it -- so after an intentional `./aixcl stack stop` followed by a host reboot, these two would silently come back up while everything else correctly stayed down, leaving a half-running stack the operator did not ask for. Aligning to `unless-stopped` makes stop/reboot behavior consistent across the whole stack.

## Test plan

- [x] `docker compose -f services/docker-compose.yml config` validates cleanly
- [x] `./scripts/checks/check-ai-elisions.sh --staged` passed before commit
- [x] `grep -n "restart:" services/docker-compose.yml` confirms every restart-managed service now uses `unless-stopped` (the 4 vault-agent bootstrap containers remain `on-failure` by design, per the file's own comment)
- [x] Operator confirms `postgres`/`open-webui` behave normally on a routine restart and stay down after an intentional stop across a daemon restart

Fixes #2004

---
- Agent: Claude Code (claude-sonnet-5)
- Date: 2026-07-24
- Method: targeted compose edit, validated with docker compose config and the elision guard
- Scope: services/docker-compose.yml
- Confirmation: yes
---
