### PR TITLE
Delegate skill shared server, default-model delegation, bounded parallelism (#2017)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -11,16 +11,25 @@ argument-hint: <task description or instructions>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
-  version: "1.6"
+  version: "1.7"
 ---
 
 # Delegate to OpenCode
 
 Delegate the given task to the OpenCode peer agent and log it for tracking.
 
-**SEQUENTIAL ONLY -- HARD RULE**: run at most one `opencode run` at a time.
-Never launch delegations in parallel: concurrent appends corrupt ordering in
-the shared JSONL log. Queue multiple tasks and run them one after another.
+**BOUNDED PARALLEL -- cap 3 concurrent.** Independent delegatable tasks
+(no shared file target, no ordering dependency between them) may run
+concurrently, up to 3 in flight at once. Every invocation attaches to the
+same shared server (Step 2), so the old model-instance corruption risk is
+gone by construction -- only the server process ever writes to
+`opencode.db`. What remains is the JSONL log: redirect each concurrent
+invocation's output to its own `mktemp` file, background with `&`, collect
+PIDs, `wait` for all of them, then process each result in turn. Wrap every
+JSONL append (both start and completion, Steps 4 and 5) in
+`flock -x .opencode/delegation-log.jsonl.lock -c '...'` so concurrent
+completions can't interleave. Tasks with a real dependency (task B needs
+task A's output) still run sequentially.
 
 `LOGFILE` is `.opencode/delegation-log.jsonl` at the repository root
 (gitignored; create with `mkdir -p .opencode` if missing).
@@ -69,35 +78,42 @@ Do NOT delegate:
 
 If the task does not fit, say so and handle it directly.
 
-## Step 2: Pick the model
+## Step 2: Ensure the shared server, then pick the model
+
+Every delegation attaches to one persistent `opencode serve` process
+instead of spawning its own instance:
+
+    URL=$(bash scripts/utils/ensure-opencode-server.sh)
+
+This is idempotent and near-instant if the server is already running --
+call it before every delegation (or once per batch of parallel
+delegations). Routing everything through one server means only that one
+process ever writes to `~/.local/share/opencode/opencode.db`, which is the
+actual fix for the sqlite-contention risk that used to justify running
+delegations one at a time.
 
 Cloud is always preferred, regardless of whether the local stack is up --
 Ollama is last resort only, since it needs a stack the operator may not want
-running just for delegation. Every invocation adds `--variant medium`
-(reasoning effort). Try in this order, falling through on failure. Each
-position is numbered (1-4) -- record whichever position actually succeeds
-as `fallback_position` in Step 5's completion log entry, so
-delegate-review can report how often the primary model serves requests
+running just for delegation. Every invocation adds `--attach "$URL"` and
+`--variant medium` (reasoning effort). Try in this order, falling through
+on failure. Each position is numbered (1-2) -- record whichever position
+actually succeeds as `fallback_position` in Step 5's completion log entry,
+so delegate-review can report how often the default model serves requests
 versus falling through.
 
-1. **`nvidia/deepseek-ai/deepseek-v4-flash`** (primary, credentialed via
-   `opencode.json`). A `503` with a body like `"ResourceExhausted: Worker
-   local total request limit reached"` is shared-endpoint saturation, not an
-   auth or quota failure -- confirmed transient (2026-07-23: a retry 8s later
-   succeeded). Retry this model up to 2 times with a short backoff (5s, then
-   10s) before falling through to step 2.
-2. **`opencode/deepseek-v4-flash-free`** (OpenCode Zen -- built into the
-   `opencode` CLI itself, zero config, no credential needed). One attempt.
-3. **`opencode/nemotron-3-ultra-free`** (OpenCode Zen, zero config). One
-   attempt. Both Zen models are picked from `opencode.db`'s
-   `session.model` recency data, not arbitrarily -- re-derive with
-   `sqlite3 ~/.local/share/opencode/opencode.db "SELECT model, MAX(time_updated) FROM session WHERE model IS NOT NULL GROUP BY model ORDER BY 2 DESC LIMIT 5;"`
-   if these stop being reachable.
-4. **`aixcl-local/qwen3-coder:30b-32k`** (Ollama) -- LAST RESORT ONLY, and
-   only if `./aixcl stack status` shows Ollama healthy. Never start the
+1. **Default -- omit `-m` entirely.** Inherits whatever `opencode.json`'s
+   `model` key configures (currently `nvidia/deepseek-ai/deepseek-v4-pro`),
+   so delegation always tracks OpenCode's actual configured default rather
+   than a separately hardcoded model. A `503` with a body like
+   `"ResourceExhausted: Worker local total request limit reached"` is
+   shared-endpoint saturation, not an auth or quota failure -- confirmed
+   transient (2026-07-23: a retry 8s later succeeded). Retry up to 2 times
+   with a short backoff (5s, then 10s) before falling through to position 2.
+2. **`-m aixcl-local/qwen3-coder:30b-32k`** (Ollama) -- LAST RESORT ONLY,
+   and only if `./aixcl stack status` shows Ollama healthy. Never start the
    stack just to delegate.
 
-If all four fail, handle the task directly (see Step 5's failure handling).
+If both fail, handle the task directly (see Step 5's failure handling).
 
 ## Step 3: Prepare the prompt
 
@@ -112,23 +128,35 @@ vague ("fix the bug").
 quick call.** A completion entry with no matching start (found 2026-07-23:
 3 of 11 entries in one session) breaks pairing-based analytics in
 delegate-review and leaves no record that the delegation was even
-attempted if it never finishes.
+attempted if it never finishes. Wrap the append in `flock` so concurrent
+delegations (bounded-parallel rule above) can't interleave lines:
 
-    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"started"}' >> .opencode/delegation-log.jsonl
+    flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"started\"}' >> .opencode/delegation-log.jsonl"
 
-Execute (one at a time; bound the runtime):
+Execute (bound the runtime; omit `-m` for the default tier, add it only for
+the Ollama fallback tier):
 
+    URL=$(bash scripts/utils/ensure-opencode-server.sh)
     START_MS=$(date +%s%3N)
-    timeout -k 10 600 opencode run --auto --dir <WORKING_DIR> -m <provider/model> --variant medium "<PROMPT>"
+    timeout -k 10 600 opencode run --attach "$URL" --auto --dir <WORKING_DIR> --variant medium "<PROMPT>"
     END_MS=$(date +%s%3N)
+
+For up to 3 independent tasks at once, background each with `&` (own
+`mktemp` output file), then `wait`:
+
+    T1=$(mktemp); T2=$(mktemp); T3=$(mktemp)
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR1> --variant medium "<PROMPT1>" > "$T1" 2>&1 ) &
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR2> --variant medium "<PROMPT2>" > "$T2" 2>&1 ) &
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR3> --variant medium "<PROMPT3>" > "$T3" 2>&1 ) &
+    wait
 
 ## Step 5: Log the result
 
 Record which provider/model actually served the request (`<provider/model>`,
-e.g. `nvidia/deepseek-ai/deepseek-v4-flash`) and its position in Step 2's
-chain (`<fallback_position>`, 1-4):
+e.g. `nvidia/deepseek-ai/deepseek-v4-pro`) and its position in Step 2's
+chain (`<fallback_position>`, 1-2), again through `flock`:
 
