### PR TITLE
Default OpenCode to NVIDIA model, local as last resort (#2015)

### DIFF
--- a/.opencode/memory/working-conventions.md
+++ b/.opencode/memory/working-conventions.md
@@ -19,8 +19,11 @@ Seed memory for the OpenCode agent, written at onboarding (2026-07-02).
   or end-of-file hooks, the files are already fixed in the working tree:
   `git add` them and retry. Never use `--no-verify`.
 - **Your identity for agent identification blocks is:**
-  `OpenCode (aixcl-local/qwen3-coder:30b-32k)`. Do NOT copy the example
-  from AGENTS.md Section 9.5 -- that names a different agent.
+  `OpenCode (nvidia/deepseek-ai/deepseek-v4-pro)`, or whichever
+  provider/model actually served the request if NVIDIA is unreachable
+  and you fell back to `aixcl-local/qwen3-coder:30b-32k` (last resort
+  only). Do NOT copy the example from AGENTS.md Section 9.5 -- that
+  names a different agent.
 - **Write PR and issue bodies to /tmp files** and pass `--body-file`.
   Inline body strings turn your newlines into literal backslash-n text.
 - **Create PRs only with `./scripts/utils/create-pr.sh`** -- it targets

--- a/config/opencode.json.example
+++ b/config/opencode.json.example
@@ -110,5 +110,6 @@
       }
     }
   },
+  "model": "nvidia/deepseek-ai/deepseek-v4-pro",
   "small_model": "nvidia/deepseek-ai/deepseek-v4-flash"
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #2015

### Description of Changes
Defaults OpenCode's main agent (`agent-context`) to the NVIDIA cloud model instead of the local Ollama model:

- `config/opencode.json.example` - added `"model": "nvidia/deepseek-ai/deepseek-v4-pro"` (previously no default `model` was set in the template)
- `.opencode/memory/working-conventions.md` - updated the agent identity string to name the new default, and to note the local model is used only as a manual last-resort fallback

opencode's config schema has no automatic provider-failover, so falling back to the local model when NVIDIA is unreachable remains a manual `-m aixcl-local/qwen3-coder:30b-32k` invocation, not an automatic behavior.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-2015/default-nvidia-model`)
- [x] Commit messages follow conventional style (`config: default OpenCode to NVIDIA model, local as last resort`)
- [x] All tests run and pass (all 22 CI checks green, see PR checks)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Tested with the AIXCL stack fully stopped (Ollama unreachable) to confirm the new default takes effect and does not fall through to the local model:

```
timeout 25 opencode run "hi" --log-level DEBUG --print-logs
```

Log output confirms: `llm.provider=nvidia llm.model=deepseek-ai/deepseek-v4-pro`, `agent=agent-context`, with a real assistant reply returned and zero `aixcl-local` stream attempts.

### Verification
To verify this change is complete:

- [x] Behavior works as expected (operator-confirmed)
- [x] No regressions observed (operator-confirmed)
- [x] Tests cover change (operator-confirmed; config-only change, verified via live opencode run test with stack down, see Testing Notes)

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #2015

## Additional Notes

Fixes #2015
