### PR TITLE
fix dead OpenCode default model after NVIDIA deepseek-v4 EOL (#2024)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -49,6 +49,11 @@ Confirm the task fits delegation. Good candidates:
   (e.g. before ticking a remediation checklist's "confirm no other path has
   this issue" item -- caught a second live instance of #2003's plaintext-
   password logging bug in a separate compose overlay file, 2026-07-23)
+- Repo-wide grep for a stale identifier after a rename or config-default
+  change (e.g. confirming no doc or skill file still names an old model,
+  env var, or file path after the live value changed -- used to sweep
+  `.claude/`, `.opencode/`, and `config/` for a dead default-model name
+  after #2024's fix, 2026-08-10)
 
 **Tier 2 -- side-effect-free analysis:**
 - Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -92,6 +92,18 @@ process ever writes to `~/.local/share/opencode/opencode.db`, which is the
 actual fix for the sqlite-contention risk that used to justify running
 delegations one at a time.
 
+**The running server caches `opencode.json` at startup.** Editing
+`model`, `small_model`, or the `provider` block does not take effect on a
+live server -- `ensure-opencode-server.sh` reuses any process that is
+still healthy, so a config change silently keeps serving the old values
+until the process is restarted. Confirmed live 2026-08-10: after fixing
+a dead default model in `opencode.json`, the first delegation still hit
+the old (dead) model because the server had started before the edit.
+Fix: `kill <pid>; rm -f .opencode/server-state.json`, then re-run
+`ensure-opencode-server.sh` to start a fresh process with the new config.
+Do this any time you change `opencode.json` and delegation doesn't
+reflect it.
+
 Cloud is always preferred, regardless of whether the local stack is up --
 Ollama is last resort only, since it needs a stack the operator may not want
 running just for delegation. Every invocation adds `--attach "$URL"` and

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -102,7 +102,7 @@ so delegate-review can report how often the default model serves requests
 versus falling through.
 
 1. **Default -- omit `-m` entirely.** Inherits whatever `opencode.json`'s
-   `model` key configures (currently `nvidia/deepseek-ai/deepseek-v4-pro`),
+   `model` key configures (currently `nvidia/z-ai/glm-5.2`),
    so delegation always tracks OpenCode's actual configured default rather
    than a separately hardcoded model. A `503` with a body like
    `"ResourceExhausted: Worker local total request limit reached"` is
@@ -153,7 +153,7 @@ For up to 3 independent tasks at once, background each with `&` (own
 ## Step 5: Log the result
 
 Record which provider/model actually served the request (`<provider/model>`,
-e.g. `nvidia/deepseek-ai/deepseek-v4-pro`) and its position in Step 2's
+e.g. `nvidia/z-ai/glm-5.2`) and its position in Step 2's
 chain (`<fallback_position>`, 1-2), again through `flock`:
 
     flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"completed\",\"success\":<true|false>,\"duration_ms\":$((END_MS - START_MS)),\"provider_model\":\"<provider/model>\",\"fallback_position\":<fallback_position>,\"result_summary\":\"<ONE_LINE_SUMMARY>\"}' >> .opencode/delegation-log.jsonl"

--- a/.opencode/memory/working-conventions.md
+++ b/.opencode/memory/working-conventions.md
@@ -19,7 +19,7 @@ Seed memory for the OpenCode agent, written at onboarding (2026-07-02).
   or end-of-file hooks, the files are already fixed in the working tree:
   `git add` them and retry. Never use `--no-verify`.
 - **Your identity for agent identification blocks is:**
-  `OpenCode (nvidia/deepseek-ai/deepseek-v4-pro)`, or whichever
+  `OpenCode (nvidia/z-ai/glm-5.2)`, or whichever
   provider/model actually served the request if NVIDIA is unreachable
   and you fell back to `aixcl-local/qwen3-coder:30b-32k` (last resort
   only). Do NOT copy the example from AGENTS.md Section 9.5 -- that

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -49,6 +49,11 @@ Confirm the task fits delegation. Good candidates:
   (e.g. before ticking a remediation checklist's "confirm no other path has
   this issue" item -- caught a second live instance of #2003's plaintext-
   password logging bug in a separate compose overlay file, 2026-07-23)
+- Repo-wide grep for a stale identifier after a rename or config-default
+  change (e.g. confirming no doc or skill file still names an old model,
+  env var, or file path after the live value changed -- used to sweep
+  `.claude/`, `.opencode/`, and `config/` for a dead default-model name
+  after #2024's fix, 2026-08-10)
 
 **Tier 2 -- side-effect-free analysis:**
 - Individual `./aixcl checks <name>` runs (paths, ascii, yaml, pins, ...)

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -92,6 +92,18 @@ process ever writes to `~/.local/share/opencode/opencode.db`, which is the
 actual fix for the sqlite-contention risk that used to justify running
 delegations one at a time.
 
+**The running server caches `opencode.json` at startup.** Editing
+`model`, `small_model`, or the `provider` block does not take effect on a
+live server -- `ensure-opencode-server.sh` reuses any process that is
+still healthy, so a config change silently keeps serving the old values
+until the process is restarted. Confirmed live 2026-08-10: after fixing
+a dead default model in `opencode.json`, the first delegation still hit
+the old (dead) model because the server had started before the edit.
+Fix: `kill <pid>; rm -f .opencode/server-state.json`, then re-run
+`ensure-opencode-server.sh` to start a fresh process with the new config.
+Do this any time you change `opencode.json` and delegation doesn't
+reflect it.
+
 Cloud is always preferred, regardless of whether the local stack is up --
 Ollama is last resort only, since it needs a stack the operator may not want
 running just for delegation. Every invocation adds `--attach "$URL"` and

--- a/.opencode/skills/delegate/SKILL.md
+++ b/.opencode/skills/delegate/SKILL.md
@@ -102,7 +102,7 @@ so delegate-review can report how often the default model serves requests
 versus falling through.
 
 1. **Default -- omit `-m` entirely.** Inherits whatever `opencode.json`'s
-   `model` key configures (currently `nvidia/deepseek-ai/deepseek-v4-pro`),
+   `model` key configures (currently `nvidia/z-ai/glm-5.2`),
    so delegation always tracks OpenCode's actual configured default rather
    than a separately hardcoded model. A `503` with a body like
    `"ResourceExhausted: Worker local total request limit reached"` is
@@ -153,7 +153,7 @@ For up to 3 independent tasks at once, background each with `&` (own
 ## Step 5: Log the result
 
 Record which provider/model actually served the request (`<provider/model>`,
-e.g. `nvidia/deepseek-ai/deepseek-v4-pro`) and its position in Step 2's
+e.g. `nvidia/z-ai/glm-5.2`) and its position in Step 2's
 chain (`<fallback_position>`, 1-2), again through `flock`:
 
     flock -x .opencode/delegation-log.jsonl.lock -c "echo '{\"ts\":\"'\$(date -u +%Y-%m-%dT%H:%M:%SZ)'\",\"task\":\"<TASK_SUMMARY_50_CHARS>\",\"dir\":\"<WORKING_DIR>\",\"status\":\"completed\",\"success\":<true|false>,\"duration_ms\":$((END_MS - START_MS)),\"provider_model\":\"<provider/model>\",\"fallback_position\":<fallback_position>,\"result_summary\":\"<ONE_LINE_SUMMARY>\"}' >> .opencode/delegation-log.jsonl"

--- a/config/opencode.json.example
+++ b/config/opencode.json.example
@@ -106,10 +106,13 @@
         },
         "z-ai/glm-5.2": {
           "name": "GLM 5.2"
+        },
+        "openai/gpt-oss-20b": {
+          "name": "GPT-OSS 20B"
         }
       }
     }
   },