-    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"completed","success":<true|false>,"duration_ms":'$((END_MS - START_MS))',"provider_model":"<provider/model>","fallback_position":<fallback_position>,"result_summary":"<ONE_LINE_SUMMARY>"}' >> .opencode/delegation-log.jsonl
+    flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"completed\",\"success\":<true|false>,\"duration_ms\":$((END_MS - START_MS)),\"provider_model\":\"<provider/model>\",\"fallback_position\":<fallback_position>,\"result_summary\":\"<ONE_LINE_SUMMARY>\"}' >> .opencode/delegation-log.jsonl"
 
 On failure set `"status":"failed"` and `"success":false`; still record
 `provider_model` and `fallback_position` for whichever model the failing

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ bun.lock
 .opencode/package-lock.json
 .opencode/bun.lock
 .opencode/delegation-log.jsonl
+.opencode/delegation-log.jsonl.lock
+.opencode/server-state.json
+.opencode/server.log
 
 # macOS
 .DS_Store

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -11,16 +11,25 @@ argument-hint: <task description or instructions>
 compatibility: OpenCode, Claude Code
 metadata:
   category: workflow
-  version: "1.6"
+  version: "1.7"
 ---
 
 # Delegate to OpenCode
 
 Delegate the given task to the OpenCode peer agent and log it for tracking.
 
