### PR TITLE
Fix test-03-stack-status stopped-stack exit code handling (#2019)

### DIFF
--- a/tests/command-tests/test-03-stack-status.sh
+++ b/tests/command-tests/test-03-stack-status.sh
@@ -10,17 +10,25 @@ source "${SCRIPT_DIR}/tests/lib/test-framework.sh"
 
 log_test_start "test-03-stack-status"
 
-# Test: Stack status command exits cleanly
-assert_command_success "${SCRIPT_DIR}/aixcl stack status" "Stack status command succeeds"
-
-# Capture output for content assertions
+# Test: Stack status command reports cleanly. `aixcl stack status` exits
+# non-zero when the stack is stopped -- that's a state signal, not a command
+# failure, so a plain assert_command_success would spuriously fail here.
+# Only exit 0 is unconditionally accepted; any other exit is only accepted
+# if the output actually reports "Status: Stopped" (proves the command ran
+# and reported cleanly rather than crashing for an unrelated reason).
+set +e
 STATUS_OUTPUT=$("${SCRIPT_DIR}/aixcl" stack status 2>&1)
+STATUS_EXIT=$?
+set -e
 
-# Test: Overall summary line is present
-if echo "$STATUS_OUTPUT" | grep -qE "^Services: [0-9]+/[0-9]+ healthy"; then
-    log_test_pass "Services summary line present"
+if [ "$STATUS_EXIT" -eq 0 ]; then
+    log_test_pass "Stack status command succeeds"
+elif echo "$STATUS_OUTPUT" | grep -q "Status: Stopped"; then
+    log_test_pass "Stack status command succeeds (stopped state, exit $STATUS_EXIT)"
 else
-    log_test_fail "Services summary line missing from stack status output"
+    log_test_fail "Stack status command failed unexpectedly (exit $STATUS_EXIT)"
+    echo "  Output:"
+    echo "$STATUS_OUTPUT" | head -5 | sed 's/^/    /'
     exit 1
 fi
 
@@ -28,6 +36,15 @@ fi
 # (regression for issue #1377 -- bootstrap containers showed as red despite exit 0)
 if echo "$STATUS_OUTPUT" | grep -q "Status: Running"; then
     log_info "Stack is running -- asserting bootstrap container health"
+
+    # Test: Overall summary line is present (only meaningful when running --
+    # the stopped-state output has no per-service health summary to report)
+    if echo "$STATUS_OUTPUT" | grep -qE "^Services: [0-9]+/[0-9]+ healthy"; then
+        log_test_pass "Services summary line present"
+    else
+        log_test_fail "Services summary line missing from stack status output"
+        exit 1
+    fi
 
     for bootstrap in \
         "Vault Agent Bootstrap (Postgres)" \


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #2019

### Description of Changes
`tests/command-tests/test-03-stack-status.sh` was using `assert_command_success` on `./aixcl stack status`, which treats any non-zero exit as a hard failure. That command legitimately exits `125` when the stack is stopped (a state signal, not an error), so the test always failed against a stopped stack.

- Replaced the `assert_command_success` call with a direct capture of output and exit code, accepting exit `0` unconditionally, or a non-zero exit only when the output confirms `Status: Stopped` (proves the command ran and reported cleanly rather than crashing for an unrelated reason)
- Moved the `Services: N/M healthy` summary-line check inside the `Status: Running` branch -- that line is never printed in stopped-state output (confirmed directly), so the check was unconditionally wrong for the stopped case too
- Removed the redundant second invocation of `aixcl stack status` (previously called once via `assert_command_success`, once to capture output for the content assertions) -- now called once

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (`issue-2019/fix-test-03-stack-status`)
- [x] Commit messages follow conventional style (`fix: test-03-stack-status no longer fails on stopped-stack exit code`)
- [x] All tests run and pass (`./aixcl checks all` clean, `shellcheck` clean, pre-commit hooks all passed at commit time, test itself passes live against the current stopped stack)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI)
- [x] **Component Label**: At least one `component:*` label (e.g., `component:cli`, `component:infrastructure`)
- [x] **Title Format**: `<description> (#<number>)` with NO colons in the description

**Note**: PR validation runs automatically and must pass before merging.

**Note**: Agent completes change checklist, Human completes verification checklist.

### Testing Notes
- `bash -n tests/command-tests/test-03-stack-status.sh` -- syntax clean
- `bash tests/command-tests/test-03-stack-status.sh` run live against the current (stopped) stack: `[PASS] Stack status command succeeds (stopped state, exit 125)` -> `[PASS] Stack status tests passed`
- `shellcheck --severity=warning --exclude=SC1091` -- clean
- Did **not** start the stack to test the `Status: Running` branch -- per this repo's guardrail, stack state changes are operator territory, not something the agent does unprompted. That branch's logic is unchanged from the original script except for the relocated summary-line check, and is a good candidate for the human verification checklist below.

### Verification
To verify this change is complete:

- [x] Behavior works as expected (operator-confirmed; verified both stopped and running-stack cases live)
- [x] No regressions observed (operator-confirmed; `./aixcl test command` 10/10 pass, 22/22 CI checks green)
- [x] Tests cover change (operator-confirmed; test itself is the fix, verified against both stack states)

### Related Issues

List one reference per line. Do not comma-pack multiple references on a single line.

- Closes #2019

## Additional Notes

Fixes #2019