-  "model": "nvidia/deepseek-ai/deepseek-v4-pro",
-  "small_model": "nvidia/deepseek-ai/deepseek-v4-flash"
+  "model": "nvidia/z-ai/glm-5.2",
+  "small_model": "nvidia/openai/gpt-oss-20b"
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes #2024

### Description of Changes
NVIDIA retired the entire `deepseek-v4` model family on 2026-08-07, which broke OpenCode delegation's default model. This PR bundles the three commits that landed the fix and its follow-up documentation, made under Emergency Workflow Override (AGENTS.md Section 8) since delegation was actively broken and the fix was minimal/reversible.

- `1eab6f2`: swap default `model`/`small_model` in `opencode.json` and `config/opencode.json.example` from the dead `deepseek-v4-pro`/`deepseek-v4-flash` to confirmed-live `z-ai/glm-5.2` and `openai/gpt-oss-20b`; update stale model-name references in the delegate skill mirror and `.opencode/memory/working-conventions.md`
- `382120e`: document that the shared `opencode serve` process caches `opencode.json` at startup, so a config edit needs a server restart to take effect (discovered live while verifying the first fix)
- `8528aed`: broaden the delegate skill's Tier 1 grep example to cover stale-identifier sweeps after a rename/config-default change

### Change Checklist
- [x] Issue referenced in title and description
- [x] Branch is named correctly (dev, override precedent per AGENTS.md Section 8)
- [x] Commit messages follow conventional style
- [x] All tests run and pass (`./aixcl checks all` green, elision guard clean on each commit)

### PR Validation Requirements
The following are enforced by `.github/workflows/pr-validation.yml` and will block merge if not met:
- [x] **Assignee**: At least one assignee is set (required by CI) -- confirmed via CI check "Validate PR Assignee" pass
- [x] **Component Label**: At least one `component:*` label -- `component:cli`, confirmed via CI check "Validate PR Labels" pass
- [x] **Title Format**: `<description> (#<number>)` with NO colons -- confirmed via CI check "Validate PR Title Format" pass

### Testing Notes
- Live-probed 8 NVIDIA models via `opencode run -m <model>` to confirm which were actually servable before selecting replacements
- Live smoke-tested delegation end-to-end after the fix (`nvidia/z-ai/glm-5.2` responded correctly)
- Verified mirror parity between `.claude/skills/delegate/SKILL.md` and `.opencode/skills/delegate/SKILL.md` on every edit
- All 23 CI checks passed on this PR (`gh pr checks 2025 --repo xencon/aixcl`)

### Verification
To verify this change is complete:

- [x] Behavior works as expected (operator-confirmed 2026-08-10)
- [x] No regressions observed (operator-confirmed 2026-08-10)
- [x] Tests cover change (operator-confirmed 2026-08-10)

### Related Issues

- Closes #2024

---
- Agent: Claude Code (claude-sonnet-5)
- Date: 2026-08-10
- Method: sync PR bundling 3 already-merged origin/dev commits into upstream/dev, per operator-directed reconciliation
- Scope: opencode.json (gitignored), config/opencode.json.example, .claude/skills/delegate/SKILL.md, .opencode/skills/delegate/SKILL.md, .opencode/memory/working-conventions.md
- Confirmation: yes, code/config changes were made (in the bundled commits, not this PR-creation step)
---