-**SEQUENTIAL ONLY -- HARD RULE**: run at most one `opencode run` at a time.
-Never launch delegations in parallel: concurrent appends corrupt ordering in
-the shared JSONL log. Queue multiple tasks and run them one after another.
+**BOUNDED PARALLEL -- cap 3 concurrent.** Independent delegatable tasks
+(no shared file target, no ordering dependency between them) may run
+concurrently, up to 3 in flight at once. Every invocation attaches to the
+same shared server (Step 2), so the old model-instance corruption risk is
+gone by construction -- only the server process ever writes to
+`opencode.db`. What remains is the JSONL log: redirect each concurrent
+invocation's output to its own `mktemp` file, background with `&`, collect
+PIDs, `wait` for all of them, then process each result in turn. Wrap every
+JSONL append (both start and completion, Steps 4 and 5) in
+`flock -x .opencode/delegation-log.jsonl.lock -c '...'` so concurrent
+completions can't interleave. Tasks with a real dependency (task B needs
+task A's output) still run sequentially.
 
 `LOGFILE` is `.opencode/delegation-log.jsonl` at the repository root
 (gitignored; create with `mkdir -p .opencode` if missing).
@@ -69,35 +78,42 @@ Do NOT delegate:
 
 If the task does not fit, say so and handle it directly.
 
-## Step 2: Pick the model
+## Step 2: Ensure the shared server, then pick the model
+
+Every delegation attaches to one persistent `opencode serve` process
+instead of spawning its own instance:
+
+    URL=$(bash scripts/utils/ensure-opencode-server.sh)
+
+This is idempotent and near-instant if the server is already running --
+call it before every delegation (or once per batch of parallel
+delegations). Routing everything through one server means only that one
+process ever writes to `~/.local/share/opencode/opencode.db`, which is the
+actual fix for the sqlite-contention risk that used to justify running
+delegations one at a time.
 
 Cloud is always preferred, regardless of whether the local stack is up --
 Ollama is last resort only, since it needs a stack the operator may not want
-running just for delegation. Every invocation adds `--variant medium`
-(reasoning effort). Try in this order, falling through on failure. Each
-position is numbered (1-4) -- record whichever position actually succeeds
-as `fallback_position` in Step 5's completion log entry, so
-delegate-review can report how often the primary model serves requests
+running just for delegation. Every invocation adds `--attach "$URL"` and
+`--variant medium` (reasoning effort). Try in this order, falling through
+on failure. Each position is numbered (1-2) -- record whichever position
+actually succeeds as `fallback_position` in Step 5's completion log entry,
+so delegate-review can report how often the default model serves requests
 versus falling through.
 
-1. **`nvidia/deepseek-ai/deepseek-v4-flash`** (primary, credentialed via
-   `opencode.json`). A `503` with a body like `"ResourceExhausted: Worker
-   local total request limit reached"` is shared-endpoint saturation, not an
-   auth or quota failure -- confirmed transient (2026-07-23: a retry 8s later
-   succeeded). Retry this model up to 2 times with a short backoff (5s, then
-   10s) before falling through to step 2.
-2. **`opencode/deepseek-v4-flash-free`** (OpenCode Zen -- built into the
-   `opencode` CLI itself, zero config, no credential needed). One attempt.
-3. **`opencode/nemotron-3-ultra-free`** (OpenCode Zen, zero config). One
-   attempt. Both Zen models are picked from `opencode.db`'s
-   `session.model` recency data, not arbitrarily -- re-derive with
-   `sqlite3 ~/.local/share/opencode/opencode.db "SELECT model, MAX(time_updated) FROM session WHERE model IS NOT NULL GROUP BY model ORDER BY 2 DESC LIMIT 5;"`
-   if these stop being reachable.
-4. **`aixcl-local/qwen3-coder:30b-32k`** (Ollama) -- LAST RESORT ONLY, and
-   only if `./aixcl stack status` shows Ollama healthy. Never start the
+1. **Default -- omit `-m` entirely.** Inherits whatever `opencode.json`'s
+   `model` key configures (currently `nvidia/deepseek-ai/deepseek-v4-pro`),
+   so delegation always tracks OpenCode's actual configured default rather
+   than a separately hardcoded model. A `503` with a body like
+   `"ResourceExhausted: Worker local total request limit reached"` is
+   shared-endpoint saturation, not an auth or quota failure -- confirmed
+   transient (2026-07-23: a retry 8s later succeeded). Retry up to 2 times
+   with a short backoff (5s, then 10s) before falling through to position 2.
+2. **`-m aixcl-local/qwen3-coder:30b-32k`** (Ollama) -- LAST RESORT ONLY,
+   and only if `./aixcl stack status` shows Ollama healthy. Never start the
    stack just to delegate.
 
