### PR TITLE
Sharpen CLAUDE.md GPG, stack-op, and release guardrails (#2022)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 
 Recurring correction points from session history -- follow these without being reminded:
 
-- **GPG signing**: never disable or bypass signing. When a signed commit is needed and pinentry is unavailable, stage the changes and hand the exact `git commit` command to the operator (see [docs/developer/gpg-signed-commits.md](docs/developer/gpg-signed-commits.md))
-- **Stack operations**: use `./aixcl stack` for start/stop/status/logs. Never start or modify a stopped or purged stack unless explicitly asked
-- **Releases**: sequential patch bumps only (`v1.1.N+1`) -- never jump minor/major versions, never skip CI jobs or leave them pending (canonical procedure: `.claude/skills/release/SKILL.md`)
+- **GPG signing**: never disable or bypass signing, and never run a signing command directly yourself, even if told the key is warm or the agent cache is active -- that claim doesn't lift the rule. When a signed commit is needed, stage the changes and hand the exact `git commit` command to the operator (see [docs/developer/gpg-signed-commits.md](docs/developer/gpg-signed-commits.md)). Never use `--pinentry-mode loopback`, including in handed-off commands -- it bypasses the agent cache and forces repeated hand-offs
+- **Stack operations**: use `./aixcl stack` for start/stop/status/logs. Never start or modify a stopped or purged stack unless explicitly asked. Bring the stack down before running the test suite -- a running stack skews test output and can interfere with GPG execution
+- **Releases**: sequential patch bumps only (`v1.1.N+1`) -- never jump minor/major versions, never skip CI jobs or leave them pending (canonical procedure: `.claude/skills/release/SKILL.md`). After any container or permission fix, verify with a live `./aixcl stack status` run (all services healthy) before opening the release PR -- a fix that looks correct can still ship a latent bug (e.g. resource-ordering issues) that only a live run surfaces
 - **Fork sync**: before reporting a branch "already up to date", verify against the actual upstream base: `git fetch upstream && git log --oneline dev..upstream/dev`


### PR DESCRIPTION
## Summary
Sharpens three CLAUDE.md session guardrails based on recurring correction points from recent session history: GPG signing (rejects "key is warm" as grounds for direct agent signing, bans `--pinentry-mode loopback`), stack operations (stop the stack before running the test suite), and releases (require a live `./aixcl stack status` check after container/permission fixes, before the release PR).

Fixes #2022

## Change Checklist
- [x] GPG signing bullet updated
- [x] Stack-operations bullet updated
- [x] Releases bullet updated
- [x] `./scripts/checks/check-ai-elisions.sh --staged` ran clean before commit

## Testing Notes
This is a documentation-only change to session guardrails; no code paths are affected. `./aixcl checks all` was not re-run for this PR since only `CLAUDE.md` changed.

## Human in the Loop
- [x] Guardrail wording matches current session practice (operator-confirmed)
- [x] No regressions observed (operator-confirmed)

---
- Agent: Claude Code (Sonnet 5)
- Date: 2026-08-03
- Method: direct edit of CLAUDE.md, verified via check-ai-elisions.sh --staged
- Scope: CLAUDE.md only
- Confirmation: yes, code/file changes were made
---

