### PR TITLE
Add sibling-instance grep sweep pattern to delegate skill (#2007)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <task description or instructions>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
-  version: "1.5"
+  version: "1.6"
 ---
 
 # Delegate to OpenCode
@@ -36,6 +36,10 @@ Confirm the task fits delegation. Good candidates:
 - Check env var presence (name/length/prefix only -- never full values)
 - Probe an HTTP endpoint and report status (e.g. `curl` against Ollama's API)
 - Parse config schemas or JSON and report structure
+- Repo-wide grep to confirm a just-fixed pattern has no other live instances
+  (e.g. before ticking a remediation checklist's "confirm no other path has
+  this issue" item -- caught a second live instance of #2003's plaintext-
+  password logging bug in a separate compose overlay file, 2026-07-23)
 
 **Tier 2 -- side-effect-free analysis:**
 - Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: <task description or instructions>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
-  version: "1.5"
+  version: "1.6"
 ---
 
 # Delegate to OpenCode
@@ -36,6 +36,10 @@ Confirm the task fits delegation. Good candidates:
 - Check env var presence (name/length/prefix only -- never full values)
 - Probe an HTTP endpoint and report status (e.g. `curl` against Ollama's API)
 - Parse config schemas or JSON and report structure
+- Repo-wide grep to confirm a just-fixed pattern has no other live instances
+  (e.g. before ticking a remediation checklist's "confirm no other path has
+  this issue" item -- caught a second live instance of #2003's plaintext-
+  password logging bug in a separate compose overlay file, 2026-07-23)
 
 **Tier 2 -- side-effect-free analysis:**
 - Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)


### PR DESCRIPTION
## Summary

- `.claude/skills/delegate/SKILL.md` and `.opencode/skills/delegate/SKILL.md`: add a Tier 1 example -- repo-wide grep to confirm a just-fixed pattern has no other live instances -- and bump the skill version 1.5 -> 1.6.

## Why

Surfaced during a session review. This exact sweep recurred twice this session (#1995's dead Vault Agent config cleanup, and #2003 where it caught a second live instance of the plaintext-password logging bug in `services/docker-compose.postgres-ssl.yml`). It's read-only, judgment-free grep work -- a clear Tier 1 candidate that was run on the primary model both times instead of being delegated, simply because it wasn't named in the skill's example list.

## Test plan

- [x] `diff .claude/skills/delegate/SKILL.md .opencode/skills/delegate/SKILL.md` empty (mirror parity)
- [x] `./aixcl checks agents` passes
- [x] `./aixcl checks ascii` passes
- [x] `./scripts/checks/check-ai-elisions.sh --staged` passed before commit

Fixes #2007

---
- Agent: Claude Code (claude-sonnet-5)
- Date: 2026-07-24
- Method: documentation-only skill file update, derived from this session's own experience
- Scope: .claude/skills/delegate/SKILL.md, .opencode/skills/delegate/SKILL.md
- Confirmation: yes
---