-If all four fail, handle the task directly (see Step 5's failure handling).
+If both fail, handle the task directly (see Step 5's failure handling).
 
 ## Step 3: Prepare the prompt
 
@@ -112,23 +128,35 @@ vague ("fix the bug").
 quick call.** A completion entry with no matching start (found 2026-07-23:
 3 of 11 entries in one session) breaks pairing-based analytics in
 delegate-review and leaves no record that the delegation was even
-attempted if it never finishes.
+attempted if it never finishes. Wrap the append in `flock` so concurrent
+delegations (bounded-parallel rule above) can't interleave lines:
 
-    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"started"}' >> .opencode/delegation-log.jsonl
+    flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"started\"}' >> .opencode/delegation-log.jsonl"
 
-Execute (one at a time; bound the runtime):
+Execute (bound the runtime; omit `-m` for the default tier, add it only for
+the Ollama fallback tier):
 
+    URL=$(bash scripts/utils/ensure-opencode-server.sh)
     START_MS=$(date +%s%3N)
-    timeout -k 10 600 opencode run --auto --dir <WORKING_DIR> -m <provider/model> --variant medium "<PROMPT>"
+    timeout -k 10 600 opencode run --attach "$URL" --auto --dir <WORKING_DIR> --variant medium "<PROMPT>"
     END_MS=$(date +%s%3N)
+
+For up to 3 independent tasks at once, background each with `&` (own
+`mktemp` output file), then `wait`:
+
+    T1=$(mktemp); T2=$(mktemp); T3=$(mktemp)
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR1> --variant medium "<PROMPT1>" > "$T1" 2>&1 ) &
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR2> --variant medium "<PROMPT2>" > "$T2" 2>&1 ) &
+    ( timeout -k 10 600 opencode run --attach "$URL" --auto --dir <DIR3> --variant medium "<PROMPT3>" > "$T3" 2>&1 ) &
+    wait
 
 ## Step 5: Log the result
 
 Record which provider/model actually served the request (`<provider/model>`,
-e.g. `nvidia/deepseek-ai/deepseek-v4-flash`) and its position in Step 2's
-chain (`<fallback_position>`, 1-4):
+e.g. `nvidia/deepseek-ai/deepseek-v4-pro`) and its position in Step 2's
+chain (`<fallback_position>`, 1-2), again through `flock`:
 
-    echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","task":"<TASK_SUMMARY_50_CHARS>","dir":"<WORKING_DIR>","status":"completed","success":<true|false>,"duration_ms":'$((END_MS - START_MS))',"provider_model":"<provider/model>","fallback_position":<fallback_position>,"result_summary":"<ONE_LINE_SUMMARY>"}' >> .opencode/delegation-log.jsonl
+    flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"completed\",\"success\":<true|false>,\"duration_ms\":$((END_MS - START_MS)),\"provider_model\":\"<provider/model>\",\"fallback_position\":<fallback_position>,\"result_summary\":\"<ONE_LINE_SUMMARY>\"}' >> .opencode/delegation-log.jsonl"
 
 On failure set `"status":"failed"` and `"success":false`; still record
 `provider_model` and `fallback_position` for whichever model the failing

--- a/scripts/utils/ensure-opencode-server.sh
+++ b/scripts/utils/ensure-opencode-server.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ensure-opencode-server.sh -- Idempotently ensure a persistent `opencode
+# serve` process is running and print its base URL.
+#
+# The delegate skill attaches every delegation to this one shared server
+# (`opencode run --attach <url> ...`) instead of spawning a fresh instance
+# per call, so only one process ever writes to the shared
+# ~/.local/share/opencode/opencode.db sqlite file.
+#
+# State: .opencode/server-state.json (gitignored) -- {"pid":N,"port":N,"url":"..."}
+# Log:   .opencode/server.log (gitignored)
+#
+# Usage: URL=$(bash scripts/utils/ensure-opencode-server.sh)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p .opencode
+STATE_FILE=".opencode/server-state.json"
+LOG_FILE=".opencode/server.log"
+
+healthy() {
+    local url="$1"
+    curl -sf -o /dev/null --max-time 2 "${url}/doc"
+}
+
+if [ -f "$STATE_FILE" ]; then
+    pid=$(python3 -c "import json; print(json.load(open('$STATE_FILE'))['pid'])" 2>/dev/null || echo "")
+    url=$(python3 -c "import json; print(json.load(open('$STATE_FILE'))['url'])" 2>/dev/null || echo "")
+    if [ -n "$pid" ] && [ -n "$url" ] && kill -0 "$pid" 2>/dev/null && healthy "$url"; then
+        echo "$url"
+        exit 0
+    fi
+    rm -f "$STATE_FILE"
+fi
+
+for port in 4097 4098 4099; do
+    : > "$LOG_FILE"
+    nohup opencode serve --port "$port" --hostname 127.0.0.1 >> "$LOG_FILE" 2>&1 &
+    pid=$!
+    disown "$pid"
+
+    url="http://127.0.0.1:${port}"
+    for _ in $(seq 1 20); do
+        if healthy "$url"; then
+            python3 -c "import json; json.dump({'pid': $pid, 'port': $port, 'url': '$url'}, open('$STATE_FILE', 'w'))"
+            echo "$url"
+            exit 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    kill "$pid" 2>/dev/null || true
+done
+
+echo "ensure-opencode-server.sh: failed to start opencode serve on ports 4097-4099" >&2
+exit 1


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #2017

### Description of Changes
Moves the delegate skill from "each delegation spawns its own opencode instance" to a shared persistent `opencode serve` process, aligns delegated tasks with OpenCode's actual configured default model, and allows bounded parallel delegation:

- `scripts/utils/ensure-opencode-server.sh` (new) - idempotent helper: reuses an already-running `opencode serve` process (checked via PID liveness + HTTP health probe) or starts one on port 4097 (falls back to 4098/4099), tracks state in gitignored `.opencode/server-state.json`
- `.claude/skills/delegate/SKILL.md` / `.opencode/skills/delegate/SKILL.md` - every delegation now attaches to the shared server (`--attach "$URL"`) instead of spawning a fresh instance; the primary attempt omits `-m` entirely so it inherits `opencode.json`'s configured default (`nvidia/deepseek-ai/deepseek-v4-pro`) instead of a separately hardcoded model; fallback chain simplified from 4 tiers to 2 (default -> `aixcl-local` last resort); "SEQUENTIAL ONLY" hard rule replaced with a bounded-parallel rule (cap 3 concurrent), with JSONL log appends wrapped in `flock` to prevent interleaving
- `.gitignore` - ignores `.opencode/server-state.json`, `.opencode/server.log`, `.opencode/delegation-log.jsonl.lock`

Follow-up to #2015/#2016 (OpenCode's interactive default model), extending the same "NVIDIA default, local last resort" philosophy to the delegation mechanism itself.

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-2017/delegate-shared-server`)
- [x] Commit messages follow conventional style (`feat: delegate skill shared server, default-model delegation, bounded parallelism`)
- [x] All tests run and pass (`./aixcl checks all` clean, `shellcheck` clean, pre-commit hooks all passed at commit time)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
Tested live before opening this PR:

- `bash scripts/utils/ensure-opencode-server.sh` run twice: first call started the server on port 4097 (0.05s startup-check loop), second call returned the same URL in 53ms (idempotent)
- `curl -s http://127.0.0.1:4097/doc` returned a valid OpenAPI document -- server genuinely listening
- `opencode run --attach http://127.0.0.1:4097 --dir . --variant medium "say ok"` with no `-m` flag: log shows `agent-context - deepseek-ai/deepseek-v4-pro`, real reply returned
- 3 concurrent `opencode run --attach` calls (backgrounded, `wait`ed) all completed correctly and independently (asked for "one"/"two"/"three", each returned its own word)
- `sqlite3 ~/.local/share/opencode/opencode.db "PRAGMA journal_mode;"` still reports `wal` after the concurrent test
- `bash scripts/utils/sync-mirrors.sh` and `./aixcl checks all` both clean

### Verification
To verify this change is complete:

- [x] Behavior works as expected (operator-confirmed; live self-test used the new skill to delegate this PR's own CI watch)
- [x] No regressions observed (operator-confirmed; 23/23 CI checks pass, sqlite still wal, mirror parity clean)
- [x] Tests cover change (operator-confirmed; idempotency, health probe, 3-way concurrency, default-model, and a full live self-test all verified, see Testing Notes)

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #2017

## Additional Notes

Fixes #2017
